### PR TITLE
Bob/add chain chain id to session payload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [ "*" ]
+    branches: ["*"]
   workflow_dispatch:
 
 jobs:

--- a/packages/core/src/codecs.ts
+++ b/packages/core/src/codecs.ts
@@ -67,6 +67,8 @@ export const sessionPayloadType: t.Type<SessionPayload> = t.intersection([
 		timestamp: t.number,
 		address: t.string,
 		duration: t.number,
+		chain: chainType,
+		chainId: chainIdType,
 	}),
 	t.partial({ block: blockType }),
 ])

--- a/packages/core/src/codecs.ts
+++ b/packages/core/src/codecs.ts
@@ -19,7 +19,6 @@ import type {
 	SessionPayload,
 	Chain,
 	ChainId,
-	Block,
 } from "@canvas-js/interfaces"
 
 export const chainType: t.Type<Chain> = t.union([
@@ -31,28 +30,20 @@ export const chainType: t.Type<Chain> = t.union([
 
 export const chainIdType: t.Type<ChainId> = t.union([t.number, t.string])
 
-export const blockType: t.Type<Block> = t.type({
-	chain: chainType,
-	chainId: chainIdType,
-	blocknum: t.number,
-	blockhash: t.string,
-	timestamp: t.number,
-})
-
 export const actionArgumentType: t.Type<ActionArgument> = t.union([t.null, t.boolean, t.number, t.string])
 
 export const actionArgumentArrayType = t.array(actionArgumentType)
 
-export const actionPayloadType: t.Type<ActionPayload> = t.intersection([
-	t.type({
-		from: t.string,
-		spec: t.string,
-		timestamp: t.number,
-		call: t.string,
-		args: t.array(actionArgumentType),
-	}),
-	t.partial({ block: blockType }),
-])
+export const actionPayloadType: t.Type<ActionPayload> = t.type({
+	from: t.string,
+	spec: t.string,
+	timestamp: t.number,
+	call: t.string,
+	args: t.array(actionArgumentType),
+	chain: chainType,
+	chainId: chainIdType,
+	blockhash: t.union([t.string, t.null]),
+})
 
 export const actionType: t.Type<Action> = t.type({
 	payload: actionPayloadType,
@@ -60,18 +51,16 @@ export const actionType: t.Type<Action> = t.type({
 	signature: t.string,
 })
 
-export const sessionPayloadType: t.Type<SessionPayload> = t.intersection([
-	t.type({
-		from: t.string,
-		spec: t.string,
-		timestamp: t.number,
-		address: t.string,
-		duration: t.number,
-		chain: chainType,
-		chainId: chainIdType,
-	}),
-	t.partial({ block: blockType }),
-])
+export const sessionPayloadType: t.Type<SessionPayload> = t.type({
+	from: t.string,
+	spec: t.string,
+	timestamp: t.number,
+	address: t.string,
+	duration: t.number,
+	chain: chainType,
+	chainId: chainIdType,
+	blockhash: t.union([t.string, t.null]),
+})
 
 export const sessionType: t.Type<Session> = t.type({
 	payload: sessionPayloadType,

--- a/packages/core/src/encoding.ts
+++ b/packages/core/src/encoding.ts
@@ -45,6 +45,8 @@ const binarySessionPayloadType = t.type({
 	timestamp: t.number,
 	address: uint8ArrayType,
 	duration: t.number,
+	chain: chainType,
+	chainId: chainIdType,
 	block: t.union([t.null, binaryBlockType]),
 })
 

--- a/packages/core/src/encoding.ts
+++ b/packages/core/src/encoding.ts
@@ -4,22 +4,12 @@ import { ethers } from "ethers"
 import * as t from "io-ts"
 import * as cbor from "microcbor"
 
-import type { Block, Session, Action, Message } from "@canvas-js/interfaces"
+import type { Session, Action, Message } from "@canvas-js/interfaces"
 
 import { actionArgumentArrayType, chainIdType, chainType, uint8ArrayType } from "./codecs.js"
 import { signalInvalidType } from "./utils.js"
 
 const { hexlify, arrayify } = ethers.utils
-
-const binaryBlockType = t.type({
-	chain: chainType,
-	chainId: chainIdType,
-	blocknum: t.number,
-	blockhash: uint8ArrayType,
-	timestamp: t.number,
-})
-
-type BinaryBlock = t.TypeOf<typeof binaryBlockType>
 
 const binaryActionPayloadType = t.type({
 	call: t.string,
@@ -27,7 +17,9 @@ const binaryActionPayloadType = t.type({
 	from: uint8ArrayType,
 	spec: t.string,
 	timestamp: t.number,
-	block: t.union([t.null, binaryBlockType]),
+	chain: chainType,
+	chainId: chainIdType,
+	blockhash: t.union([t.null, uint8ArrayType]),
 })
 
 export const binaryActionType = t.type({
@@ -47,7 +39,7 @@ const binarySessionPayloadType = t.type({
 	duration: t.number,
 	chain: chainType,
 	chainId: chainIdType,
-	block: t.union([t.null, binaryBlockType]),
+	blockhash: t.union([t.null, uint8ArrayType]),
 })
 
 export const binarySessionType = t.type({
@@ -62,61 +54,57 @@ export const binaryMessageType = t.union([binaryActionType, binarySessionType])
 
 export type BinaryMessage = t.TypeOf<typeof binaryMessageType>
 
-const toBinaryBlock = ({ blockhash, ...block }: Block): BinaryBlock => ({ ...block, blockhash: arrayify(blockhash) })
+const toBinarySession = (session: Session): BinarySession => {
+	const { blockhash } = session.payload
+	return {
+		type: "session",
+		signature: arrayify(session.signature),
+		payload: {
+			...session.payload,
+			from: arrayify(session.payload.from),
+			address: arrayify(session.payload.address),
+			blockhash: blockhash ? arrayify(blockhash) : null,
+		},
+	}
+}
 
-const fromBinaryBlock = ({ blockhash, ...binaryBlock }: BinaryBlock): Block => ({
-	...binaryBlock,
-	blockhash: hexlify(blockhash).toLowerCase(),
-})
-
-const toBinarySession = (session: Session): BinarySession => ({
-	type: "session",
-	signature: arrayify(session.signature),
-	payload: {
-		...session.payload,
-		from: arrayify(session.payload.from),
-		address: arrayify(session.payload.address),
-		block: session.payload.block ? toBinaryBlock(session.payload.block) : null,
-	},
-})
-
-function fromBinarySession({ signature, payload: { from, address, block, ...payload } }: BinarySession): Session {
+function fromBinarySession({ signature, payload: { from, address, blockhash, ...payload } }: BinarySession): Session {
 	const session: Session = {
 		signature: hexlify(signature).toLowerCase(),
 		payload: {
 			...payload,
 			from: hexlify(from).toLowerCase(),
 			address: hexlify(address).toLowerCase(),
+			blockhash: blockhash ? hexlify(blockhash).toLowerCase() : null,
 		},
-	}
-
-	if (block !== null) {
-		session.payload.block = fromBinaryBlock(block)
 	}
 
 	return session
 }
 
-const toBinaryAction = (action: Action): BinaryAction => ({
-	type: "action",
-	signature: arrayify(action.signature),
-	session: action.session ? arrayify(action.session) : null,
-	payload: {
-		...action.payload,
-		from: arrayify(action.payload.from),
-		block: action.payload.block ? toBinaryBlock(action.payload.block) : null,
-	},
-})
+const toBinaryAction = (action: Action): BinaryAction => {
+	const blockhash = action.payload.blockhash
+	return {
+		type: "action",
+		signature: arrayify(action.signature),
+		session: action.session ? arrayify(action.session) : null,
+		payload: {
+			...action.payload,
+			from: arrayify(action.payload.from),
+			blockhash: blockhash ? arrayify(blockhash) : null,
+		},
+	}
+}
 
-function fromBinaryAction({ signature, session, payload: { from, block, ...payload } }: BinaryAction): Action {
+function fromBinaryAction({ signature, session, payload: { from, blockhash, ...payload } }: BinaryAction): Action {
 	const action: Action = {
 		signature: hexlify(signature).toLowerCase(),
 		session: session && hexlify(session).toLowerCase(),
-		payload: { ...payload, from: hexlify(from).toLowerCase() },
-	}
-
-	if (block !== null) {
-		action.payload.block = fromBinaryBlock(block)
+		payload: {
+			...payload,
+			from: hexlify(from).toLowerCase(),
+			blockhash: blockhash ? hexlify(blockhash).toLowerCase() : null,
+		},
 	}
 
 	return action

--- a/packages/core/src/messageStore.ts
+++ b/packages/core/src/messageStore.ts
@@ -195,7 +195,7 @@ export class MessageStore {
     session_address BLOB    REFERENCES sessions(session_address),
     from_address    BLOB    NOT NULL,
     timestamp       INTEGER NOT NULL,
-    blockhash       BLOB    NOT NULL,
+    blockhash       BLOB            ,
 		chain           TEXT    NOT NULL,
     chain_id        INTEGER NOT NULL,
     call            TEXT    NOT NULL,
@@ -210,7 +210,7 @@ export class MessageStore {
     session_address BLOB    NOT NULL UNIQUE,
     duration        INTEGER NOT NULL,
     timestamp       INTEGER NOT NULL,
-    blockhash       BLOB    NOT NULL,
+    blockhash       BLOB            ,
 		chain           TEXT    NOT NULL,
     chain_id        INTEGER NOT NULL
   );`

--- a/packages/core/src/messageStore.ts
+++ b/packages/core/src/messageStore.ts
@@ -3,7 +3,7 @@ import assert from "node:assert"
 import Database, * as sqlite from "better-sqlite3"
 import * as cbor from "microcbor"
 
-import type { Action, Session, Block, ActionArgument } from "@canvas-js/interfaces"
+import type { Action, Session, Block, ActionArgument, Chain, ChainId } from "@canvas-js/interfaces"
 
 import { mapEntries, fromHex, toHex } from "./utils.js"
 import { chainType } from "./codecs.js"
@@ -35,6 +35,8 @@ type SessionRecord = {
 	duration: number
 	timestamp: number
 	block_id: number | null
+	chain: Chain
+	chain_id: ChainId
 }
 
 /**
@@ -109,6 +111,8 @@ export class MessageStore {
 			duration: session.payload.duration,
 			timestamp: session.payload.timestamp,
 			block_id: null,
+			chain: session.payload.chain,
+			chain_id: session.payload.chainId,
 		}
 
 		if (session.payload.block !== undefined) {
@@ -175,6 +179,8 @@ export class MessageStore {
 				timestamp: record.timestamp,
 				address: toHex(record.session_address),
 				duration: record.duration,
+				chain: record.chain,
+				chainId: record.chain_id,
 			},
 		}
 

--- a/packages/core/src/messageStore.ts
+++ b/packages/core/src/messageStore.ts
@@ -3,18 +3,9 @@ import assert from "node:assert"
 import Database, * as sqlite from "better-sqlite3"
 import * as cbor from "microcbor"
 
-import type { Action, Session, Block, ActionArgument, Chain, ChainId } from "@canvas-js/interfaces"
+import type { Action, Session, ActionArgument, Chain, ChainId } from "@canvas-js/interfaces"
 
 import { mapEntries, fromHex, toHex } from "./utils.js"
-import { chainType } from "./codecs.js"
-
-type BlockRecord = {
-	chain: string
-	chain_id: number
-	blocknum: number
-	blockhash: Buffer
-	timestamp: number
-}
 
 type ActionRecord = {
 	hash: Buffer
@@ -22,9 +13,11 @@ type ActionRecord = {
 	from_address: Buffer
 	session_address: Buffer | null
 	timestamp: number
-	block_id: number | null
+	blockhash: string | null
 	call: string
 	args: Buffer
+	chain: Chain
+	chain_id: ChainId
 }
 
 type SessionRecord = {
@@ -34,7 +27,7 @@ type SessionRecord = {
 	session_address: Buffer
 	duration: number
 	timestamp: number
-	block_id: number | null
+	blockhash: string | null
 	chain: Chain
 	chain_id: ChainId
 }
@@ -62,7 +55,6 @@ export class MessageStore {
 			this.database = new Database(path)
 		}
 
-		this.database.exec(MessageStore.createBlocksTable)
 		this.database.exec(MessageStore.createSessionsTable)
 		this.database.exec(MessageStore.createActionsTable)
 
@@ -86,11 +78,9 @@ export class MessageStore {
 			timestamp: action.payload.timestamp,
 			call: action.payload.call,
 			args: Buffer.from(args.buffer, args.byteOffset, args.byteLength),
-			block_id: null,
-		}
-
-		if (action.payload.block !== undefined) {
-			record.block_id = this.getBlockId(action.payload.block)
+			blockhash: action.payload.blockhash,
+			chain: action.payload.chain,
+			chain_id: action.payload.chainId,
 		}
 
 		if (action.session !== null) {
@@ -110,15 +100,12 @@ export class MessageStore {
 			session_address: fromHex(session.payload.address),
 			duration: session.payload.duration,
 			timestamp: session.payload.timestamp,
-			block_id: null,
+			blockhash: session.payload.blockhash,
 			chain: session.payload.chain,
 			chain_id: session.payload.chainId,
 		}
 
-		if (session.payload.block !== undefined) {
-			record.block_id = this.getBlockId(session.payload.block)
-		}
-
+		console.log(record)
 		this.statements.insertSession.run(record)
 	}
 
@@ -140,11 +127,10 @@ export class MessageStore {
 				call: record.call,
 				args: cbor.decode(record.args) as ActionArgument[],
 				timestamp: record.timestamp,
+				chain: record.chain,
+				chainId: record.chain_id,
+				blockhash: record.blockhash,
 			},
-		}
-
-		if (record.block_id !== null) {
-			action.payload.block = this.getBlock(record.block_id)
 		}
 
 		return action
@@ -181,11 +167,8 @@ export class MessageStore {
 				duration: record.duration,
 				chain: record.chain,
 				chainId: record.chain_id,
+				blockhash: record.blockhash,
 			},
-		}
-
-		if (record.block_id !== null) {
-			session.payload.block = this.getBlock(record.block_id)
 		}
 
 		return session
@@ -205,57 +188,6 @@ export class MessageStore {
 		}
 	}
 
-	private getBlockId(block: Block): number {
-		const record: undefined | { id: number; blockhash: Buffer; timestamp: number } = this.statements.getBlockId.get({
-			chain: block.chain,
-			chain_id: block.chainId,
-			blocknum: block.blocknum,
-		})
-
-		if (record === undefined) {
-			const { lastInsertRowid } = this.statements.insertBlock.run({
-				chain: block.chain,
-				chain_id: block.chainId,
-				blockhash: fromHex(block.blockhash),
-				blocknum: block.blocknum,
-				timestamp: block.timestamp,
-			})
-
-			return Number(lastInsertRowid)
-		} else {
-			assert(block.blockhash === toHex(record.blockhash), "MessageStore.getBlockId: blockhashes did not match")
-			assert(block.timestamp === record.timestamp, "MessageStore.getBlockId: timestamps did not match")
-			return record.id
-		}
-	}
-
-	private getBlock(blockId: number): Block {
-		const record: undefined | BlockRecord = this.statements.getBlock.get({ id: blockId })
-		if (record === undefined) {
-			throw new Error("internal error: failed to look up block id")
-		}
-
-		assert(chainType.is(record.chain), `invalid chain type ${JSON.stringify(record.chain)}`)
-
-		return {
-			chain: record.chain,
-			chainId: record.chain_id,
-			blocknum: record.blocknum,
-			blockhash: toHex(record.blockhash),
-			timestamp: record.timestamp,
-		}
-	}
-
-	private static createBlocksTable = `CREATE TABLE IF NOT EXISTS blocks (
-    id        INTEGER PRIMARY KEY AUTOINCREMENT,
-    chain     TEXT    NOT NULL,
-    chain_id  INTEGER NOT NULL,
-    blocknum  INTEGER NOT NULL,
-    blockhash BLOB    NOT NULL,
-    timestamp INTEGER NOT NULL,
-    UNIQUE(chain, chain_id, blocknum)
-  );`
-
 	private static createActionsTable = `CREATE TABLE IF NOT EXISTS actions (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     hash            BLOB    NOT NULL UNIQUE,
@@ -263,7 +195,9 @@ export class MessageStore {
     session_address BLOB    REFERENCES sessions(session_address),
     from_address    BLOB    NOT NULL,
     timestamp       INTEGER NOT NULL,
-    block_id        INTEGER REFERENCES blocks(id),
+    blockhash       BLOB    NOT NULL,
+		chain           TEXT    NOT NULL,
+    chain_id        INTEGER NOT NULL,
     call            TEXT    NOT NULL,
     args            BLOB    NOT NULL
   );`
@@ -276,27 +210,22 @@ export class MessageStore {
     session_address BLOB    NOT NULL UNIQUE,
     duration        INTEGER NOT NULL,
     timestamp       INTEGER NOT NULL,
-    block_id        INTEGER REFERENCES blocks(id)
+    blockhash       BLOB    NOT NULL,
+		chain           TEXT    NOT NULL,
+    chain_id        INTEGER NOT NULL
   );`
 
 	private static statements = {
-		insertBlock: `INSERT INTO BLOCKS (
-      chain, chain_id, blocknum, blockhash, timestamp
-    ) VALUES (
-      :chain, :chain_id, :blocknum, :blockhash, :timestamp
-    )`,
 		insertAction: `INSERT INTO actions (
-      hash, signature, session_address, from_address, timestamp, block_id, call, args
+      hash, signature, session_address, from_address, timestamp, blockhash, call, args, chain, chain_id
     ) VALUES (
-      :hash, :signature, :session_address, :from_address, :timestamp, :block_id, :call, :args
+      :hash, :signature, :session_address, :from_address, :timestamp, :blockhash, :call, :args, :chain, :chain_id
     )`,
 		insertSession: `INSERT INTO sessions (
-      hash, signature, from_address, session_address, duration, timestamp, block_id
+      hash, signature, from_address, session_address, duration, timestamp, blockhash, chain, chain_id
     ) VALUES (
-      :hash, :signature, :from_address, :session_address, :duration, :timestamp, :block_id
+      :hash, :signature, :from_address, :session_address, :duration, :timestamp, :blockhash, :chain, :chain_id
     )`,
-		getBlock: `SELECT * FROM blocks WHERE id = :id`,
-		getBlockId: `SELECT id, blockhash, timestamp FROM blocks WHERE chain = :chain AND chain_id = :chain_id AND blocknum = :blocknum`,
 		getActionByHash: `SELECT * FROM actions WHERE hash = :hash`,
 		getSessionByHash: `SELECT * FROM sessions WHERE hash = :hash`,
 		getSessionByAddress: `SELECT * FROM sessions WHERE session_address = :session_address`,

--- a/packages/core/src/messageStore.ts
+++ b/packages/core/src/messageStore.ts
@@ -13,7 +13,7 @@ type ActionRecord = {
 	from_address: Buffer
 	session_address: Buffer | null
 	timestamp: number
-	blockhash: string | null
+	blockhash: Buffer | null
 	call: string
 	args: Buffer
 	chain: Chain
@@ -27,7 +27,7 @@ type SessionRecord = {
 	session_address: Buffer
 	duration: number
 	timestamp: number
-	blockhash: string | null
+	blockhash: Buffer | null
 	chain: Chain
 	chain_id: ChainId
 }
@@ -78,7 +78,7 @@ export class MessageStore {
 			timestamp: action.payload.timestamp,
 			call: action.payload.call,
 			args: Buffer.from(args.buffer, args.byteOffset, args.byteLength),
-			blockhash: action.payload.blockhash,
+			blockhash: action.payload.blockhash ? fromHex(action.payload.blockhash) : null,
 			chain: action.payload.chain,
 			chain_id: action.payload.chainId,
 		}
@@ -100,7 +100,7 @@ export class MessageStore {
 			session_address: fromHex(session.payload.address),
 			duration: session.payload.duration,
 			timestamp: session.payload.timestamp,
-			blockhash: session.payload.blockhash,
+			blockhash: session.payload.blockhash ? fromHex(session.payload.blockhash) : null,
 			chain: session.payload.chain,
 			chain_id: session.payload.chainId,
 		}
@@ -129,7 +129,7 @@ export class MessageStore {
 				timestamp: record.timestamp,
 				chain: record.chain,
 				chainId: record.chain_id,
-				blockhash: record.blockhash,
+				blockhash: record.blockhash ? toHex(record.blockhash) : null,
 			},
 		}
 
@@ -167,7 +167,7 @@ export class MessageStore {
 				duration: record.duration,
 				chain: record.chain,
 				chainId: record.chain_id,
-				blockhash: record.blockhash,
+				blockhash: record.blockhash ? toHex(record.blockhash) : null,
 			},
 		}
 

--- a/packages/core/src/vm/vm.ts
+++ b/packages/core/src/vm/vm.ts
@@ -243,12 +243,12 @@ export class VM {
 					mapEntries(contract.functions, (key, fn) =>
 						context.newFunction(`${name}.${key}`, (...argHandles: QuickJSHandle[]) => {
 							assert(this.actionContext !== null, "internal error: this.actionContext is null")
-							const { block } = this.actionContext
-							assert(block !== undefined, "action called a contract function but did not include a blockhash")
+							const { blockhash } = this.actionContext
+							assert(blockhash !== undefined, "action called a contract function but did not include a blockhash")
 							const args = argHandles.map(context.dump)
 							if (options.verbose) {
 								const call = chalk.green(`${name}.${key}(${args.map((arg) => JSON.stringify(arg)).join(", ")})`)
-								console.log(`[canvas-vm] contract: ${call} at block ${block.blocknum} (${block.blockhash})`)
+								console.log(`[canvas-vm] contract: ${call} at block (${blockhash})`)
 							}
 
 							const deferred = context.newPromise()
@@ -327,14 +327,14 @@ export class VM {
 		const argHandles = args.map(this.wrapActionArgument)
 
 		// everything that goes into the VM must be deterministic, and deterministic means normalized!
-		const blockhash = context.block ? context.block.blockhash.toLowerCase() : null
+		const blockhash = context.blockhash ? context.blockhash.toLowerCase() : null
 		const thisArg = wrapJSON(
 			this.context,
 			blockhash
 				? {
 						hash: hash.toLowerCase(),
 						from: context.from.toLowerCase(),
-						block: { ...context.block, blockhash },
+						blockhash,
 				  }
 				: { hash: hash.toLowerCase(), from: context.from.toLowerCase() }
 		)

--- a/packages/core/test/contracts.test.ts
+++ b/packages/core/test/contracts.test.ts
@@ -49,7 +49,16 @@ test("Test calling the public ENS resolver contract", async (t) => {
 	async function sign(call: string, args: ActionArgument[]): Promise<Action> {
 		const timestamp = Date.now()
 		const block = await getCurrentBlock(provider)
-		const actionPayload: ActionPayload = { from: signerAddress, spec: uri, call, args, timestamp, block }
+		const actionPayload: ActionPayload = {
+			from: signerAddress,
+			spec: uri,
+			call,
+			args,
+			timestamp,
+			chain: "eth",
+			chainId: 1,
+			blockhash: block.blockhash,
+		}
 		const actionSignatureData = getActionSignatureData(actionPayload)
 		const actionSignature = await signer._signTypedData(...actionSignatureData)
 

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -3,7 +3,13 @@ import test from "ava"
 import { ethers } from "ethers"
 
 import { Core, ApplicationError, compileSpec } from "@canvas-js/core"
-import { ActionArgument, getActionSignatureData, getSessionSignatureData, SessionPayload } from "@canvas-js/interfaces"
+import {
+	ActionArgument,
+	ActionPayload,
+	getActionSignatureData,
+	getSessionSignatureData,
+	SessionPayload,
+} from "@canvas-js/interfaces"
 
 const signer = ethers.Wallet.createRandom()
 const signerAddress = signer.address.toLowerCase()
@@ -39,7 +45,16 @@ const { spec, uri } = await compileSpec({
 
 async function sign(call: string, args: ActionArgument[]) {
 	const timestamp = Date.now()
-	const actionPayload = { from: signerAddress, spec: uri, call, args, timestamp }
+	const actionPayload = {
+		from: signerAddress,
+		spec: uri,
+		call,
+		args,
+		timestamp,
+		blockhash: null,
+		chain: "eth",
+		chainId: 1,
+	} as ActionPayload
 	const actionSignatureData = getActionSignatureData(actionPayload)
 	const actionSignature = await signer._signTypedData(...actionSignatureData)
 	return { payload: actionPayload, session: null, signature: actionSignature }
@@ -93,7 +108,16 @@ const sessionSignerAddress = await sessionSigner.getAddress()
 
 async function signWithSession(call: string, args: ActionArgument[]) {
 	const timestamp = Date.now()
-	const actionPayload = { from: signerAddress, spec: uri, call, args, timestamp }
+	const actionPayload = {
+		from: signerAddress,
+		spec: uri,
+		call,
+		args,
+		timestamp,
+		blockhash: null,
+		chain: "eth",
+		chainId: 1,
+	} as ActionPayload
 	const actionSignatureData = getActionSignatureData(actionPayload)
 	const actionSignature = await sessionSigner._signTypedData(...actionSignatureData)
 	return { payload: actionPayload, session: sessionSignerAddress, signature: actionSignature }
@@ -110,6 +134,7 @@ test("Apply action signed with session key", async (t) => {
 		duration: 60 * 60 * 1000, // 1 hour
 		chain: "eth",
 		chainId: 1,
+		blockhash: null,
 	}
 
 	const sessionSignatureData = getSessionSignatureData(sessionPayload)
@@ -144,6 +169,7 @@ test("Apply two actions signed with session keys", async (t) => {
 		duration: 60 * 60 * 1000, // 1 hour
 		chain: "eth",
 		chainId: 1,
+		blockhash: null,
 	}
 
 	const sessionSignatureData = getSessionSignatureData(sessionPayload)

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -108,6 +108,8 @@ test("Apply action signed with session key", async (t) => {
 		timestamp: Date.now(),
 		address: sessionSignerAddress,
 		duration: 60 * 60 * 1000, // 1 hour
+		chain: "eth",
+		chainId: 1,
 	}
 
 	const sessionSignatureData = getSessionSignatureData(sessionPayload)
@@ -140,6 +142,8 @@ test("Apply two actions signed with session keys", async (t) => {
 		timestamp: Date.now(),
 		address: sessionSignerAddress,
 		duration: 60 * 60 * 1000, // 1 hour
+		chain: "eth",
+		chainId: 1,
 	}
 
 	const sessionSignatureData = getSessionSignatureData(sessionPayload)

--- a/packages/core/test/deletes.test.ts
+++ b/packages/core/test/deletes.test.ts
@@ -2,7 +2,7 @@ import test from "ava"
 
 import { ethers } from "ethers"
 
-import { ActionArgument, getActionSignatureData } from "@canvas-js/interfaces"
+import { ActionArgument, ActionPayload, getActionSignatureData } from "@canvas-js/interfaces"
 import { Core, compileSpec } from "@canvas-js/core"
 
 const signer = ethers.Wallet.createRandom()
@@ -27,7 +27,16 @@ test("Test setting and then deleting a record", async (t) => {
 
 	async function sign(signer: ethers.Wallet, session: string | null, call: string, args: ActionArgument[]) {
 		const timestamp = Date.now()
-		const actionPayload = { from: signerAddress, spec: uri, call, args, timestamp }
+		const actionPayload: ActionPayload = {
+			from: signerAddress,
+			spec: uri,
+			call,
+			args,
+			timestamp,
+			chain: "eth",
+			chainId: 1,
+			blockhash: null,
+		}
 		const actionSignatureData = getActionSignatureData(actionPayload)
 		const actionSignature = await signer._signTypedData(...actionSignatureData)
 		return { payload: actionPayload, session, signature: actionSignature }

--- a/packages/core/test/globals.test.ts
+++ b/packages/core/test/globals.test.ts
@@ -2,7 +2,7 @@ import test from "ava"
 
 import { ethers } from "ethers"
 
-import { ActionArgument, getActionSignatureData } from "@canvas-js/interfaces"
+import { ActionArgument, ActionPayload, getActionSignatureData } from "@canvas-js/interfaces"
 import { compileSpec, Core } from "@canvas-js/core"
 
 const signer = ethers.Wallet.createRandom()
@@ -20,7 +20,16 @@ const { spec, uri } = await compileSpec({
 
 async function sign(signer: ethers.Wallet, session: string | null, call: string, args: ActionArgument[]) {
 	const timestamp = Date.now()
-	const actionPayload = { from: signerAddress, spec: uri, call, args, timestamp }
+	const actionPayload: ActionPayload = {
+		from: signerAddress,
+		spec: uri,
+		call,
+		args,
+		timestamp,
+		chain: "eth",
+		chainId: 1,
+		blockhash: null,
+	}
 	const actionSignatureData = getActionSignatureData(actionPayload)
 	const actionSignature = await signer._signTypedData(...actionSignatureData)
 	return { payload: actionPayload, session, signature: actionSignature }

--- a/packages/core/test/sqlite.test.ts
+++ b/packages/core/test/sqlite.test.ts
@@ -3,7 +3,7 @@ import test from "ava"
 import { ethers } from "ethers"
 
 import { Core, compileSpec } from "@canvas-js/core"
-import { ActionArgument, getActionSignatureData } from "@canvas-js/interfaces"
+import { ActionArgument, ActionPayload, getActionSignatureData } from "@canvas-js/interfaces"
 
 const signer = ethers.Wallet.createRandom()
 const signerAddress = signer.address.toLowerCase()
@@ -43,7 +43,16 @@ const { spec, uri } = await compileSpec({
 
 async function sign(call: string, args: ActionArgument[]) {
 	const timestamp = Date.now()
-	const actionPayload = { from: signerAddress, spec: uri, call, args, timestamp }
+	const actionPayload = {
+		from: signerAddress,
+		spec: uri,
+		call,
+		args,
+		timestamp,
+		blockhash: null,
+		chain: "eth",
+		chainId: 1,
+	} as ActionPayload
 	const actionSignatureData = getActionSignatureData(actionPayload)
 	const actionSignature = await signer._signTypedData(...actionSignatureData)
 	return { payload: actionPayload, session: null, signature: actionSignature }

--- a/packages/hooks/src/useCanvas.ts
+++ b/packages/hooks/src/useCanvas.ts
@@ -57,7 +57,16 @@ export function useCanvas(): {
 				const address = await signer.getAddress()
 				console.log("from address", address)
 
-				const payload: ActionPayload = { from: address, spec: data.uri, call, args, timestamp, block }
+				const payload: ActionPayload = {
+					from: address,
+					spec: data.uri,
+					call,
+					args,
+					timestamp,
+					blockhash: block.blockhash,
+					chain: block.chain,
+					chainId: block.chainId,
+				}
 
 				const signatureData = getActionSignatureData(payload)
 				const signature = await sessionWallet._signTypedData(...signatureData)

--- a/packages/hooks/src/useSession.ts
+++ b/packages/hooks/src/useSession.ts
@@ -99,18 +99,15 @@ export function useSession(signer: ethers.providers.JsonRpcSigner | null): {
 
 			const block = await getLatestBlock(signer.provider)
 
-			const chain = "eth"
-			const chainId = await signer.getChainId()
-
 			const payload: SessionPayload = {
 				from: signerAddress,
 				spec: data.uri,
 				address: wallet.address,
 				duration: sessionDuration,
 				timestamp,
-				block,
-				chain,
-				chainId,
+				blockhash: block.blockhash,
+				chain: block.chain,
+				chainId: block.chainId,
 			}
 
 			const sessionSignatureData = getSessionSignatureData(payload)

--- a/packages/hooks/src/useSession.ts
+++ b/packages/hooks/src/useSession.ts
@@ -99,6 +99,9 @@ export function useSession(signer: ethers.providers.JsonRpcSigner | null): {
 
 			const block = await getLatestBlock(signer.provider)
 
+			const chain = "eth"
+			const chainId = await signer.getChainId()
+
 			const payload: SessionPayload = {
 				from: signerAddress,
 				spec: data.uri,
@@ -106,6 +109,8 @@ export function useSession(signer: ethers.providers.JsonRpcSigner | null): {
 				duration: sessionDuration,
 				timestamp,
 				block,
+				chain,
+				chainId,
 			}
 
 			const sessionSignatureData = getSessionSignatureData(payload)

--- a/packages/interfaces/src/actions.ts
+++ b/packages/interfaces/src/actions.ts
@@ -29,7 +29,9 @@ export type ActionContext = {
 	from: string
 	spec: string
 	timestamp: number
-	block?: Block
+	chain: Chain
+	chainId: ChainId
+	blockhash: string | null
 }
 
 export type ActionPayload = ActionContext & {

--- a/packages/interfaces/src/sessions.ts
+++ b/packages/interfaces/src/sessions.ts
@@ -1,4 +1,3 @@
-import type { Block } from "./actions.js"
 import { Chain, ChainId } from "./contracts.js"
 
 /**
@@ -14,7 +13,7 @@ export type SessionPayload = {
 	timestamp: number
 	address: string
 	duration: number
-	block?: Block
+	blockhash: string | null
 	chain: Chain
 	chainId: ChainId
 }

--- a/packages/interfaces/src/sessions.ts
+++ b/packages/interfaces/src/sessions.ts
@@ -1,4 +1,5 @@
 import type { Block } from "./actions.js"
+import { Chain, ChainId } from "./contracts.js"
 
 /**
  * A `SessionPayload` is the data signed by the user to initiate a session.
@@ -14,6 +15,8 @@ export type SessionPayload = {
 	address: string
 	duration: number
 	block?: Block
+	chain: Chain
+	chainId: ChainId
 }
 
 /**


### PR DESCRIPTION
The basic idea here is to get rid of the `blocks` table and corresponding object in the session/action requests and replace it with just the `blockhash` field. This request also adds a `chain` and `chain_id` column to the session and action table. We are currently throwing away the blocknum and block timestamp - if we want to do any validation using these then we can make a request/access the blockResolver at request time if needed. This also means we don't need any of the code that converts between the `block_id` foreign key and the block hash.

This is a breaking change - we don't have a process for migrating the existing messageStore databases. Would peering between the new version of this code and the old version work? I haven't looked at this either.

The tests pass now