### PR TITLE
only call useEffect in useRoute in useRoute once when applicationData is initialised

### DIFF
--- a/packages/hooks/src/useRoute.ts
+++ b/packages/hooks/src/useRoute.ts
@@ -110,7 +110,7 @@ export function useRoute<T extends Record<string, ModelValue> = Record<string, M
 					setIsLoading(false)
 				})
 		}
-	}, [route, url, applicationData, subscribe])
+	}, [route, url, !!applicationData, subscribe])
 
 	return { error, data, isLoading }
 }


### PR DESCRIPTION
This PR fixes the bug in https://linear.app/canvasxyz/issue/CAN-23/useroute-is-making-repeat-http-requests where the route endpoint is being requested once for every message. We are using `useEffect` to create the request, which is called every time one of the arguments (`route, url, applicationData, subscribe`) change. The `applicationData` object changes every time the `app` endpoint is called but this does not mean we need to make a new request.
