### PR TITLE
Require specs to define the database they're using

### DIFF
--- a/examples/polls.canvas.js
+++ b/examples/polls.canvas.js
@@ -1,3 +1,5 @@
+export const database = "sqlite"
+
 export const models = {
 	poll: {
 		title: "string",

--- a/examples/reddit.canvas.js
+++ b/examples/reddit.canvas.js
@@ -1,3 +1,5 @@
+export const database = "sqlite"
+
 export const models = {
 	threads: {
 		title: "string",

--- a/packages/example-chat-client/spec.canvas.js
+++ b/packages/example-chat-client/spec.canvas.js
@@ -1,3 +1,5 @@
+export const database = "sqlite"
+
 export const models = {
 	posts: {
 		content: "string",

--- a/packages/example-chat-server/spec.canvas.js
+++ b/packages/example-chat-server/spec.canvas.js
@@ -1,3 +1,5 @@
+export const database = "sqlite"
+
 export const models = {
 	posts: {
 		content: "string",


### PR DESCRIPTION
`export const database = 'sqlite'` or `export const database = 'postgres'`