### PR TITLE
Fix example-chat-client deployment port

### DIFF
--- a/packages/example-chat-client/fly.toml
+++ b/packages/example-chat-client/fly.toml
@@ -11,7 +11,7 @@ processes = []
 
 [[services]]
   http_checks = []
-  internal_port = 8080
+  internal_port = 8000
   processes = ["app"]
   protocol = "tcp"
   script_checks = []


### PR DESCRIPTION
Want to double check with @twofactor, does this look right / did you have to make this change?