### PR TITLE
pass through core options from daemon

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -118,6 +118,8 @@ export class Core extends EventEmitter<CoreEvents> {
 	) {
 		super()
 
+		this.options = options
+
 		const modelDatabasePath = directory && path.resolve(directory, constants.MODEL_DATABASE_FILENAME)
 		this.modelStore = new ModelStore(modelDatabasePath, vm.models, vm.routes, { verbose: options.verbose })
 
@@ -239,6 +241,7 @@ export class Core extends EventEmitter<CoreEvents> {
 		assert(timestamp > constants.BOUNDS_CHECK_LOWER_LIMIT, "action timestamp too far in the past")
 		assert(timestamp < constants.BOUNDS_CHECK_UPPER_LIMIT, "action timestamp too far in the future")
 
+		console.log(this.options)
 		if (!this.options.unchecked) {
 			// check the action was signed with a valid, recent block
 			assert(block !== undefined, "action is missing block data")


### PR DESCRIPTION
This change is required for https://github.com/canvasxyz/canvas-hub/pull/41 because in the canvas-hub API tests we need to be able to run the daemon in unchecked and offline mode.
