### PR TITLE
allow chainId to be a number or a string

### DIFF
--- a/packages/canvas-core/src/codecs.ts
+++ b/packages/canvas-core/src/codecs.ts
@@ -29,7 +29,7 @@ export const chainType: t.Type<Chain> = t.union([
 	t.literal("substrate"),
 ])
 
-export const chainIdType: t.Type<ChainId> = t.number
+export const chainIdType: t.Type<ChainId> = t.union([t.number, t.string])
 
 export const blockType: t.Type<Block> = t.type({
 	chain: chainType,

--- a/packages/canvas-interfaces/src/contracts.ts
+++ b/packages/canvas-interfaces/src/contracts.ts
@@ -3,7 +3,7 @@
  */
 export type Chain = "eth" | "cosmos" | "solana" | "substrate"
 
-export type ChainId = number
+export type ChainId = number | string
 
 /**
  * A `ContractMetadata` defines the metadata for a contract read by a


### PR DESCRIPTION
Required by: https://github.com/hicommonwealth/commonwealth/pull/2190

This PR changes the expected type of `ChainId` to be either a number or a string.

Ethereum uses numbers as its chain ids (e.g. 1 = mainnet, 5 = görli) but other networks (e.g. Cosmos) use strings (e.g. "osmosis-1"). We should be able to accept either type in API requests.

