### PR TITLE
Add Driver to core and "canvas install" CLI command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15105,7 +15105,7 @@
         "@ava/typescript": "^3.0.1",
         "@canvas-js/interfaces": "0.0.18",
         "@canvas-js/rpc": "0.0.17",
-        "@chainsafe/libp2p-gossipsub": "*",
+        "@chainsafe/libp2p-gossipsub": "^5.0.0",
         "@chainsafe/libp2p-noise": "^10.0.0",
         "@libp2p/bootstrap": "^5.0.0",
         "@libp2p/interface-connection": "^3.0.2",

--- a/packages/canvas-cli/src/commands/export.ts
+++ b/packages/canvas-cli/src/commands/export.ts
@@ -1,43 +1,42 @@
+import assert from "node:assert"
+import path from "node:path"
+import fs from "node:fs"
+
 import yargs from "yargs"
 import chalk from "chalk"
 
-import { Core } from "@canvas-js/core"
-import { locateSpec } from "../utils.js"
+import { constants, MessageStore } from "@canvas-js/core"
+
+import { parseSpecArgument } from "../utils.js"
 
 export const command = "export <spec>"
 export const desc = "Export actions and sessions as JSON to stdout"
 export const builder = (yargs: yargs.Argv) =>
-	yargs
-		.positional("spec", {
-			describe: "Path to spec file, or IPFS hash of spec",
-			type: "string",
-			demandOption: true,
-		})
-		.option("ipfs", {
-			type: "string",
-			desc: "IPFS Gateway URL",
-			default: "http://127.0.0.1:8080",
-		})
+	yargs.positional("spec", {
+		describe: "IPFS hash of spec",
+		type: "string",
+		demandOption: true,
+	})
 
 type Args = ReturnType<typeof builder> extends yargs.Argv<infer T> ? T : never
 
 export async function handler(args: Args) {
-	const { directory, spec, uri } = await locateSpec(args.spec, args.ipfs)
+	const { directory, uri } = parseSpecArgument(args.spec)
+	assert(directory !== null, "Cannot export from local specs because they do not persist any data")
 
-	const core = await Core.initialize({ directory, spec, uri, unchecked: true })
+	const messageStore = new MessageStore(uri, path.resolve(directory, constants.MESSAGE_DATABASE_FILENAME))
 
 	let i = 0
-	for await (const [_, session] of core.messageStore.getSessionStream()) {
+	for await (const [_, session] of messageStore.getSessionStream()) {
 		console.log(JSON.stringify(session))
 		i++
 	}
 
-	for await (const [_, action] of core.messageStore.getActionStream()) {
+	for await (const [_, action] of messageStore.getActionStream()) {
 		console.log(JSON.stringify(action))
 		i++
 	}
 
 	console.error(chalk.yellow(`Exported ${i} message${i === 1 ? "" : "s"}`))
-	await core.close()
 	process.exit(0)
 }

--- a/packages/canvas-cli/src/commands/index.ts
+++ b/packages/canvas-cli/src/commands/index.ts
@@ -6,5 +6,6 @@ import * as run from "./run.js"
 import * as exportData from "./export.js"
 import * as importData from "./import.js"
 import * as list from "./list.js"
+import * as install from "./install.js"
 
-export const commands = [init, info, run, exportData, importData, list] as CommandModule[]
+export const commands = [init, info, run, exportData, importData, list, install] as CommandModule[]

--- a/packages/canvas-cli/src/commands/install.ts
+++ b/packages/canvas-cli/src/commands/install.ts
@@ -77,6 +77,8 @@ export async function handler(args: Args) {
 			{ signal: controller.signal, delay: 1000 }
 		)
 
+		await libp2p.stop()
+
 		console.log(chalk.yellow(`[canvas-cli] Creating ${specPath}`))
 		fs.writeFileSync(specPath, spec)
 		runCommand = `canvas run ${cid.toString()}`

--- a/packages/canvas-cli/src/commands/install.ts
+++ b/packages/canvas-cli/src/commands/install.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs"
+import path from "node:path"
+
+import yargs from "yargs"
+import chalk from "chalk"
+import Hash from "ipfs-only-hash"
+
+import type { PeerId } from "@libp2p/interface-peer-id"
+import type { Multiaddr } from "@multiformats/multiaddr"
+import { createLibp2p, Libp2pOptions } from "libp2p"
+import { webSockets } from "@libp2p/websockets"
+import { noise } from "@chainsafe/libp2p-noise"
+import { mplex } from "@libp2p/mplex"
+import { bootstrap } from "@libp2p/bootstrap"
+import { kadDHT } from "@libp2p/kad-dht"
+import { isLoopback } from "@libp2p/utils/multiaddr/is-loopback"
+import { isPrivate } from "@libp2p/utils/multiaddr/is-private"
+import { createFromProtobuf } from "@libp2p/peer-id-factory"
+
+import { constants } from "@canvas-js/core"
+import { retry } from "@canvas-js/core/lib/utils.js"
+
+import { CANVAS_HOME, cidPattern } from "../utils.js"
+import { CID } from "multiformats"
+
+export const command = "install <spec>"
+export const desc = "Install a spec in the canvas home directory"
+
+export const builder = (yargs: yargs.Argv) =>
+	yargs.positional("spec", {
+		describe: "Path to spec file, or IPFS hash of spec",
+		type: "string",
+		demandOption: true,
+	})
+
+type Args = ReturnType<typeof builder> extends yargs.Argv<infer T> ? T : never
+
+export async function handler(args: Args) {
+	let runCommand
+	if (cidPattern.test(args.spec)) {
+		const specPath = path.resolve(CANVAS_HOME, args.spec, constants.SPEC_FILENAME)
+		if (fs.existsSync(specPath)) {
+			console.log(chalk.yellow(`[canvas-cli] ${specPath} already exists`))
+			return
+		}
+
+		// Oooookay now we have to initialize a libp2p node :/
+		const peerIdPath = path.resolve(CANVAS_HOME, constants.PEER_ID_FILENAME)
+		const peerId = await createFromProtobuf(fs.readFileSync(peerIdPath))
+		const libp2p = await createLibp2p(getLibp2pInit(peerId))
+		await libp2p.start()
+
+		const controller = new AbortController()
+		process.on("SIGINT", () => {
+			controller.abort()
+			libp2p.stop()
+		})
+
+		const cid = CID.parse(args.spec)
+		const spec = await retry(
+			async (signal) => {
+				for await (const { id } of libp2p.contentRouting.findProviders(cid)) {
+					console.log(chalk.yellow(`[canvas-cli] Trying to fetch ${cid.toString} from ${id.toString()}`))
+					const value = await libp2p.fetch(id, `ipfs://${cid.toString()}/`, { signal })
+					if (value !== null) {
+						const hash = await Hash.of(value)
+						if (hash === args.spec) {
+							console.log(chalk.yellow(`[canvas-cli] Success!`))
+							return value
+						}
+					}
+				}
+
+				throw new Error("No peers found")
+			},
+			(err, n) => console.log(chalk.red(`[canvas-cli] Failed to fetch spec. Trying again in 1s.`)),
+			{ signal: controller.signal, delay: 1000 }
+		)
+
+		console.log(chalk.yellow(`[canvas-cli] Creating ${specPath}`))
+		fs.writeFileSync(specPath, spec)
+		runCommand = `canvas run ${cid.toString()}`
+	} else {
+		const spec = fs.readFileSync(args.spec, "utf-8")
+		const cid = await Hash.of(spec)
+		const directory = path.resolve(CANVAS_HOME, cid)
+		if (!fs.existsSync(directory)) {
+			console.log(chalk.yellow(`[canvas-cli] Creating directory ${directory}`))
+			fs.mkdirSync(directory)
+		}
+
+		const specPath = path.resolve(directory, constants.SPEC_FILENAME)
+		if (fs.existsSync(specPath)) {
+			console.log(chalk.yellow(`[canvas-cli] ${specPath} already exists`))
+		} else {
+			console.log(chalk.yellow(`[canvas-cli] Creating ${specPath}`))
+			fs.writeFileSync(specPath, spec, "utf-8")
+		}
+
+		runCommand = `canvas run ${cid}`
+	}
+
+	console.log(chalk.yellow(`[canvas-cli] You can run the app with ${chalk.bold(runCommand)}`))
+}
+
+const bootstrapList = [
+	"/ip4/137.66.12.223/tcp/4002/ws/p2p/12D3KooWP4DLJuVUKoThfzYugv8c326MuM2Tx38ybvEyDjLQkE2o",
+	"/ip4/137.66.11.73/tcp/4002/ws/p2p/12D3KooWRftkCBMtYou4pM3VKdqkKVDAsWXnc8NabUNzx7gp7cPT",
+	"/ip4/137.66.27.235/tcp/4002/ws/p2p/12D3KooWPopNdRnzswSd8oVxrUBKGhgKzkYALETK7EHkToy7DKk3",
+]
+
+function getLibp2pInit(peerId: PeerId): Libp2pOptions {
+	return {
+		connectionGater: {
+			denyDialMultiaddr: async (peerId: PeerId, multiaddr: Multiaddr) => isLoopback(multiaddr) || isPrivate(multiaddr),
+		},
+		addresses: {
+			announce: bootstrapList.map((multiaddr) => `${multiaddr}/p2p-circuit/p2p/${peerId.toString()}`),
+		},
+		transports: [webSockets()],
+		connectionEncryption: [noise()],
+		streamMuxers: [mplex()],
+		peerDiscovery: [bootstrap({ list: bootstrapList })],
+		dht: kadDHT({ protocolPrefix: "/canvas", clientMode: true }),
+	}
+}

--- a/packages/canvas-cli/src/commands/install.ts
+++ b/packages/canvas-cli/src/commands/install.ts
@@ -5,30 +5,16 @@ import yargs from "yargs"
 import chalk from "chalk"
 import Hash from "ipfs-only-hash"
 
-import type { PeerId } from "@libp2p/interface-peer-id"
-import type { Multiaddr } from "@multiformats/multiaddr"
-import { createLibp2p, Libp2pOptions } from "libp2p"
-import { webSockets } from "@libp2p/websockets"
-import { noise } from "@chainsafe/libp2p-noise"
-import { mplex } from "@libp2p/mplex"
-import { bootstrap } from "@libp2p/bootstrap"
-import { kadDHT } from "@libp2p/kad-dht"
-import { isLoopback } from "@libp2p/utils/multiaddr/is-loopback"
-import { isPrivate } from "@libp2p/utils/multiaddr/is-private"
-import { createFromProtobuf } from "@libp2p/peer-id-factory"
-
 import { constants } from "@canvas-js/core"
-import { retry } from "@canvas-js/core/lib/utils.js"
 
-import { CANVAS_HOME, cidPattern } from "../utils.js"
-import { CID } from "multiformats"
+import { CANVAS_HOME } from "../utils.js"
 
 export const command = "install <spec>"
-export const desc = "Install a spec in the canvas home directory"
+export const desc = "Install an app in the canvas home directory"
 
 export const builder = (yargs: yargs.Argv) =>
 	yargs.positional("spec", {
-		describe: "Path to spec file, or IPFS hash of spec",
+		describe: "Path to development spec file",
 		type: "string",
 		demandOption: true,
 	})
@@ -36,93 +22,21 @@ export const builder = (yargs: yargs.Argv) =>
 type Args = ReturnType<typeof builder> extends yargs.Argv<infer T> ? T : never
 
 export async function handler(args: Args) {
-	let runCommand
-	if (cidPattern.test(args.spec)) {
-		const specPath = path.resolve(CANVAS_HOME, args.spec, constants.SPEC_FILENAME)
-		if (fs.existsSync(specPath)) {
-			console.log(chalk.yellow(`[canvas-cli] ${specPath} already exists`))
-			return
-		}
+	const spec = fs.readFileSync(args.spec, "utf-8")
+	const cid = await Hash.of(spec)
+	const directory = path.resolve(CANVAS_HOME, cid)
+	if (!fs.existsSync(directory)) {
+		console.log(`[canvas-cli] Creating app directory at ${directory}`)
+		fs.mkdirSync(directory)
+	}
 
-		// Oooookay now we have to initialize a libp2p node :/
-		const peerIdPath = path.resolve(CANVAS_HOME, constants.PEER_ID_FILENAME)
-		const peerId = await createFromProtobuf(fs.readFileSync(peerIdPath))
-		const libp2p = await createLibp2p(getLibp2pInit(peerId))
-		await libp2p.start()
-
-		const controller = new AbortController()
-		process.on("SIGINT", () => {
-			controller.abort()
-			libp2p.stop()
-		})
-
-		const cid = CID.parse(args.spec)
-		const spec = await retry(
-			async (signal) => {
-				for await (const { id } of libp2p.contentRouting.findProviders(cid)) {
-					console.log(chalk.yellow(`[canvas-cli] Trying to fetch ${cid.toString} from ${id.toString()}`))
-					const value = await libp2p.fetch(id, `ipfs://${cid.toString()}/`, { signal })
-					if (value !== null) {
-						const hash = await Hash.of(value)
-						if (hash === args.spec) {
-							console.log(chalk.yellow(`[canvas-cli] Success!`))
-							return value
-						}
-					}
-				}
-
-				throw new Error("No peers found")
-			},
-			(err, n) => console.log(chalk.red(`[canvas-cli] Failed to fetch spec. Trying again in 1s.`)),
-			{ signal: controller.signal, delay: 1000 }
-		)
-
-		await libp2p.stop()
-
-		console.log(chalk.yellow(`[canvas-cli] Creating ${specPath}`))
-		fs.writeFileSync(specPath, spec)
-		runCommand = `canvas run ${cid.toString()}`
+	const specPath = path.resolve(directory, constants.SPEC_FILENAME)
+	if (fs.existsSync(specPath)) {
+		console.log(`[canvas-cli] ${specPath} already exists`)
 	} else {
-		const spec = fs.readFileSync(args.spec, "utf-8")
-		const cid = await Hash.of(spec)
-		const directory = path.resolve(CANVAS_HOME, cid)
-		if (!fs.existsSync(directory)) {
-			console.log(chalk.yellow(`[canvas-cli] Creating directory ${directory}`))
-			fs.mkdirSync(directory)
-		}
-
-		const specPath = path.resolve(directory, constants.SPEC_FILENAME)
-		if (fs.existsSync(specPath)) {
-			console.log(chalk.yellow(`[canvas-cli] ${specPath} already exists`))
-		} else {
-			console.log(chalk.yellow(`[canvas-cli] Creating ${specPath}`))
-			fs.writeFileSync(specPath, spec, "utf-8")
-		}
-
-		runCommand = `canvas run ${cid}`
+		console.log(`[canvas-cli] Creating ${specPath}`)
+		fs.writeFileSync(specPath, spec, "utf-8")
 	}
 
-	console.log(chalk.yellow(`[canvas-cli] You can run the app with ${chalk.bold(runCommand)}`))
-}
-
-const bootstrapList = [
-	"/ip4/137.66.12.223/tcp/4002/ws/p2p/12D3KooWP4DLJuVUKoThfzYugv8c326MuM2Tx38ybvEyDjLQkE2o",
-	"/ip4/137.66.11.73/tcp/4002/ws/p2p/12D3KooWRftkCBMtYou4pM3VKdqkKVDAsWXnc8NabUNzx7gp7cPT",
-	"/ip4/137.66.27.235/tcp/4002/ws/p2p/12D3KooWPopNdRnzswSd8oVxrUBKGhgKzkYALETK7EHkToy7DKk3",
-]
-
-function getLibp2pInit(peerId: PeerId): Libp2pOptions {
-	return {
-		connectionGater: {
-			denyDialMultiaddr: async (peerId: PeerId, multiaddr: Multiaddr) => isLoopback(multiaddr) || isPrivate(multiaddr),
-		},
-		addresses: {
-			announce: bootstrapList.map((multiaddr) => `${multiaddr}/p2p-circuit/p2p/${peerId.toString()}`),
-		},
-		transports: [webSockets()],
-		connectionEncryption: [noise()],
-		streamMuxers: [mplex()],
-		peerDiscovery: [bootstrap({ list: bootstrapList })],
-		dht: kadDHT({ protocolPrefix: "/canvas", clientMode: true }),
-	}
+	console.log(chalk.yellow(`[canvas-cli] Run the app with ${chalk.bold(`canvas run ${cid}`)}`))
 }

--- a/packages/canvas-cli/src/commands/run.ts
+++ b/packages/canvas-cli/src/commands/run.ts
@@ -7,9 +7,9 @@ import chalk from "chalk"
 import prompts from "prompts"
 import Hash from "ipfs-only-hash"
 
-import { Core, constants, actionType } from "@canvas-js/core"
+import { Core, constants, actionType, Driver } from "@canvas-js/core"
 
-import { setupRpcs, locateSpec, confirmOrExit } from "../utils.js"
+import { setupRpcs, locateSpec, confirmOrExit, CANVAS_HOME } from "../utils.js"
 import { API } from "../api.js"
 
 export const command = "run <spec>"
@@ -152,21 +152,13 @@ export async function handler(args: Args) {
 		console.log("")
 	}
 
-	const { verbose, replay, unchecked, peering, "peering-port": peeringPort } = args
+	const { verbose, replay, unchecked, "peering-port": peeringPort } = args
+
+	const driver = await Driver.initialize({ rootDirectory: CANVAS_HOME, port: peeringPort, rpc })
 
 	let core: Core
 	try {
-		core = await Core.initialize({
-			directory,
-			uri,
-			spec,
-			rpc,
-			verbose,
-			unchecked,
-			peering,
-			port: peeringPort,
-			peerId,
-		})
+		core = await driver.start(uri, { unchecked })
 	} catch (err) {
 		if (err instanceof Error) {
 			console.log(chalk.red(err.message))

--- a/packages/canvas-cli/src/commands/run.ts
+++ b/packages/canvas-cli/src/commands/run.ts
@@ -154,7 +154,7 @@ export async function handler(args: Args) {
 
 	let core: Core
 	try {
-		core = await driver.start(uri, { unchecked })
+		core = await driver.start(uri, { unchecked, verbose })
 	} catch (err) {
 		if (err instanceof Error) {
 			console.log(chalk.red(err.message))

--- a/packages/canvas-core/src/core.ts
+++ b/packages/canvas-core/src/core.ts
@@ -393,6 +393,10 @@ export class Core extends EventEmitter<CoreEvents> {
 	private static peeringInterval = 1000 * 60 * 60 * 1
 	private static peeringRetryInterval = 1000 * 5
 	private async startPeeringService(libp2p: Libp2p) {
+		if (this.options.verbose) {
+			console.log("[canvas-core] Staring announce service")
+		}
+
 		const { signal } = this.controller
 		try {
 			await wait({ signal, delay: Core.peeringDelay })
@@ -419,6 +423,10 @@ export class Core extends EventEmitter<CoreEvents> {
 	private static syncInterval = 1000 * 60 * 1
 	private static syncRetryInterval = 1000 * 5
 	private async startSyncService(libp2p: Libp2p) {
+		if (this.options.verbose) {
+			console.log("[canvas-core] Staring sync service")
+		}
+
 		const { signal } = this.controller
 
 		try {

--- a/packages/canvas-core/src/core.ts
+++ b/packages/canvas-core/src/core.ts
@@ -2,17 +2,15 @@ import assert from "node:assert"
 import path from "node:path"
 import { createHash } from "node:crypto"
 
-import { ethers } from "ethers"
-
 import chalk from "chalk"
 import PQueue from "p-queue"
+import { ethers } from "ethers"
 import Hash from "ipfs-only-hash"
 import { CID } from "multiformats/cid"
-import { createEd25519PeerId } from "@libp2p/peer-id-factory"
 
 import { EventEmitter, CustomEvent, EventHandler } from "@libp2p/interfaces/events"
 
-import { createLibp2p, type Libp2p } from "libp2p"
+import type { Libp2p } from "libp2p"
 import type { FetchService } from "libp2p/fetch"
 import type { SignedMessage, UnsignedMessage } from "@libp2p/interface-pubsub"
 import type { Stream } from "@libp2p/interface-connection"
@@ -30,13 +28,11 @@ import {
 	verifyActionSignature,
 	verifySessionSignature,
 	ModelValue,
-	Chain,
 	Message,
-	ChainId,
 } from "@canvas-js/interfaces"
 
 import { actionType, sessionType } from "./codecs.js"
-import { signalInvalidType, wait, retry, toHex, BlockCache, BlockResolver } from "./utils.js"
+import { signalInvalidType, wait, retry, toHex, BlockResolver } from "./utils.js"
 import { encodeMessage, decodeMessage, getActionHash, getSessionHash } from "./encoding.js"
 import { ModelStore } from "./model-store/index.js"
 import { VM } from "./vm/index.js"
@@ -44,18 +40,22 @@ import { MessageStore } from "./message-store/store.js"
 
 import * as RPC from "./rpc/index.js"
 import * as constants from "./constants.js"
-import { getLibp2pInit } from "./libp2p.js"
 
-export interface CoreConfig {
+interface CoreConfig extends CoreOptions {
+	// pass `null` to run in memory
 	directory: string | null
 	uri: string
 	spec: string
-	verbose?: boolean
+	// omit or pass `null` to run offline
+	libp2p?: Libp2p | null
+	providers?: Record<string, ethers.providers.JsonRpcProvider>
+	// defaults to fetching each block from the provider with no caching
+	blockResolver?: BlockResolver
+}
+
+interface CoreOptions {
 	unchecked?: boolean
-	rpc?: Partial<Record<Chain, Record<ChainId, string>>>
-	peering?: boolean
-	port?: number
-	peerId?: PeerId
+	verbose?: boolean
 }
 
 interface CoreEvents {
@@ -65,71 +65,29 @@ interface CoreEvents {
 	session: CustomEvent<SessionPayload>
 }
 
-const ipfsURIPattern = /^ipfs:\/\/([a-zA-Z0-9]+)$/
-const fileURIPattern = /^file:\/\/(.+)$/
-
 export class Core extends EventEmitter<CoreEvents> {
-	public static async initialize(config: CoreConfig): Promise<Core> {
-		const { directory, uri, spec, verbose, unchecked, rpc, peering, port } = config
-
-		if (verbose) {
-			console.log(`[canvas-core] Initializing core ${uri}`)
-		}
-
-		assert(ipfsURIPattern.test(uri) || fileURIPattern.test(uri), "Core.uri must be an ipfs:// or file:// URI")
-
-		const cid = await Hash.of(spec).then((cid) => {
-			if (ipfsURIPattern.test(uri)) {
-				assert(uri === `ipfs://${cid}`, "Core.uri is not equal to the hash of the provided spec.")
-			}
-
-			return CID.parse(cid)
-		})
-
-		const providers: Record<string, ethers.providers.JsonRpcProvider> = {}
-		for (const [chain, chainIds] of Object.entries(rpc || {})) {
-			for (const [chainId, url] of Object.entries(chainIds)) {
-				const key = `${chain}:${chainId}`
-				providers[key] = new ethers.providers.JsonRpcProvider(url)
-			}
-		}
-
-		const vm = await VM.initialize(uri, spec, providers, { verbose })
-
-		let libp2p: Libp2p | null = null
-		if (directory !== null && peering) {
-			assert(port !== undefined, "a peeringPort must be provided if peering is enabled")
-
-			const peerId = config.peerId || (await createEd25519PeerId())
-			libp2p = await createLibp2p(getLibp2pInit(peerId, port))
-			console.log(`[canvas-core] PeerId ${libp2p.peerId.toString()}`)
-			await libp2p.start()
-		}
-
-		const blockCache = new BlockCache(providers)
-		const options = { verbose, unchecked, peering: true, sync: true }
-		const core = new Core(directory, uri, cid, spec, vm, libp2p, providers, blockCache, options)
-		core.addEventListener("close", () => {
-			blockCache.close()
-			if (libp2p !== null) {
-				libp2p.stop()
-			}
-		})
-
-		if (verbose) {
-			console.log(`[canvas-core] Successfully initialized core ${config.uri}`)
-		}
-
-		return core
-	}
-
 	public readonly modelStore: ModelStore
 	public readonly messageStore: MessageStore
-	public readonly mst: okra.Tree | null
-	public readonly rpcServer: RPC.Server | null
+	public readonly mst: okra.Tree | null = null
+	public readonly rpcServer: RPC.Server | null = null
 
 	private readonly queue: PQueue = new PQueue({ concurrency: 1 })
 	private readonly controller = new AbortController()
+
+	public static async initialize({ directory, uri, spec, libp2p, providers, blockResolver, ...options }: CoreConfig) {
+		const cid = await Hash.of(spec).then(CID.parse)
+		const vm = await VM.initialize(uri, spec, providers || {})
+
+		if (blockResolver === undefined) {
+			blockResolver = (chain, chainId, blockhash) => {
+				const provider = providers?.[`${chain}:${chainId}`]
+				assert(provider !== undefined, `no provider for ${chain}:${chainId}`)
+				return provider.getBlock(blockhash)
+			}
+		}
+
+		return new Core(directory || null, uri, cid, spec, vm, libp2p || null, blockResolver || null, options)
+	}
 
 	private constructor(
 		public readonly directory: string | null,
@@ -138,14 +96,8 @@ export class Core extends EventEmitter<CoreEvents> {
 		public readonly spec: string,
 		public readonly vm: VM,
 		public readonly libp2p: Libp2p | null,
-		private readonly providers: Record<string, ethers.providers.JsonRpcProvider>,
-		private readonly blockResolver: BlockResolver | null,
-		private readonly options: {
-			verbose?: boolean
-			unchecked?: boolean
-			peering?: boolean
-			sync?: boolean
-		}
+		private readonly blockResolver: BlockResolver,
+		private readonly options: CoreOptions
 	) {
 		super()
 
@@ -155,30 +107,25 @@ export class Core extends EventEmitter<CoreEvents> {
 		const messageDatabasePath = directory && path.resolve(directory, constants.MESSAGE_DATABASE_FILENAME)
 		this.messageStore = new MessageStore(uri, messageDatabasePath, { verbose: options.verbose })
 
-		if (directory === null) {
-			this.rpcServer = null
-			this.mst = null
-		} else {
+		if (directory !== null) {
+			// offline cores might be run with a non-null directory; we still want to update the MST
 			this.mst = new okra.Tree(path.resolve(directory, constants.MST_FILENAME))
-			this.rpcServer = new RPC.Server({ mst: this.mst, messageStore: this.messageStore })
-		}
 
-		if (this.libp2p !== null) {
-			if (options.peering) {
+			if (this.libp2p !== null) {
+				this.rpcServer = new RPC.Server({ mst: this.mst, messageStore: this.messageStore })
+
 				this.libp2p.pubsub.subscribe(this.uri)
 				this.libp2p.pubsub.addEventListener("message", this.handleMessage)
 				console.log(`[canvas-core] Subscribed to pubsub topic ${this.uri}`)
-			}
 
-			if (options.sync) {
 				this.libp2p.handle(this.syncProtocol, this.handleIncomingStream)
 				this.startSyncService()
 				this.startPeeringService()
-			}
 
-			if (this.uri.startsWith("ipfs://")) {
-				const { fetchService } = this.libp2p as Libp2p & { fetchService: FetchService }
-				fetchService.registerLookupFunction(`${this.uri}/`, this.fetchLookupFunction)
+				if (this.uri.startsWith("ipfs://")) {
+					const { fetchService } = this.libp2p as Libp2p & { fetchService: FetchService }
+					fetchService.registerLookupFunction(`${this.uri}/`, this.fetchLookupFunction)
+				}
 			}
 		}
 	}
@@ -197,13 +144,6 @@ export class Core extends EventEmitter<CoreEvents> {
 
 	public async onIdle(): Promise<void> {
 		await this.queue.onIdle()
-	}
-
-	public getProvider(chain: Chain, chainId: ChainId): ethers.providers.JsonRpcProvider {
-		const key = `${chain}:${chainId}`
-		const provider = this.providers[key]
-		assert(provider !== undefined, `No provider for ${key}`)
-		return provider
 	}
 
 	public async close() {
@@ -234,10 +174,9 @@ export class Core extends EventEmitter<CoreEvents> {
 	/**
 	 * Helper for verifying the blockhash for an action or session.
 	 */
-	public async verifyBlock(blockInfo: Block, options: { sync?: boolean }) {
+	public async verifyBlock(blockInfo: Block) {
 		const { chain, chainId, blocknum, blockhash, timestamp } = blockInfo
-		assert(this.blockResolver !== null, "No block resolver provided")
-		const block = await this.blockResolver.getBlock(chain, chainId, blockhash)
+		const block = await this.blockResolver(chain, chainId, blockhash)
 
 		// check the block retrieved from RPC matches metadata from the user
 		assert(block.number === blocknum, "action/session provided with invalid block number")
@@ -262,12 +201,12 @@ export class Core extends EventEmitter<CoreEvents> {
 		return { hash }
 	}
 
-	private async applyActionInternal(hash: string, action: Action, options: { sync?: boolean } = {}) {
+	private async applyActionInternal(hash: string, action: Action) {
 		if (this.options.verbose) {
 			console.log(chalk.green(`[canvas-core] Applying action ${hash}`), action)
 		}
 
-		await this.validateAction(action, options)
+		await this.validateAction(action)
 
 		const effects = await this.vm.execute(hash, action.payload)
 		this.messageStore.insertAction(hash, action)
@@ -287,7 +226,7 @@ export class Core extends EventEmitter<CoreEvents> {
 		}
 	}
 
-	private async validateAction(action: Action, options: { sync?: boolean }) {
+	private async validateAction(action: Action) {
 		const { timestamp, block, spec } = action.payload
 		const fromAddress = action.payload.from.toLowerCase()
 
@@ -299,8 +238,8 @@ export class Core extends EventEmitter<CoreEvents> {
 
 		if (!this.options.unchecked) {
 			// check the action was signed with a valid, recent block
-			assert(block !== undefined, "action missing block data")
-			await this.verifyBlock(block, options)
+			assert(block !== undefined, "action is missing block data")
+			await this.verifyBlock(block)
 		}
 
 		// verify the signature, either using a session signature or action signature
@@ -345,12 +284,12 @@ export class Core extends EventEmitter<CoreEvents> {
 		return { hash }
 	}
 
-	private async applySessionInternal(hash: string, session: Session, options: { sync?: boolean } = {}) {
+	private async applySessionInternal(hash: string, session: Session) {
 		if (this.options.verbose) {
 			console.log(chalk.green(`[canvas-core] Applying session ${hash}`), session)
 		}
 
-		await this.validateSession(session, options)
+		await this.validateSession(session)
 		this.messageStore.insertSession(hash, session)
 		if (this.mst !== null) {
 			const hashBuffer = Buffer.from(hash.slice(2), "hex")
@@ -366,7 +305,7 @@ export class Core extends EventEmitter<CoreEvents> {
 		}
 	}
 
-	private async validateSession(session: Session, options: { sync?: boolean }) {
+	private async validateSession(session: Session) {
 		const { from, spec, timestamp, block } = session.payload
 		assert(spec === this.uri, "session signed for wrong spec")
 
@@ -377,10 +316,10 @@ export class Core extends EventEmitter<CoreEvents> {
 		assert(timestamp > constants.BOUNDS_CHECK_LOWER_LIMIT, "session timestamp too far in the past")
 		assert(timestamp < constants.BOUNDS_CHECK_UPPER_LIMIT, "session timestamp too far in the future")
 
-		// check the session was signed with a valid, recent block
 		if (!this.options.unchecked) {
-			assert(block !== undefined, "session missing block info")
-			await this.verifyBlock(block, options)
+			// check the session was signed with a valid, recent block
+			assert(block !== undefined, "session is missing block data")
+			await this.verifyBlock(block)
 		}
 	}
 
@@ -506,15 +445,15 @@ export class Core extends EventEmitter<CoreEvents> {
 				await wait({ signal, delay: Core.syncInterval })
 			}
 		} catch (err) {
-			console.log(`[canvas-core] Aborting sync service`)
+			console.log("[canvas-core] Aborting sync service")
 		}
 	}
 
 	private findPeers = async (signal: AbortSignal): Promise<PeerId[]> => {
 		const peers: PeerId[] = []
-		this.libp2p?.pubsub.getSubscribers(this.uri)
 
 		if (this.libp2p !== null) {
+			// this.libp2p.pubsub.getSubscribers(this.uri)
 			for await (const { id } of this.libp2p.contentRouting.findProviders(this.cid, { signal })) {
 				if (id.equals(this.libp2p.peerId)) {
 					continue
@@ -561,7 +500,7 @@ export class Core extends EventEmitter<CoreEvents> {
 					if (message.type === "session") {
 						const { type, ...session } = message
 						try {
-							await this.applySessionInternal(hash, session, { sync: true })
+							await this.applySessionInternal(hash, session)
 							successCount += 1
 						} catch (err) {
 							console.log(chalk.red(`[canvas-core] Failed to apply session ${hash}`), err)
@@ -570,7 +509,7 @@ export class Core extends EventEmitter<CoreEvents> {
 					} else if (message.type === "action") {
 						const { type, ...action } = message
 						try {
-							await this.applyActionInternal(hash, action, { sync: true })
+							await this.applyActionInternal(hash, action)
 							successCount += 1
 						} catch (err) {
 							console.log(chalk.red(`[canvas-core] Failed to apply action ${hash}`), err)
@@ -583,6 +522,7 @@ export class Core extends EventEmitter<CoreEvents> {
 			})
 
 		await RPC.sync(this.mst, stream, applyBatch)
+
 		console.log(
 			`[canvas-core] Sync with ${peer.toString()} completed. Applied ${successCount} new messages with ${failureCount} failures.`
 		)

--- a/packages/canvas-core/src/driver.ts
+++ b/packages/canvas-core/src/driver.ts
@@ -80,7 +80,10 @@ export class Driver {
 		}
 	}
 
-	public start(uri: string, options: { unchecked?: boolean; offline?: boolean } = {}): Promise<Core> {
+	public start(
+		uri: string,
+		options: { unchecked?: boolean; verbose?: boolean; offline?: boolean } = {}
+	): Promise<Core> {
 		return this.queue.add(async () => {
 			const ipfsURI = ipfsURIPattern.exec(uri)
 			const fileURI = fileURIPattern.exec(uri)
@@ -108,6 +111,7 @@ export class Driver {
 				providers: this.providers,
 				blockResolver: this.blockCache.getBlock,
 				unchecked: options.unchecked,
+				verbose: options.verbose,
 			})
 
 			this.cores[uri] = core

--- a/packages/canvas-core/src/driver.ts
+++ b/packages/canvas-core/src/driver.ts
@@ -1,0 +1,165 @@
+import path from "node:path"
+import fs from "node:fs"
+
+import { ethers } from "ethers"
+import chalk from "chalk"
+import PQueue from "p-queue"
+
+import type { PeerId } from "@libp2p/interface-peer-id"
+import { createEd25519PeerId, exportToProtobuf, createFromProtobuf } from "@libp2p/peer-id-factory"
+import { createLibp2p, Libp2p } from "libp2p"
+import Hash from "ipfs-only-hash"
+import { CID } from "multiformats/cid"
+
+import type { Chain, ChainId } from "@canvas-js/interfaces"
+
+import { Core } from "./core.js"
+import { VM } from "./vm/index.js"
+import { getLibp2pInit } from "./libp2p.js"
+import { BlockCache } from "./utils.js"
+import * as constants from "./constants.js"
+
+const ipfsURIPattern = /^ipfs:\/\/([a-zA-Z0-9]+)$/
+const fileURIPattern = /^file:\/\/(.+)$/
+
+export interface DriverConfig {
+	rootDirectory: string | null
+	port?: number
+	rpc?: Partial<Record<Chain, Record<ChainId, string>>>
+}
+
+export class Driver {
+	public static async initialize({ rootDirectory, port, rpc }: DriverConfig) {
+		let peerId: PeerId | null = null
+		let libp2p: Libp2p | null = null
+		if (rootDirectory !== null) {
+			const peerIdPath = path.resolve(rootDirectory, "peer.id")
+
+			if (fs.existsSync(peerIdPath)) {
+				peerId = await createFromProtobuf(fs.readFileSync(peerIdPath))
+			} else {
+				peerId = await createEd25519PeerId()
+				fs.writeFileSync(peerIdPath, exportToProtobuf(peerId))
+			}
+
+			console.log(`[canvas-core] PeerId ${peerId.toString()}`)
+
+			const libp2p = await createLibp2p(getLibp2pInit(peerId, port))
+			await libp2p.start()
+		}
+
+		const providers: Record<string, ethers.providers.JsonRpcProvider> = {}
+		for (const [chain, chainIds] of Object.entries(rpc || {})) {
+			for (const [chainId, url] of Object.entries(chainIds)) {
+				const key = `${chain}:${chainId}`
+				providers[key] = new ethers.providers.JsonRpcProvider(url)
+			}
+		}
+
+		return new Driver(rootDirectory, libp2p, providers)
+	}
+
+	public readonly cores: Record<string, Core> = {}
+	private readonly queue = new PQueue({ concurrency: 1 })
+	private readonly controller = new AbortController()
+	private readonly blockCache: BlockCache
+
+	private constructor(
+		public readonly rootDirectory: string | null,
+		public readonly libp2p: Libp2p | null,
+		public readonly providers: Record<string, ethers.providers.JsonRpcProvider>
+	) {
+		this.blockCache = new BlockCache(this.providers)
+	}
+
+	async close() {
+		this.controller.abort()
+		this.blockCache.close()
+		for (const key of Object.keys(this.cores)) {
+			await this.stop(key)
+		}
+	}
+
+	public start(uri: string, options: { unchecked?: boolean; offline?: boolean } = {}): Promise<Core> {
+		return this.queue.add(async () => {
+			const ipfsURI = ipfsURIPattern.exec(uri)
+			const fileURI = fileURIPattern.exec(uri)
+
+			let directory: string | null = null
+			let spec: string
+			if (ipfsURI !== null) {
+				const [_, cid] = ipfsURI
+				spec = await this.fetch(CID.parse(cid))
+				if (this.rootDirectory !== null) {
+					directory = path.relative(this.rootDirectory, cid)
+				}
+			} else if (fileURI !== null) {
+				const [_, specPath] = fileURI
+				spec = fs.readFileSync(specPath, "utf-8")
+			} else {
+				throw new Error("uri must be a file:// or ipfs:// URI")
+			}
+
+			const core = await Core.initialize({
+				directory,
+				uri,
+				spec,
+				libp2p: options.offline ? null : this.libp2p,
+				providers: this.providers,
+				blockResolver: this.blockCache.getBlock,
+				unchecked: options.unchecked,
+			})
+
+			this.cores[uri] = core
+			core.addEventListener("close", () => delete this.cores[uri])
+			return core
+		})
+	}
+
+	public stop(uri: string): Promise<void> {
+		return this.queue.add(async () => {
+			const core = this.cores[uri]
+			if (core === undefined) {
+				throw new Error(`${uri} is not running`)
+			}
+
+			await core.close()
+		})
+	}
+
+	public async fetch(cid: CID): Promise<string> {
+		if (this.rootDirectory !== null) {
+			const directory = path.resolve(this.rootDirectory, cid.toString())
+			const specPath = path.resolve(directory, constants.SPEC_FILENAME)
+			if (fs.existsSync(specPath)) {
+				return fs.readFileSync(specPath, "utf-8")
+			}
+		}
+
+		if (this.libp2p === null) {
+			throw new Error("cannot fetch spec because the driver is offline")
+		}
+
+		const { signal } = this.controller
+
+		for await (const { id } of this.libp2p.contentRouting.findProviders(cid, { signal })) {
+			let data: Uint8Array | null = null
+			try {
+				data = await this.libp2p.fetch(id, `ipfs://${cid.toString()}/`)
+			} catch (err) {
+				console.log(chalk.red(`[canvas-core] Failed to fetch spec from ${id.toString()}`))
+			} finally {
+				if (data === null) {
+					continue
+				}
+			}
+
+			const hash = await Hash.of(data)
+			if (hash === cid.toString()) {
+				return Buffer.from(data).toString("utf-8")
+			}
+		}
+
+		throw new Error("failed to fetch spec from libp2p")
+	}
+}

--- a/packages/canvas-core/src/driver.ts
+++ b/packages/canvas-core/src/driver.ts
@@ -91,7 +91,7 @@ export class Driver {
 				const [_, cid] = ipfsURI
 				spec = await this.fetch(CID.parse(cid))
 				if (this.rootDirectory !== null) {
-					directory = path.relative(this.rootDirectory, cid)
+					directory = path.resolve(this.rootDirectory, cid)
 				}
 			} else if (fileURI !== null) {
 				const [_, specPath] = fileURI

--- a/packages/canvas-core/src/index.ts
+++ b/packages/canvas-core/src/index.ts
@@ -3,6 +3,7 @@
 import "fp-ts"
 
 export * from "./core.js"
+export * from "./driver.js"
 export * from "./vm/index.js"
 export * from "./model-store/index.js"
 export * from "./message-store/store.js"

--- a/packages/canvas-core/src/utils.ts
+++ b/packages/canvas-core/src/utils.ts
@@ -170,11 +170,9 @@ export class CacheMap<K, V> extends Map<K, V> {
 	}
 }
 
-export interface BlockResolver {
-	getBlock(chain: Chain, chainId: ChainId, blockhash: string): Promise<ethers.providers.Block>
-}
+export type BlockResolver = (chain: Chain, chainId: ChainId, blockhash: string) => Promise<ethers.providers.Block>
 
-export class BlockCache implements BlockResolver {
+export class BlockCache {
 	private readonly controller = new AbortController()
 	private readonly caches: Record<string, CacheMap<string, ethers.providers.Block>> = {}
 	constructor(private readonly providers: Record<string, ethers.providers.Provider>) {
@@ -199,7 +197,7 @@ export class BlockCache implements BlockResolver {
 		this.controller.abort()
 	}
 
-	async getBlock(chain: Chain, chainId: ChainId, blockhash: string): Promise<ethers.providers.Block> {
+	public getBlock: BlockResolver = async (chain, chainId, blockhash) => {
 		const key = `${chain}:${chainId}`
 		const provider = this.providers[key]
 		assert(provider !== undefined, `No provider for ${chain}:${chainId}`)

--- a/packages/canvas-core/test/contracts.test.ts
+++ b/packages/canvas-core/test/contracts.test.ts
@@ -4,9 +4,10 @@ import * as dotenv from "dotenv"
 import { ethers } from "ethers"
 
 import { Action, ActionArgument, ActionPayload, getActionSignatureData } from "@canvas-js/interfaces"
-import { Core, compileSpec } from "@canvas-js/core"
+import { compileSpec, Core, Driver } from "@canvas-js/core"
 
 import { getCurrentBlock } from "./utils.js"
+import { BlockCache } from "../src/utils.js"
 
 dotenv.config({ path: "../../.env" })
 
@@ -42,9 +43,9 @@ test("Test calling the public ENS resolver contract", async (t) => {
 		},
 	})
 
-	const rpc = { eth: { [ETH_CHAIN_ID]: ETH_CHAIN_RPC } }
-	const core = await Core.initialize({ uri, directory: null, spec, rpc })
-	const provider = core.getProvider("eth", ETH_CHAIN_ID)
+	const provider = new ethers.providers.JsonRpcProvider(ETH_CHAIN_RPC)
+	const providers = { [`eth:${ETH_CHAIN_ID}`]: provider }
+	const core = await Core.initialize({ directory: null, uri, spec, providers })
 
 	async function sign(call: string, args: ActionArgument[]): Promise<Action> {
 		const timestamp = Date.now()

--- a/packages/canvas-core/test/core.test.ts
+++ b/packages/canvas-core/test/core.test.ts
@@ -132,7 +132,7 @@ test("Apply action signed with session key", async (t) => {
 })
 
 test("Apply two actions signed with session keys", async (t) => {
-	const core = await Core.initialize({ uri, spec, directory: null, unchecked: true })
+	const core = await Core.initialize({ directory: null, uri, spec, unchecked: true })
 
 	const sessionPayload: SessionPayload = {
 		from: signerAddress,


### PR DESCRIPTION
- `@canvas-js/core` now exports a `Driver` class, which replaces `Core` as the main entry point for most use cases.
- `canvas install ./path/to/development/spec.js` hashes the file and installs it inside `~/.canvas/`, replacing the need for a running IPFS daemon in day-to-day development.
