### PR TITLE
Add NEAR to the chain enum

### DIFF
--- a/packages/core/src/chains/index.ts
+++ b/packages/core/src/chains/index.ts
@@ -27,6 +27,8 @@ export function encodeAddress(chain: Chain, chainId: ChainId, address: string): 
 		return base58.decode(address)
 	} else if (chain === "substrate") {
 		return decodeSS58Address(address)
+	} else if (chain === "near") {
+		throw Error("The NEAR chain is not supported")
 	} else {
 		signalInvalidType(chain)
 	}
@@ -45,6 +47,8 @@ export function decodeAddress(chain: Chain, chainId: ChainId, address: Uint8Arra
 		return base58.encode(address)
 	} else if (chain === "substrate") {
 		return encodeSS58Address(address)
+	} else if (chain === "near") {
+		throw Error("The NEAR chain is not supported")
 	} else {
 		signalInvalidType(chain)
 	}
@@ -59,6 +63,8 @@ export function encodeBlockhash(chain: Chain, chainId: ChainId, blockhash: strin
 		return base58.decode(blockhash)
 	} else if (chain === "substrate") {
 		return arrayify(blockhash)
+	} else if (chain === "near") {
+		throw Error("The NEAR chain is not supported")
 	} else {
 		signalInvalidType(chain)
 	}
@@ -73,6 +79,8 @@ export function decodeBlockhash(chain: Chain, chainId: ChainId, blockhash: Uint8
 		return base58.encode(blockhash)
 	} else if (chain === "substrate") {
 		return hexlify(blockhash)
+	} else if (chain === "near") {
+		throw Error("The NEAR chain is not supported")
 	} else {
 		signalInvalidType(chain)
 	}

--- a/packages/core/src/codecs.ts
+++ b/packages/core/src/codecs.ts
@@ -24,6 +24,7 @@ import type {
 export const chainType: t.Type<Chain> = t.union([
 	t.literal("eth"),
 	t.literal("cosmos"),
+	t.literal("near"),
 	t.literal("solana"),
 	t.literal("substrate"),
 ])

--- a/packages/interfaces/src/contracts.ts
+++ b/packages/interfaces/src/contracts.ts
@@ -1,7 +1,7 @@
 /**
  * A `Chain` is a string representation of a type of chain.
  */
-export type Chain = "eth" | "cosmos" | "solana" | "substrate"
+export type Chain = "eth" | "cosmos" | "solana" | "substrate" | "near"
 
 export type ChainId = number | string
 


### PR DESCRIPTION
This is needed because Commonwealth supports the NEAR wallet, this does not require anything in the Canvas codebase to change apart from this interface type definition.

## Description
<!--- Describe your changes in detail -->

## How has this been tested?
- [x] CI tests pass
- [x] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
