### PR TITLE
Add "unchecked mode" for running without Infura RPC

### DIFF
--- a/packages/canvas-cli/commands/run.js
+++ b/packages/canvas-cli/commands/run.js
@@ -66,6 +66,10 @@ export const builder = (yargs) => {
 			type: "boolean",
 			desc: "Reconstruct the model database by replying the action log",
 		})
+		.option("unchecked", {
+			type: "boolean",
+			desc: "Run the node in unchecked mode, without verifying block hashes",
+		})
 		.option("watch", {
 			type: "boolean",
 			desc: "Restart the core on spec file changes",
@@ -172,6 +176,7 @@ export async function handler(args) {
 			database: args.database,
 			quickJS,
 			replay: args.replay,
+			unchecked: args.unchecked,
 			development,
 			rpc,
 		})


### PR DESCRIPTION
- Unchecked mode skips the blockhash check for actions/sessions.
- This allows Canvas nodes to start, without supplying an RPC URL (i.e. without getting an Infura developer token).
- Calls to contracts will still work, if an RPC has been provided. They will fail at execution time if no RPC has been provided.