### PR TITLE
Pass spec to frontend

### DIFF
--- a/packages/canvas-cli/src/api.ts
+++ b/packages/canvas-cli/src/api.ts
@@ -30,18 +30,20 @@ export class API {
 		api.use(cors({ exposedHeaders: ["ETag"] }))
 		api.use(bodyParser.json())
 
-		// TODO: once we start sending more than { name: core.name } to the client,
-		// we should set No-Cache on dev cores since ETag will not update
 		api.head("/", (req, res) => {
 			res.status(StatusCodes.OK)
-			res.header("ETag", `"${core.name}"`)
+			res.header("ETag", `"${core.name}-${core.cid.toString()}"`)
 			res.header("Content-Type", "application/json")
 			res.end()
 		})
 
-		api.get("/", (req, res) => {
-			res.header("ETag", `"${core.name}"`)
-			res.json({ name: core.name })
+		api.get("/", (req: Request, res: Response) => {
+			res.header("ETag", `"${core.name}-${core.cid.toString()}"`)
+			if (req.query.spec === "true") {
+				res.json({ name: core.name, spec: core.spec })
+			} else {
+				res.json({ name: core.name })
+			}
 		})
 
 		api.post("/actions", this.handleAction)

--- a/packages/canvas-core/src/core.ts
+++ b/packages/canvas-core/src/core.ts
@@ -152,7 +152,7 @@ export class Core extends EventEmitter<CoreEvents> {
 		}
 
 		const options = { verbose, unchecked, peering: true, sync: true }
-		const core = new Core(directory, name, cid, vm, exports, providers, libp2p, options)
+		const core = new Core(directory, name, cid, vm, exports, providers, libp2p, spec, options)
 
 		if (replay) {
 			console.log(chalk.green(`[canvas-core] Replaying action log...`))
@@ -197,6 +197,7 @@ export class Core extends EventEmitter<CoreEvents> {
 		public readonly exports: Exports,
 		public readonly providers: Record<string, ethers.providers.JsonRpcProvider> = {},
 		public readonly libp2p: Libp2p | null,
+		public readonly spec: string,
 		private readonly options: {
 			verbose?: boolean
 			unchecked?: boolean
@@ -205,6 +206,7 @@ export class Core extends EventEmitter<CoreEvents> {
 		}
 	) {
 		super()
+		this.spec = spec
 		this.syncProtocol = `/x/canvas/sync/${cid.toString()}/0.0.0`
 
 		this.modelStore = new ModelStore(directory, exports.models, exports.routes, { verbose: options.verbose })


### PR DESCRIPTION
Have the API send the spec to the frontend, if queried with `/?spec=true`.