### PR TITLE
upgrade hub to react 18

### DIFF
--- a/packages/canvas-hub/components/ProjectMenu.tsx
+++ b/packages/canvas-hub/components/ProjectMenu.tsx
@@ -49,32 +49,30 @@ export default function ProjectMenu({ app }: ProjectMenuProps) {
 
 	return (
 		<Popover className="inline text-sm">
-			<>
-				<Popover.Button
-					ref={setReferenceElement}
-					className={`bg-gray-200 hover:bg-gray-300 inline-block px-1.5 py-1 ml-2 rounded`}
-				>
-					<span className="inline-block relative -top-0.5">&hellip;</span>
-				</Popover.Button>
+			<Popover.Button
+				ref={setReferenceElement}
+				className={`bg-gray-200 hover:bg-gray-300 inline-block px-1.5 py-1 ml-2 rounded`}
+			>
+				<span className="inline-block relative -top-0.5">&hellip;</span>
+			</Popover.Button>
 
-				{appBody &&
-					ReactDOM.createPortal(
-						<Popover.Panel
-							ref={setPopperElement}
-							className="absolute z-10 bg-white border border-gray-200 rounded shadow w-28 mt-2"
-							style={styles.popper}
-							{...attributes.popper}
+			{appBody &&
+				ReactDOM.createPortal(
+					<Popover.Panel
+						ref={setPopperElement}
+						className="absolute z-10 bg-white border border-gray-200 rounded shadow w-28 mt-2"
+						style={styles.popper}
+						{...attributes.popper}
+					>
+						<button
+							className="block w-full text-left px-3 py-2 hover:bg-gray-100 text-sm border-b border-gray-200"
+							onClick={deleteApp}
 						>
-							<button
-								className="block w-full text-left px-3 py-2 hover:bg-gray-100 text-sm border-b border-gray-200"
-								onClick={deleteApp}
-							>
-								Delete
-							</button>
-						</Popover.Panel>,
-						appBody
-					)}
-			</>
+							Delete
+						</button>
+					</Popover.Panel>,
+					appBody
+				)}
 		</Popover>
 	)
 }

--- a/packages/canvas-hub/components/UserMenu.tsx
+++ b/packages/canvas-hub/components/UserMenu.tsx
@@ -18,32 +18,30 @@ export default function UserMenu() {
 
 	return (
 		<Popover className="">
-			<>
-				<Popover.Button ref={setReferenceElement} className={`text-sm pt-0.25`}>
-					Menu
-				</Popover.Button>
+			<Popover.Button ref={setReferenceElement} className={`text-sm pt-0.25`}>
+				Menu
+			</Popover.Button>
 
-				{appBody &&
-					ReactDOM.createPortal(
-						<Popover.Panel
-							ref={setPopperElement}
-							className="absolute z-10 bg-white border border-gray-200 rounded shadow w-28 mt-2"
-							style={styles.popper}
-							{...attributes.popper}
-						>
-							<div>
-								<a
-									className="block px-3 py-2 hover:bg-gray-100 text-sm border-b border-gray-200"
-									href="#"
-									onClick={() => toast("Unimplemented: logout")}
-								>
-									Logout
-								</a>
-							</div>
-						</Popover.Panel>,
-						appBody
-					)}
-			</>
+			{appBody &&
+				ReactDOM.createPortal(
+					<Popover.Panel
+						ref={setPopperElement}
+						className="absolute z-10 bg-white border border-gray-200 rounded shadow w-28 mt-2"
+						style={styles.popper}
+						{...attributes.popper}
+					>
+						<div>
+							<a
+								className="block px-3 py-2 hover:bg-gray-100 text-sm border-b border-gray-200"
+								href="#"
+								onClick={() => toast("Unimplemented: logout")}
+							>
+								Logout
+							</a>
+						</div>
+					</Popover.Panel>,
+					appBody
+				)}
 		</Popover>
 	)
 }

--- a/packages/canvas-hub/pages/_app.tsx
+++ b/packages/canvas-hub/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { Toaster, resolveValue } from "react-hot-toast"
+import { Toaster } from "react-hot-toast"
 import { Transition } from "@tailwindui/react"
 
 import type { AppProps } from "next/app"
@@ -54,7 +54,7 @@ export default function App({ Component, pageProps }: AppProps) {
 									leaveFrom="opacity-100 scale-100"
 									leaveTo="opacity-0 scale-75"
 								>
-									{resolveValue(t.message, t)}
+									{t.message}
 								</Transition>
 							)}
 						</Toaster>


### PR DESCRIPTION
The reason we had multiple versions of React getting bundled into browser builds was that canvas-hub was still on react 17 while canvas-hooks and the example repo were both on 18.

When using workspaces, npm automatically hoists all common dependencies into the repo root's node_modules, but if it can't resolve a common version for a dependency them it splits them all into local packages/[package]/node_modules folders.

This upgrades react and removes setup_hooks.sh. **You'll need to remove all node_modules folders (in the repo root and all inside all the individual packages) and re-install everything (with just `npm i` in the root).** (and then re-generate the hub prisma client with `cd packages/canvas-hub && npx prisma generate`)