### PR TITLE
pass action arguments as an object, not an array

### DIFF
--- a/examples/chat-next/components/Messages.tsx
+++ b/examples/chat-next/components/Messages.tsx
@@ -20,7 +20,7 @@ export const Messages: React.FC<{}> = ({}) => {
 			if (event.key === "Enter" && inputRef.current !== null) {
 				const input = inputRef.current
 				try {
-					const { hash } = await dispatch("createPost", input.value)
+					const { hash } = await dispatch("createPost", { content: input.value })
 					console.log("created post", hash)
 					input.value = ""
 					setTimeout(() => input.focus(), 0)

--- a/examples/chat-next/spec.canvas.js
+++ b/examples/chat-next/spec.canvas.js
@@ -13,7 +13,7 @@ export const routes = {
 }
 
 export const actions = {
-	createPost(content) {
-		this.db.posts.set(this.hash, { content, from_id: this.from })
+	createPost({ content }, { db, hash, from }) {
+		db.posts.set(hash, { content, from_id: from })
 	},
 }

--- a/examples/chat-webpack/spec.canvas.js
+++ b/examples/chat-webpack/spec.canvas.js
@@ -13,7 +13,7 @@ export const routes = {
 }
 
 export const actions = {
-	createPost(content) {
-		this.db.posts.set(this.hash, { content, from_id: this.from })
+	createPost({ content }, { db, hash, from }) {
+		db.posts.set(hash, { content, from_id: from })
 	},
 }

--- a/examples/chat-webpack/src/Messages.tsx
+++ b/examples/chat-webpack/src/Messages.tsx
@@ -21,7 +21,7 @@ export const Messages: React.FC<{}> = ({}) => {
 			if (event.key === "Enter" && inputRef.current !== null) {
 				const input = inputRef.current
 				try {
-					const { hash } = await dispatch("createPost", input.value)
+					const { hash } = await dispatch("createPost", { content: input.value })
 					console.log("created post", hash)
 					input.value = ""
 					setTimeout(() => input.focus(), 0)

--- a/examples/chat-webpack/webpack.config.js
+++ b/examples/chat-webpack/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = {
 	},
 	plugins: [
 		new CopyWebpackPlugin({ patterns: [{ from: "public" }] }),
-		new webpack.DefinePlugin({ "process.env.HOST": JSON.stringify(process.env.HOST) }),
+		new webpack.DefinePlugin({ "process.env.HOST": JSON.stringify(process.env.HOST ?? "http://localhost:8000") }),
 	],
 	devServer: {
 		static: [path.join(__dirname, "public")],

--- a/packages/core/src/codecs.ts
+++ b/packages/core/src/codecs.ts
@@ -32,14 +32,12 @@ export const chainIdType: t.Type<ChainId> = t.union([t.number, t.string])
 
 export const actionArgumentType: t.Type<ActionArgument> = t.union([t.null, t.boolean, t.number, t.string])
 
-export const actionArgumentArrayType = t.array(actionArgumentType)
-
 export const actionPayloadType: t.Type<ActionPayload> = t.type({
 	from: t.string,
 	spec: t.string,
 	timestamp: t.number,
 	call: t.string,
-	args: t.array(actionArgumentType),
+	args: t.record(t.string, actionArgumentType),
 	chain: chainType,
 	chainId: chainIdType,
 	blockhash: t.union([t.string, t.null]),

--- a/packages/core/src/encoding.ts
+++ b/packages/core/src/encoding.ts
@@ -6,14 +6,14 @@ import * as cbor from "microcbor"
 
 import type { Session, Action, Message } from "@canvas-js/interfaces"
 
-import { actionArgumentArrayType, chainIdType, chainType, uint8ArrayType } from "./codecs.js"
+import { actionArgumentType, chainIdType, chainType, uint8ArrayType } from "./codecs.js"
 import { signalInvalidType } from "./utils.js"
 
 const { hexlify, arrayify } = ethers.utils
 
 const binaryActionPayloadType = t.type({
 	call: t.string,
-	args: actionArgumentArrayType,
+	args: t.record(t.string, actionArgumentType),
 	from: uint8ArrayType,
 	spec: t.string,
 	timestamp: t.number,

--- a/packages/core/src/messageStore.ts
+++ b/packages/core/src/messageStore.ts
@@ -105,7 +105,6 @@ export class MessageStore {
 			chain_id: session.payload.chainId,
 		}
 
-		console.log(record)
 		this.statements.insertSession.run(record)
 	}
 
@@ -125,7 +124,7 @@ export class MessageStore {
 				spec: this.uri,
 				from: toHex(record.from_address),
 				call: record.call,
-				args: cbor.decode(record.args) as ActionArgument[],
+				args: cbor.decode(record.args) as Record<string, ActionArgument>,
 				timestamp: record.timestamp,
 				chain: record.chain,
 				chainId: record.chain_id,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -60,7 +60,7 @@ export type Context<Models extends Record<string, Model>> = {
 
 export async function compileSpec<Models extends Record<string, Model>>(exports: {
 	models: Models
-	actions: Record<string, (this: Context<Models>, ...args: ActionArgument[]) => void>
+	actions: Record<string, (this: undefined, args: Record<string, ActionArgument>, ctx: Context<Models>) => void>
 	routes?: Record<string, string>
 	contracts?: Record<string, { chain: Chain; chainId: ChainId; address: string; abi: string[] }>
 }): Promise<{ uri: string; spec: string }> {

--- a/packages/core/test/contracts.test.ts
+++ b/packages/core/test/contracts.test.ts
@@ -25,8 +25,8 @@ test("Test calling the public ENS resolver contract", async (t) => {
 	const { uri, spec } = await compileSpec({
 		models: {},
 		actions: {
-			async verify() {
-				const [balance] = await this.contracts.milady.balanceOf(this.from)
+			async verify({}, { contracts, from }) {
+				const [balance] = await contracts.milady.balanceOf(from)
 				if (balance === 0) {
 					throw new Error("balance is zero!")
 				}
@@ -46,7 +46,7 @@ test("Test calling the public ENS resolver contract", async (t) => {
 	const providers = { [`eth:${ETH_CHAIN_ID}`]: provider }
 	const core = await Core.initialize({ directory: null, uri, spec, providers, offline: true })
 
-	async function sign(call: string, args: ActionArgument[]): Promise<Action> {
+	async function sign(call: string, args: Record<string, ActionArgument>): Promise<Action> {
 		const timestamp = Date.now()
 		const block = await getCurrentBlock(provider)
 		const actionPayload: ActionPayload = {
@@ -65,7 +65,7 @@ test("Test calling the public ENS resolver contract", async (t) => {
 		return { payload: actionPayload, session: null, signature: actionSignature }
 	}
 
-	const action = await sign("verify", [])
+	const action = await sign("verify", {})
 	await t.throwsAsync(core.applyAction(action), { message: "balance is zero!" })
 	await core.close()
 })

--- a/packages/core/test/globals.test.ts
+++ b/packages/core/test/globals.test.ts
@@ -18,7 +18,7 @@ const { spec, uri } = await compileSpec({
 	},
 })
 
-async function sign(signer: ethers.Wallet, session: string | null, call: string, args: ActionArgument[]) {
+async function sign(signer: ethers.Wallet, session: string | null, call: string, args: Record<string, ActionArgument>) {
 	const timestamp = Date.now()
 	const actionPayload: ActionPayload = {
 		from: signerAddress,
@@ -38,7 +38,7 @@ async function sign(signer: ethers.Wallet, session: string | null, call: string,
 test("test fetch and log IP address", async (t) => {
 	const core = await Core.initialize({ uri, spec, directory: null, unchecked: true, offline: true })
 
-	const action = await sign(signer, null, "logIP", [])
+	const action = await sign(signer, null, "logIP", {})
 	await core.applyAction(action)
 	await core.close()
 

--- a/packages/core/test/sqlite.test.ts
+++ b/packages/core/test/sqlite.test.ts
@@ -20,19 +20,19 @@ const { spec, uri } = await compileSpec({
 		},
 	},
 	actions: {
-		newThread(title, link) {
+		newThread({ title, link }, { db, hash, from }) {
 			if (typeof title === "string" && typeof link === "string") {
-				this.db.threads.set(this.hash, { creator: this.from, title, link })
+				db.threads.set(hash, { creator: from, title, link })
 			}
 		},
-		voteThread(threadId, value) {
+		voteThread({ threadId, value }, { db, from }) {
 			if (typeof threadId !== "string") {
 				throw new Error("threadId must be a string")
 			} else if (value !== 1 && value !== -1) {
 				throw new Error("invalid vote value")
 			}
 
-			this.db.thread_votes.set(`${threadId}/${this.from}`, { creator: this.from, thread_id: threadId, value })
+			db.thread_votes.set(`${threadId}/${from}`, { creator: from, thread_id: threadId, value })
 		},
 	},
 	routes: {
@@ -41,9 +41,9 @@ const { spec, uri } = await compileSpec({
 	},
 })
 
-async function sign(call: string, args: ActionArgument[]) {
+async function sign(call: string, args: Record<string, ActionArgument>) {
 	const timestamp = Date.now()
-	const actionPayload = {
+	const actionPayload: ActionPayload = {
 		from: signerAddress,
 		spec: uri,
 		call,
@@ -52,7 +52,7 @@ async function sign(call: string, args: ActionArgument[]) {
 		blockhash: null,
 		chain: "eth",
 		chainId: 1,
-	} as ActionPayload
+	}
 	const actionSignatureData = getActionSignatureData(actionPayload)
 	const actionSignature = await signer._signTypedData(...actionSignatureData)
 	return { payload: actionPayload, session: null, signature: actionSignature }
@@ -61,11 +61,11 @@ async function sign(call: string, args: ActionArgument[]) {
 test("get /all", async (t) => {
 	const core = await Core.initialize({ uri, spec, directory: null, unchecked: true, offline: true })
 
-	const action = await sign("newThread", ["Hacker News", "https://news.ycombinator.com"])
-	const { hash } = await core.applyAction(action)
+	const action = await sign("newThread", { title: "Hacker News", link: "https://news.ycombinator.com" })
+	const { hash: threadId } = await core.applyAction(action)
 
 	const expected = {
-		id: hash,
+		id: threadId,
 		title: "Hacker News",
 		creator: signerAddress,
 		link: "https://news.ycombinator.com",
@@ -74,10 +74,10 @@ test("get /all", async (t) => {
 
 	t.deepEqual(await core.getRoute("/all", {}), [{ ...expected, score: null }])
 
-	await sign("voteThread", [hash, 1]).then((action) => core.applyAction(action))
+	await sign("voteThread", { threadId, value: 1 }).then((action) => core.applyAction(action))
 	t.deepEqual(await core.getRoute("/all", {}), [{ ...expected, score: 1 }])
 
-	await sign("voteThread", [hash, -1]).then((action) => core.applyAction(action))
+	await sign("voteThread", { threadId, value: -1 }).then((action) => core.applyAction(action))
 	t.deepEqual(await core.getRoute("/all", {}), [{ ...expected, score: -1 }])
 
 	await core.close()
@@ -86,14 +86,16 @@ test("get /all", async (t) => {
 test("get /votes/:thread_id", async (t) => {
 	const core = await Core.initialize({ uri, spec, directory: null, unchecked: true })
 
-	const action = await sign("newThread", ["Hacker News", "https://news.ycombinator.com"])
-	const { hash } = await core.applyAction(action)
+	const action = await sign("newThread", { title: "Hacker News", link: "https://news.ycombinator.com" })
+	const { hash: threadId } = await core.applyAction(action)
 
-	await sign("voteThread", [hash, 1]).then((action) => core.applyAction(action))
-	t.deepEqual(await core.getRoute("/votes/:thread_id", { thread_id: hash }), [{ creator: signerAddress, value: 1 }])
+	await sign("voteThread", { threadId, value: 1 }).then((action) => core.applyAction(action))
+	t.deepEqual(await core.getRoute("/votes/:thread_id", { thread_id: threadId }), [{ creator: signerAddress, value: 1 }])
 
-	await sign("voteThread", [hash, -1]).then((action) => core.applyAction(action))
-	t.deepEqual(await core.getRoute("/votes/:thread_id", { thread_id: hash }), [{ creator: signerAddress, value: -1 }])
+	await sign("voteThread", { threadId, value: -1 }).then((action) => core.applyAction(action))
+	t.deepEqual(await core.getRoute("/votes/:thread_id", { thread_id: threadId }), [
+		{ creator: signerAddress, value: -1 },
+	])
 
 	await core.close()
 })

--- a/packages/hooks/src/useCanvas.ts
+++ b/packages/hooks/src/useCanvas.ts
@@ -28,7 +28,7 @@ export function useCanvas(): {
 	const [isPending, setIsPending] = useState(false)
 
 	const dispatch: Dispatch = useCallback(
-		async (call, ...args) => {
+		async (call, args) => {
 			console.log("dispatch:", call, args)
 			if (host === null) {
 				throw new Error("no host configured")

--- a/packages/hooks/src/utils.ts
+++ b/packages/hooks/src/utils.ts
@@ -3,7 +3,7 @@ import { ActionArgument, Block } from "@canvas-js/interfaces"
 
 export const getCanvasSessionKey = (address: string) => `CANVAS_SESSION:${address}`
 
-export type Dispatch = (call: string, ...args: ActionArgument[]) => Promise<{ hash: string }>
+export type Dispatch = (call: string, args: Record<string, ActionArgument>) => Promise<{ hash: string }>
 
 export async function getLatestBlock(provider: ethers.providers.Provider): Promise<Block> {
 	const [network, providerBlock] = await Promise.all([provider.getNetwork(), provider.getBlock("latest")])

--- a/packages/interfaces/src/actions.ts
+++ b/packages/interfaces/src/actions.ts
@@ -36,7 +36,7 @@ export type ActionContext = {
 
 export type ActionPayload = ActionContext & {
 	call: string
-	args: ActionArgument[]
+	args: Record<string, ActionArgument>
 }
 
 /**


### PR DESCRIPTION
This refactors `ActionPayload.args` to be `Record<string, ActionArgument>` instead of `ActionArgument[]`. The keys of the arguments object must match `/^[a-zA-Z][a-zA-Z0-9]*$/`.

Action handlers in specs are now typed as `(args: Record<string, ActionArgument>, ctx: Context) => Promise<void>` instead of `(this: Context, ...args: ActionArgument[]) => Promise<void>`. In practice this means writing actions like this:

```
export const actions = {
  createPost({ content }, { db, hash, from }) {
    db.posts.set(hash, { text: content })
  }
}
```

The chat example and tests have been updated. Old specs will no longer run.