### PR TITLE
add new endpoints for canvas-hub

### DIFF
--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -16,6 +16,7 @@ import { BlockCache, Core, getLibp2pInit, constants, BlockResolver } from "@canv
 
 import { CANVAS_HOME, getPeerId, getProviders, SOCKET_FILENAME, SOCKET_PATH, startSignalServer } from "../utils.js"
 import { handleAction, handleRoute, handleSession } from "../api.js"
+import { installSpec } from "./install.js"
 
 import { ethers } from "ethers"
 
@@ -191,6 +192,19 @@ class Daemon {
 				fs.rmSync(directory, { recursive: true })
 				res.status(StatusCodes.OK).end()
 			})
+		})
+
+		this.api.post("/app/install", async (req, res) => {
+			// @ts-ignore
+			const { spec } = req.params
+			const multihash = Hash.of(spec)
+			console.log(`installing app with hash ${multihash}`)
+
+			await installSpec(spec)
+
+			console.log(`installed app with hash ${multihash}`)
+
+			res.status(StatusCodes.CREATED).end()
 		})
 
 		this.api.post("/app/:name/start", async (req, res) => {

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -312,6 +312,24 @@ class Daemon {
 			})
 		})
 
+		this.api.get("/app/:name/sessions", (req, res) => {
+			const { name } = req.params
+
+			this.queue.add(async () => {
+				const core = this.cores.get(name)
+				if (core === undefined) {
+					return res.status(StatusCodes.NOT_FOUND).end()
+				}
+
+				const sessions = []
+				for await (const entry of core.messageStore.getSessionStream()) {
+					sessions.push(entry)
+				}
+
+				return res.status(StatusCodes.OK).json(sessions)
+			})
+		})
+
 		this.api.post("/app/:name/sessions", (req, res) => {
 			const { name } = req.params
 

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -220,43 +220,43 @@ class Daemon {
 		this.api.post("/app/:name/start", async (req, res) => {
 			const { name } = req.params
 
-			// this.queue.add(async () => {
-			if (this.cores.has(name)) {
-				return res.status(StatusCodes.CONFLICT).end()
-			}
+			this.queue.add(async () => {
+				if (this.cores.has(name)) {
+					return res.status(StatusCodes.CONFLICT).end()
+				}
 
-			const directory = path.resolve(CANVAS_HOME, name)
-			if (!fs.existsSync(directory)) {
-				return res.status(StatusCodes.NOT_FOUND).end()
-			}
+				const directory = path.resolve(CANVAS_HOME, name)
+				if (!fs.existsSync(directory)) {
+					return res.status(StatusCodes.NOT_FOUND).end()
+				}
 
-			const specPath = path.resolve(CANVAS_HOME, name, constants.SPEC_FILENAME)
-			if (!fs.existsSync(specPath)) {
-				return res.status(StatusCodes.NOT_FOUND).end()
-			}
+				const specPath = path.resolve(CANVAS_HOME, name, constants.SPEC_FILENAME)
+				if (!fs.existsSync(specPath)) {
+					return res.status(StatusCodes.NOT_FOUND).end()
+				}
 
-			const spec = fs.readFileSync(specPath, "utf-8")
-			let hash
-			try {
-				hash = await Hash.of(spec)
-			} catch (err) {
-				console.log(spec)
-				const message = err instanceof Error ? err.message : (err as any).toString()
-				res.status(StatusCodes.INTERNAL_SERVER_ERROR).end(message)
-			}
+				const spec = fs.readFileSync(specPath, "utf-8")
+				let hash
+				try {
+					hash = await Hash.of(spec)
+				} catch (err) {
+					console.log(spec)
+					const message = err instanceof Error ? err.message : (err as any).toString()
+					res.status(StatusCodes.INTERNAL_SERVER_ERROR).end(message)
+				}
 
-			const uri = `ipfs://${hash}`
+				const uri = `ipfs://${hash}`
 
-			try {
-				const core = await Core.initialize({ directory, uri, spec, libp2p, providers, blockResolver })
-				this.cores.set(name, core)
-				console.log(`[canvas-cli] Started ${core.uri}`)
-				res.status(StatusCodes.OK).end()
-			} catch (err) {
-				const message = err instanceof Error ? err.message : (err as any).toString()
-				res.status(StatusCodes.INTERNAL_SERVER_ERROR).end(message)
-			}
-			// })
+				try {
+					const core = await Core.initialize({ directory, uri, spec, libp2p, providers, blockResolver })
+					this.cores.set(name, core)
+					console.log(`[canvas-cli] Started ${core.uri}`)
+					res.status(StatusCodes.OK).end()
+				} catch (err) {
+					const message = err instanceof Error ? err.message : (err as any).toString()
+					res.status(StatusCodes.INTERNAL_SERVER_ERROR).end(message)
+				}
+			})
 		})
 
 		this.api.post("/app/:name/stop", (req, res) => {

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -146,7 +146,17 @@ class Daemon {
 					if (fs.existsSync(specPath)) {
 						const spec = fs.readFileSync(specPath, "utf-8")
 						const cid = await Hash.of(spec)
-						apps[name] = { uri: `ipfs://${cid}`, cid, status }
+
+						const core = this.cores.get(name)
+
+						apps[name] = {
+							uri: `ipfs://${cid}`,
+							// @ts-ignore
+							models: core && core.vm.models,
+							actionParameters: core && core.vm.actionParameters,
+							cid,
+							status,
+						}
 					}
 				}
 
@@ -210,35 +220,43 @@ class Daemon {
 		this.api.post("/app/:name/start", async (req, res) => {
 			const { name } = req.params
 
-			this.queue.add(async () => {
-				if (this.cores.has(name)) {
-					return res.status(StatusCodes.CONFLICT).end()
-				}
+			// this.queue.add(async () => {
+			if (this.cores.has(name)) {
+				return res.status(StatusCodes.CONFLICT).end()
+			}
 
-				const directory = path.resolve(CANVAS_HOME, name)
-				if (!fs.existsSync(directory)) {
-					return res.status(StatusCodes.NOT_FOUND).end()
-				}
+			const directory = path.resolve(CANVAS_HOME, name)
+			if (!fs.existsSync(directory)) {
+				return res.status(StatusCodes.NOT_FOUND).end()
+			}
 
-				const specPath = path.resolve(CANVAS_HOME, name, constants.SPEC_FILENAME)
-				if (!fs.existsSync(specPath)) {
-					return res.status(StatusCodes.NOT_FOUND).end()
-				}
+			const specPath = path.resolve(CANVAS_HOME, name, constants.SPEC_FILENAME)
+			if (!fs.existsSync(specPath)) {
+				return res.status(StatusCodes.NOT_FOUND).end()
+			}
 
-				const spec = fs.readFileSync(specPath, "utf-8")
-				const hash = await Hash.of(spec)
-				const uri = `ipfs://${hash}`
+			const spec = fs.readFileSync(specPath, "utf-8")
+			let hash
+			try {
+				hash = await Hash.of(spec)
+			} catch (err) {
+				console.log(spec)
+				const message = err instanceof Error ? err.message : (err as any).toString()
+				res.status(StatusCodes.INTERNAL_SERVER_ERROR).end(message)
+			}
 
-				try {
-					const core = await Core.initialize({ directory, uri, spec, libp2p, providers, blockResolver })
-					this.cores.set(name, core)
-					console.log(`[canvas-cli] Started ${core.uri}`)
-					res.status(StatusCodes.OK).end()
-				} catch (err) {
-					const message = err instanceof Error ? err.message : (err as any).toString()
-					res.status(StatusCodes.INTERNAL_SERVER_ERROR).end(message)
-				}
-			})
+			const uri = `ipfs://${hash}`
+
+			try {
+				const core = await Core.initialize({ directory, uri, spec, libp2p, providers, blockResolver })
+				this.cores.set(name, core)
+				console.log(`[canvas-cli] Started ${core.uri}`)
+				res.status(StatusCodes.OK).end()
+			} catch (err) {
+				const message = err instanceof Error ? err.message : (err as any).toString()
+				res.status(StatusCodes.INTERNAL_SERVER_ERROR).end(message)
+			}
+			// })
 		})
 
 		this.api.post("/app/:name/stop", (req, res) => {
@@ -286,6 +304,28 @@ class Daemon {
 				}
 
 				await handleSession(core, req, res)
+			})
+		})
+
+		this.api.get("/app/:name/models/:modelName", (req, res) => {
+			const { modelName, name } = req.params
+
+			this.queue.add(async () => {
+				const core = this.cores.get(name)
+				if (core === undefined) {
+					return res.status(StatusCodes.NOT_FOUND).end()
+				}
+				const model = core.vm.models[modelName]
+				if (model === undefined) {
+					return res.status(StatusCodes.NOT_FOUND).end()
+				}
+
+				const query = `SELECT * FROM ${modelName} ORDER BY updated_at DESC LIMIT 10`
+				// @ts-ignore
+				const rows = core.modelStore.database.prepare(query).all()
+				console.log(rows)
+
+				return res.status(StatusCodes.OK).json(rows)
 			})
 		})
 

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -281,6 +281,24 @@ class Daemon {
 			})
 		})
 
+		this.api.get("/app/:name/actions", (req, res) => {
+			const { name } = req.params
+
+			this.queue.add(async () => {
+				const core = this.cores.get(name)
+				if (core === undefined) {
+					return res.status(StatusCodes.NOT_FOUND).end()
+				}
+
+				const actions = []
+				for await (const entry of core.messageStore.getActionStream()) {
+					actions.push(entry)
+				}
+
+				return res.status(StatusCodes.OK).json(actions)
+			})
+		})
+
 		this.api.post("/app/:name/actions", (req, res) => {
 			const { name } = req.params
 
@@ -323,7 +341,6 @@ class Daemon {
 				const query = `SELECT * FROM ${modelName} ORDER BY updated_at DESC LIMIT 10`
 				// @ts-ignore
 				const rows = core.modelStore.database.prepare(query).all()
-				console.log(rows)
 
 				return res.status(StatusCodes.OK).json(rows)
 			})

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -195,9 +195,9 @@ class Daemon {
 		})
 
 		this.api.post("/app/install", async (req, res) => {
-			// @ts-ignore
-			const { spec } = req.params
-			const multihash = Hash.of(spec)
+			const { spec } = req.body
+
+			const multihash = await Hash.of(spec)
 			console.log(`installing app with hash ${multihash}`)
 
 			await installSpec(spec)

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -21,8 +21,7 @@ export const builder = (yargs: yargs.Argv) =>
 
 type Args = ReturnType<typeof builder> extends yargs.Argv<infer T> ? T : never
 
-export async function handler(args: Args) {
-	const spec = fs.readFileSync(args.spec, "utf-8")
+export async function installSpec(spec: string): Promise<string> {
 	const cid = await Hash.of(spec)
 	const directory = path.resolve(CANVAS_HOME, cid)
 	if (!fs.existsSync(directory)) {
@@ -37,6 +36,13 @@ export async function handler(args: Args) {
 		console.log(`[canvas-cli] Creating ${specPath}`)
 		fs.writeFileSync(specPath, spec, "utf-8")
 	}
+	return cid
+}
+
+export async function handler(args: Args) {
+	const spec = fs.readFileSync(args.spec, "utf-8")
+
+	const cid = await installSpec(spec)
 
 	console.log(chalk.yellow(`[canvas-cli] Run the app with ${chalk.bold(`canvas run ${cid}`)}`))
 }


### PR DESCRIPTION
We want `canvas-hub` to access the core through the daemon, so this will need some more endpoints to reach feature parity.

- [x] `install` - this is equivalent to running `canvas install ...`
~- [ ] `uninstall` - remove an app. this might depend on how we want to scope apps to users, i.e. if user A creates an app in the hub then deletes/stops it, if user B creates an app with the same hash do we want it to use the data from A? i doubt it... alternatively we could check for existing apps in the `.canvas` directory when an app is being installed/created?~ the `delete` endpoint already exists
- [x] `models` - directly query the models tables for the "data" tab
- [x] `actions` - directly query the past actions table for the "send" tab
- [x] `sessions` - directly query the sessions table for the "send" tab
- [x] make sure submitting actions and creating sessions works