### PR TITLE
make daemon requests without trailing slash

### DIFF
--- a/packages/hooks/src/Canvas.tsx
+++ b/packages/hooks/src/Canvas.tsx
@@ -17,7 +17,7 @@ export const Canvas: React.FC<CanvasProps> = (props) => {
 	const [sessionWallet, setSessionWallet] = useState<ethers.Wallet | null>(null)
 	const [sessionExpiration, setSessionExpiration] = useState<number | null>(null)
 
-	const host = props.host.endsWith("/") ? props.host : props.host + "/"
+	const host = props.host
 
 	useEffect(() => {
 		fetch(host)

--- a/packages/hooks/src/useCanvas.ts
+++ b/packages/hooks/src/useCanvas.ts
@@ -2,7 +2,7 @@ import { Action, ActionPayload, getActionSignatureData } from "@canvas-js/interf
 import { useCallback, useContext, useState } from "react"
 
 import { CanvasContext, ApplicationData } from "./CanvasContext.js"
-import { Dispatch, CANVAS_SESSION_KEY, getLatestBlock } from "./utils.js"
+import { urlJoin, Dispatch, CANVAS_SESSION_KEY, getLatestBlock } from "./utils.js"
 
 export function useCanvas(): {
 	isLoading: boolean
@@ -65,7 +65,7 @@ export function useCanvas(): {
 
 				const action: Action = { session: sessionWallet.address, signature, payload }
 
-				const res = await fetch(host + "actions", {
+				const res = await fetch(urlJoin(host, "actions"), {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify(action),

--- a/packages/hooks/src/useSession.ts
+++ b/packages/hooks/src/useSession.ts
@@ -4,7 +4,7 @@ import { ethers } from "ethers"
 import { SessionPayload, getSessionSignatureData, Session } from "@canvas-js/interfaces"
 
 import { CanvasContext } from "./CanvasContext.js"
-import { CANVAS_SESSION_KEY, getLatestBlock } from "./utils.js"
+import { CANVAS_SESSION_KEY, getLatestBlock, urlJoin } from "./utils.js"
 
 export function useSession(signer: ethers.providers.JsonRpcSigner | null): {
 	error: Error | null
@@ -106,7 +106,7 @@ export function useSession(signer: ethers.providers.JsonRpcSigner | null): {
 			const signature = await signer._signTypedData(...sessionSignatureData)
 			const session: Session = { signature, payload }
 
-			const res = await fetch(host + "sessions", {
+			const res = await fetch(urlJoin(host, "sessions"), {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(session),

--- a/packages/hooks/src/utils.ts
+++ b/packages/hooks/src/utils.ts
@@ -16,3 +16,71 @@ export async function getLatestBlock(provider: ethers.providers.Provider): Promi
 		timestamp: providerBlock.timestamp,
 	}
 }
+
+// Copied from https://github.com/jfromaniello/url-join/blob/main/lib/url-join.js
+
+function normalize(strArray: string[]) {
+	const resultArray = []
+	if (strArray.length === 0) {
+		return ""
+	}
+
+	if (typeof strArray[0] !== "string") {
+		throw new TypeError("Url must be a string. Received " + strArray[0])
+	}
+
+	// If the first part is a plain protocol, we combine it with the next part.
+	if (strArray[0].match(/^[^/:]+:\/*$/) && strArray.length > 1) {
+		strArray[0] = strArray.shift() + strArray[0]
+	}
+
+	// There must be two or three slashes in the file protocol, two slashes in anything else.
+	if (strArray[0].match(/^file:\/\/\//)) {
+		strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, "$1:///")
+	} else {
+		strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, "$1://")
+	}
+
+	for (let i = 0; i < strArray.length; i++) {
+		let component = strArray[i]
+
+		if (typeof component !== "string") {
+			throw new TypeError("Url must be a string. Received " + component)
+		}
+
+		if (component === "") {
+			continue
+		}
+
+		if (i > 0) {
+			// Removing the starting slashes for each component but the first.
+			component = component.replace(/^[\/]+/, "")
+		}
+		if (i < strArray.length - 1) {
+			// Removing the ending slashes for each component but the last.
+			component = component.replace(/[\/]+$/, "")
+		} else {
+			// For the last component we will combine multiple slashes to a single one.
+			component = component.replace(/[\/]+$/, "/")
+		}
+
+		resultArray.push(component)
+	}
+
+	let str = resultArray.join("/")
+	// Each input component is now separated by a single slash except the possible first plain protocol part.
+
+	// remove trailing slash before parameters or hash
+	str = str.replace(/\/(\?|&|#[^!])/g, "$1")
+
+	// replace ? in parameters with &
+	const parts = str.split("?")
+	str = parts.shift() + (parts.length > 0 ? "?" : "") + parts.join("&")
+
+	return str
+}
+
+export function urlJoin(...args: string[]) {
+	const parts = Array.from(Array.isArray(args[0]) ? args[0] : args)
+	return normalize(parts)
+}


### PR DESCRIPTION
This PR modifies `canvas-hooks` so that all of the requests it makes to the API do *not* have trailing slashes.

Previously, we were sending a mix of requests with trailing slashes (e.g. `/`) and without trailing slashes (e.g. `/actions`). next.js requires URLs to all either have trailing slashes or not have trailing slashes. I found that if the URL had the wrong ending, a request would be 308 redirected to the correct URL but in the process lose its CORS headers, which would cause the request to fail... The redirect approach is a result of next.js being primarily designed to render web pages, where having two versions of the same URL would be really bad for SEO. This is not really the case with APIs... Ideally we would have a less opinionated web framework running on canvas-hub but this should work for now.