### PR TITLE
Sources Stage 1

### DIFF
--- a/examples/chat-next/pages/index.tsx
+++ b/examples/chat-next/pages/index.tsx
@@ -14,7 +14,7 @@ export default function Index({}) {
 	const { isLoading, error, data } = useCanvas()
 
 	const gossipPeers = data?.peers ? Object.entries(data.peers.gossip) : []
-	const backlogPeers = data?.peers ? Object.entries(data.peers.backlog) : []
+	const syncPeers = data?.peers ? Object.entries(data.peers.sync) : []
 
 	return (
 		<main>
@@ -39,7 +39,7 @@ export default function Index({}) {
 								</p>
 								{data.peers && (
 									<ul className="tree-view">
-										<li>{gossipPeers.length + " gossip peers"}</li>
+										<li>{gossipPeers.length} gossip peers</li>
 										<li>
 											<ul>
 												{gossipPeers.map(([peerId, { lastSeen }]) => (
@@ -52,10 +52,10 @@ export default function Index({}) {
 												))}
 											</ul>
 										</li>
-										<li>{backlogPeers.length + " backlog sync peers"}</li>
+										<li>{syncPeers.length} sync peers</li>
 										<li>
 											<ul>
-												{backlogPeers.map(([peerId, { lastSeen }]) => (
+												{syncPeers.map(([peerId, { lastSeen }]) => (
 													<li key={peerId} data-id={peerId} style={{ display: "flex" }}>
 														<div style={{ flex: 1 }}>
 															{peerId.slice(0, 10) + "..." + peerId.slice(peerId.length - 3)}

--- a/examples/chat-webpack/src/App.tsx
+++ b/examples/chat-webpack/src/App.tsx
@@ -10,7 +10,7 @@ export const App: React.FC<{}> = ({}) => {
 	const { isLoading, error, data, host } = useCanvas()
 
 	const gossipPeers = data?.peers ? Object.entries(data.peers.gossip) : []
-	const backlogPeers = data?.peers ? Object.entries(data.peers.backlog) : []
+	const syncPeers = data?.peers ? Object.entries(data.peers.sync) : []
 
 	return (
 		<>
@@ -31,7 +31,7 @@ export const App: React.FC<{}> = ({}) => {
 								</p>
 								{data.peers && (
 									<ul className="tree-view">
-										<li>{gossipPeers.length + " gossip peers"}</li>
+										<li>{gossipPeers.length} gossip peers</li>
 										<li>
 											<ul>
 												{gossipPeers.map(([peerId, { lastSeen }]) => (
@@ -44,10 +44,10 @@ export const App: React.FC<{}> = ({}) => {
 												))}
 											</ul>
 										</li>
-										<li>{backlogPeers.length + " backlog sync peers"}</li>
+										<li>{syncPeers.length} sync peers</li>
 										<li>
 											<ul>
-												{backlogPeers.map(([peerId, { lastSeen }]) => (
+												{syncPeers.map(([peerId, { lastSeen }]) => (
 													<li key={peerId} data-id={peerId} style={{ display: "flex" }}>
 														<div style={{ flex: 1 }}>
 															{peerId.slice(0, 10) + "..." + peerId.slice(peerId.length - 3)}

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -23,7 +23,7 @@ export async function handler(args: Args) {
 	const { directory, uri } = parseSpecArgument(args.spec)
 	assert(directory !== null, "Cannot export from local specs because they do not persist any data")
 
-	const messageStore = new MessageStore(uri, path.resolve(directory, constants.MESSAGE_DATABASE_FILENAME))
+	const messageStore = new MessageStore(uri, path.resolve(directory, constants.MESSAGE_DATABASE_FILENAME), [])
 
 	let i = 0
 	for await (const [_, session] of messageStore.getSessionStream()) {

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -67,7 +67,6 @@ export async function handler(args: Args) {
 	})
 
 	rl.on("close", async () => {
-		await core.onIdle()
 		console.log(`[canvas-cli] Imported ${actionCount} actions, ${sessionCount} sessions`)
 	})
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -168,6 +168,7 @@ export async function handler(args: Args) {
 	const { verbose, replay, unchecked, offline, metrics: exposeMetrics, listen: peeringPort, announce } = args
 
 	const peerId = await getPeerId()
+	console.log(`[canvas-cli] Using PeerId ${peerId.toString()}`)
 
 	let libp2p: Libp2p
 	if (announce !== undefined) {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -37,8 +37,8 @@ export function getAPI(core: Core, options: Partial<Options> = {}): express.Expr
 			routes: Object.keys(routes),
 			peers: core.libp2p
 				? {
-						gossip: Object.fromEntries(core.recentGossipSubPeers),
-						backlog: Object.fromEntries(core.recentBacklogSyncPeers),
+						gossip: Object.fromEntries(core.recentGossipPeers),
+						sync: Object.fromEntries(core.recentSyncPeers),
 				  }
 				: null,
 		})

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -63,8 +63,8 @@ export class Core extends EventEmitter<CoreEvents> {
 	public readonly modelStore: ModelStore
 	public readonly messageStore: MessageStore
 
-	public readonly recentGossipSubPeers = new CacheMap<string, { lastSeen: number }>(1000)
-	public readonly recentBacklogSyncPeers = new CacheMap<string, { lastSeen: number }>(1000)
+	public readonly recentGossipPeers = new CacheMap<string, { lastSeen: number }>(1000)
+	public readonly recentSyncPeers = new CacheMap<string, { lastSeen: number }>(1000)
 
 	private readonly source: Source | null = null
 	private readonly queue: PQueue = new PQueue({ concurrency: 1 })
@@ -119,9 +119,6 @@ export class Core extends EventEmitter<CoreEvents> {
 		const messageDatabasePath = directory && path.resolve(directory, constants.MESSAGE_DATABASE_FILENAME)
 		this.messageStore = new MessageStore(uri, messageDatabasePath, [], { verbose: options.verbose })
 
-		// this.recentGossipSubPeers = new CacheMap(1000)
-		// this.recentBacklogSyncPeers = new CacheMap(1000)
-
 		if (directory !== null) {
 			this.source = Source.initialize({
 				path: path.resolve(directory, constants.MST_FILENAME),
@@ -129,6 +126,8 @@ export class Core extends EventEmitter<CoreEvents> {
 				applyMessage: this.applyMessage,
 				messageStore: this.messageStore,
 				libp2p,
+				recentGossipPeers: this.recentGossipPeers,
+				recentSyncPeers: this.recentSyncPeers,
 				verbose: options.verbose,
 				offline: options.offline,
 			})

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -129,6 +129,8 @@ export class Core extends EventEmitter<CoreEvents> {
 				applyMessage: this.applyMessage,
 				messageStore: this.messageStore,
 				libp2p,
+				verbose: options.verbose,
+				offline: options.offline,
 			})
 		}
 	}

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -24,7 +24,7 @@ import {
 import { verifyActionSignature, verifySessionSignature } from "@canvas-js/verifiers"
 
 import { actionType, sessionType } from "./codecs.js"
-import { toHex, BlockResolver, signalInvalidType } from "./utils.js"
+import { toHex, BlockResolver, signalInvalidType, CacheMap } from "./utils.js"
 import { normalizeAction, fromBinaryAction, fromBinarySession, normalizeSession, BinaryMessage } from "./encoding.js"
 import { VM } from "./vm/index.js"
 import { MessageStore } from "./messageStore.js"
@@ -63,8 +63,8 @@ export class Core extends EventEmitter<CoreEvents> {
 	public readonly modelStore: ModelStore
 	public readonly messageStore: MessageStore
 
-	// public readonly recentGossipSubPeers: CacheMap<string, { lastSeen: number }>
-	// public readonly recentBacklogSyncPeers: CacheMap<string, { lastSeen: number }>
+	public readonly recentGossipSubPeers = new CacheMap<string, { lastSeen: number }>(1000)
+	public readonly recentBacklogSyncPeers = new CacheMap<string, { lastSeen: number }>(1000)
 
 	private readonly source: Source | null = null
 	private readonly queue: PQueue = new PQueue({ concurrency: 1 })

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -18,6 +18,7 @@ import {
 	BlockProvider,
 	Chain,
 	ChainId,
+	Block,
 } from "@canvas-js/interfaces"
 
 import { verifyActionSignature, verifySessionSignature } from "@canvas-js/verifiers"
@@ -308,5 +309,9 @@ export class Core extends EventEmitter<CoreEvents> {
 		assert(this.blockResolver !== null, "missing blockResolver")
 		const block = await this.blockResolver(chain, chainId, blockhash)
 		// TODO: add blocknums to messages, verify blocknum and blockhash match
+	}
+
+	public async getLatestBlock({ chain, chainId }: { chain: Chain; chainId: ChainId }): Promise<Block> {
+		return this.blockResolver(chain, chainId, "latest")
 	}
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert"
 import path from "node:path"
-import { createHash } from "node:crypto"
 
 import chalk from "chalk"
 import PQueue from "p-queue"
@@ -10,46 +9,29 @@ import { EventEmitter, CustomEvent } from "@libp2p/interfaces/events"
 import { createEd25519PeerId } from "@libp2p/peer-id-factory"
 import { createLibp2p, Libp2p } from "libp2p"
 
-import type { SignedMessage, UnsignedMessage } from "@libp2p/interface-pubsub"
-import type { Stream } from "@libp2p/interface-connection"
-import type { PeerId } from "@libp2p/interface-peer-id"
-import type { StreamHandler } from "@libp2p/interface-registrar"
-
-import * as okra from "node-okra"
-
 import {
 	Action,
 	ActionPayload,
 	Session,
 	SessionPayload,
 	ModelValue,
+	BlockProvider,
 	Chain,
 	ChainId,
-	Block,
-	BlockProvider,
 } from "@canvas-js/interfaces"
 
 import { verifyActionSignature, verifySessionSignature } from "@canvas-js/verifiers"
 
 import { actionType, sessionType } from "./codecs.js"
-import { signalInvalidType, wait, retry, toHex, BlockResolver, AbortError, CacheMap, fromHex } from "./utils.js"
-import {
-	normalizeAction,
-	BinaryMessage,
-	BinaryAction,
-	fromBinaryAction,
-	fromBinarySession,
-	normalizeSession,
-	BinarySession,
-	decodeBinaryMessage,
-} from "./encoding.js"
+import { toHex, BlockResolver, signalInvalidType } from "./utils.js"
+import { normalizeAction, fromBinaryAction, fromBinarySession, normalizeSession, BinaryMessage } from "./encoding.js"
 import { VM } from "./vm/index.js"
 import { MessageStore } from "./messageStore.js"
 import { ModelStore } from "./modelStore.js"
 
-import { sync, handleIncomingStream } from "./rpc/index.js"
 import * as constants from "./constants.js"
 import { getLibp2pInit } from "./libp2p.js"
+import { Source } from "./source.js"
 
 export interface CoreConfig extends CoreOptions {
 	// pass `null` to run in memory
@@ -79,13 +61,12 @@ interface CoreEvents {
 export class Core extends EventEmitter<CoreEvents> {
 	public readonly modelStore: ModelStore
 	public readonly messageStore: MessageStore
-	public readonly mst: okra.Tree | null = null
 
-	public readonly recentGossipSubPeers: CacheMap<string, { lastSeen: number }>
-	public readonly recentBacklogSyncPeers: CacheMap<string, { lastSeen: number }>
+	// public readonly recentGossipSubPeers: CacheMap<string, { lastSeen: number }>
+	// public readonly recentBacklogSyncPeers: CacheMap<string, { lastSeen: number }>
 
+	private readonly source: Source | null = null
 	private readonly queue: PQueue = new PQueue({ concurrency: 1 })
-	private readonly controller = new AbortController()
 
 	public static async initialize({ directory, uri, spec, libp2p, providers, blockResolver, ...options }: CoreConfig) {
 		const cid = await Hash.of(spec).then(CID.parse)
@@ -135,68 +116,42 @@ export class Core extends EventEmitter<CoreEvents> {
 		this.modelStore = new ModelStore(modelDatabasePath, vm, { verbose: options.verbose })
 
 		const messageDatabasePath = directory && path.resolve(directory, constants.MESSAGE_DATABASE_FILENAME)
-		this.messageStore = new MessageStore(uri, messageDatabasePath, { verbose: options.verbose })
+		this.messageStore = new MessageStore(uri, messageDatabasePath, [], { verbose: options.verbose })
 
-		this.recentGossipSubPeers = new CacheMap(1000)
-		this.recentBacklogSyncPeers = new CacheMap(1000)
+		// this.recentGossipSubPeers = new CacheMap(1000)
+		// this.recentBacklogSyncPeers = new CacheMap(1000)
 
 		if (directory !== null) {
-			// offline cores might be run with a non-null directory; we still want to update the MST
-			this.mst = new okra.Tree(path.resolve(directory, constants.MST_FILENAME))
-
-			if (libp2p !== null && !this.options.offline) {
-				libp2p.pubsub.subscribe(this.uri)
-				libp2p.pubsub.addEventListener("message", this.handleMessage)
-				if (this.options.verbose) {
-					console.log(`[canvas-core] Using PeerId ${libp2p.peerId.toString()}`)
-					console.log(`[canvas-core] Subscribed to pubsub topic ${this.uri}`)
-				}
-
-				libp2p.handle(this.syncProtocol, this.streamHandler)
-				this.startSyncService()
-				this.startAnnounceService()
-			}
+			this.source = Source.initialize({
+				path: path.resolve(directory, constants.MST_FILENAME),
+				cid,
+				applyMessage: this.applyMessage,
+				messageStore: this.messageStore,
+				libp2p,
+			})
 		}
-	}
-
-	public get syncProtocol() {
-		return `/x/canvas/sync/${this.cid.toString()}`
-	}
-
-	public async onIdle(): Promise<void> {
-		await this.queue.onIdle()
 	}
 
 	public async close() {
-		this.controller.abort()
-
-		if (this.libp2p !== null && !this.options.offline) {
-			this.libp2p.unhandle(this.syncProtocol)
-			this.libp2p.pubsub.unsubscribe(this.uri)
-			this.libp2p.pubsub.removeEventListener("message", this.handleMessage)
-		}
-
 		await this.queue.onIdle()
 
 		this.vm.dispose()
 		this.messageStore.close()
 		this.modelStore.close()
-		if (this.mst !== null) {
-			this.mst.close()
+
+		if (this.source !== null) {
+			await this.source.close()
 		}
 
 		this.dispatchEvent(new Event("close"))
 	}
 
-	public async getLatestBlock({ chain, chainId }: { chain: Chain; chainId: ChainId }): Promise<Block> {
-		return this.blockResolver(chain, chainId, "latest")
-	}
+	public async getRoute(route: string, params: Record<string, string>): Promise<Record<string, ModelValue>[]> {
+		if (this.options.verbose) {
+			console.log("[canvas-core] getRoute:", route, params)
+		}
 
-	/**
-	 * Helper for verifying the blockhash for an action or session.
-	 */
-	public async verifyBlock({ chain, chainId, blockhash }: { chain: Chain; chainId: ChainId; blockhash: string }) {
-		await this.blockResolver(chain, chainId, blockhash)
+		return this.modelStore.getRoute(route, params)
 	}
 
 	/**
@@ -205,52 +160,84 @@ export class Core extends EventEmitter<CoreEvents> {
 	public async applyAction(action: Action): Promise<{ hash: string }> {
 		assert(actionType.is(action), "Invalid action value")
 
-		// Since this method is the external entrypoint for actions
-		// (ie used by the HTTP API) we have to calculate the hash ourselves.
-		// We ALSO need to "normalize" the action - making sure that the
-		// binary values like address and blockhash have canonical values for
-		// the appropriate chain. We can't just call toLowerCase() since some
-		// chains use base58 for these values. Instead, the simplest way for us
-		// to guarantee canonicality is to encode and then decode again.
-		const [hash, binaryAction, data] = normalizeAction(action)
+		const [hash, message, data] = normalizeAction(action)
+
 		const existingRecord = this.messageStore.getActionByHash(hash)
 		if (existingRecord !== null) {
 			return { hash: toHex(hash) }
 		}
 
-		await this.queue.add(() => this.applyActionInternal(hash, binaryAction))
+		await this.applyMessage(hash, message)
 
-		await this.publishMessage(hash, data)
+		if (this.source !== null) {
+			this.source.insertMessage(hash, message)
+			await this.source.publishMessage(hash, data)
+		}
+
 		return { hash: toHex(hash) }
 	}
 
-	private async applyActionInternal(hashBuffer: Buffer, binaryAction: BinaryAction) {
-		// We deliberately translate actions to BinaryActions and back in order to
-		// guarantee consistent address capitalization etc. fromBinaryAction serves
-		// as a normalizer; if we want to change the canonical format for anythingl
-		// we would do it there.
-		const action = fromBinaryAction(binaryAction)
-		const hash = toHex(hashBuffer)
-		if (this.options.verbose) {
-			console.log(chalk.green(`[canvas-core] Applying action ${hash}`), action)
+	/**
+	 * Create a new session.
+	 */
+	public async applySession(session: Session): Promise<{ hash: string }> {
+		assert(sessionType.is(session), "invalid session")
+
+		const [hash, message, data] = normalizeSession(session)
+
+		const existingRecord = this.messageStore.getSessionByHash(hash)
+		if (existingRecord !== null) {
+			return { hash: toHex(hash) }
 		}
 
-		await this.validateAction(action)
+		await this.applyMessage(hash, message)
 
-		const effects = await this.vm.execute(hash, action.payload)
-		this.messageStore.insertAction(hash, binaryAction)
-		this.modelStore.applyEffects(action.payload, effects)
-		if (this.mst !== null) {
-			const leafBuffer = Buffer.alloc(14)
-			leafBuffer.writeUintBE(action.payload.timestamp * 2 + 1, 0, 6)
-			hashBuffer.copy(leafBuffer, 6, 0, 8)
-			this.mst.insert(leafBuffer, hashBuffer)
+		if (this.source !== null) {
+			this.source.insertMessage(hash, message)
+			await this.source.publishMessage(hash, data)
 		}
 
-		this.dispatchEvent(new CustomEvent("action", { detail: action.payload }))
+		return { hash: toHex(hash) }
+	}
 
-		if (this.options.verbose) {
-			console.log(chalk.green(`[canvas-core] Successfully applied action ${hash}`))
+	/**
+	 * Apply a message.
+	 * For actions: validate, execute, apply effects, insert into message store.
+	 * For sessions: validate, insert into message store.
+	 * This method is also passed to Source as the callback for GossipSub and MST sync messages.
+	 */
+	private applyMessage = async (hash: Buffer, message: BinaryMessage) => {
+		const id = toHex(hash)
+		if (message.type === "action") {
+			const action = fromBinaryAction(message)
+			await this.validateAction(action)
+
+			if (this.options.verbose) {
+				console.log(chalk.green(`[canvas-core] Applying action ${id}`), action)
+			}
+
+			// only execute one action at a time.
+			await this.queue.add(async () => {
+				const effects = await this.vm.execute(id, action.payload)
+				this.modelStore.applyEffects(action.payload, effects)
+			})
+
+			this.messageStore.insertAction(hash, message)
+
+			this.dispatchEvent(new CustomEvent("action", { detail: action.payload }))
+		} else if (message.type === "session") {
+			const session = fromBinarySession(message)
+			await this.validateSession(session)
+
+			if (this.options.verbose) {
+				console.log(chalk.green(`[canvas-core] Applying session ${id}`), session)
+			}
+
+			this.messageStore.insertSession(hash, message)
+
+			this.dispatchEvent(new CustomEvent("session", { detail: session.payload }))
+		} else {
+			signalInvalidType(message)
 		}
 	}
 
@@ -267,7 +254,7 @@ export class Core extends EventEmitter<CoreEvents> {
 		if (!this.options.unchecked) {
 			// check the action was signed with a valid, recent block
 			assert(blockhash, "action is missing block data")
-			await this.verifyBlock({ blockhash, chain, chainId })
+			await this.validateBlock({ blockhash, chain, chainId })
 		}
 
 		// verify the signature, either using a session signature or action signature
@@ -276,10 +263,7 @@ export class Core extends EventEmitter<CoreEvents> {
 			assert(binarySession !== null, "session not found")
 			const session = fromBinarySession(binarySession)
 			assert(session.payload.chain === action.payload.chain, "session and action chains must match")
-			assert(
-				session.payload.chainId.toString() === action.payload.chainId.toString(),
-				"session and action chain IDs must match"
-			)
+			assert(session.payload.chainId === action.payload.chainId, "session and action chain IDs must match")
 			assert(session.payload.timestamp + session.payload.duration > timestamp, "session expired")
 			assert(session.payload.timestamp <= timestamp, "session timestamp must precede action timestamp")
 
@@ -299,44 +283,6 @@ export class Core extends EventEmitter<CoreEvents> {
 		}
 	}
 
-	/**
-	 * Create a new session.
-	 */
-	public async applySession(session: Session): Promise<{ hash: string }> {
-		assert(sessionType.is(session), "invalid session")
-		const [hash, binarySession, data] = normalizeSession(session)
-		const existingRecord = this.messageStore.getSessionByHash(hash)
-		if (existingRecord !== null) {
-			return { hash: toHex(hash) }
-		}
-
-		await this.queue.add(() => this.applySessionInternal(hash, binarySession))
-		await this.publishMessage(hash, data)
-		return { hash: toHex(hash) }
-	}
-
-	private async applySessionInternal(hashBuffer: Buffer, binarySession: BinarySession) {
-		const hash = toHex(hashBuffer)
-		const session = fromBinarySession(binarySession)
-		if (this.options.verbose) {
-			console.log(chalk.green(`[canvas-core] Applying session ${hash}`), session)
-		}
-
-		await this.validateSession(session)
-		this.messageStore.insertSession(hash, binarySession)
-		if (this.mst !== null) {
-			const leafBuffer = Buffer.alloc(14)
-			leafBuffer.writeUintBE(session.payload.timestamp * 2, 0, 6)
-			hashBuffer.copy(leafBuffer, 6, 0, 8)
-			this.mst.insert(leafBuffer, hashBuffer)
-		}
-
-		this.dispatchEvent(new CustomEvent("session", { detail: session.payload }))
-		if (this.options.verbose) {
-			console.log(chalk.green(`[canvas-core] Successfully applied session ${hash}`))
-		}
-	}
-
 	private async validateSession(session: Session) {
 		const { from, spec, timestamp, blockhash, chain, chainId } = session.payload
 		assert(spec === this.uri, "session signed for wrong spec")
@@ -351,285 +297,16 @@ export class Core extends EventEmitter<CoreEvents> {
 		if (!this.options.unchecked) {
 			// check the session was signed with a valid, recent block
 			assert(blockhash, "session is missing block data")
-			await this.verifyBlock({ blockhash, chain, chainId })
+			await this.validateBlock({ blockhash, chain, chainId })
 		}
 	}
 
-	public async getRoute(route: string, params: Record<string, string>): Promise<Record<string, ModelValue>[]> {
-		if (this.options.verbose) {
-			console.log("[canvas-core] getRoute:", route, params)
-		}
-
-		return this.modelStore.getRoute(route, params)
-	}
-
-	private async publishMessage(hash: Buffer, data: Uint8Array) {
-		if (this.libp2p === null || this.options.offline) {
-			return
-		}
-
-		if (this.options.verbose) {
-			console.log(`[canvas-core] Publishing action ${toHex(hash)} to GossipSub`)
-		}
-
-		await this.libp2p.pubsub
-			.publish(this.uri, data)
-			.then(({ recipients }) => {
-				if (this.options.verbose) {
-					console.log(`[canvas-core] Published message to ${recipients.length} peers`)
-				}
-			})
-			.catch((err) => {
-				const message = err instanceof Error ? err.message : err.toString()
-				console.error(chalk.red("[canvas-core] Failed to publish action to pubsub topic"), message)
-			})
-	}
-
-	private handleMessage = async ({ detail: message }: CustomEvent<SignedMessage | UnsignedMessage>) => {
-		if (message.topic !== this.uri || message.type !== "signed") {
-			return
-		}
-
-		const binaryMessage = decodeBinaryMessage(message.data)
-		const hash = createHash("sha256").update(message.data).digest()
-		try {
-			if (binaryMessage.type === "action") {
-				await this.queue.add(() => this.applyActionInternal(hash, binaryMessage))
-			} else if (binaryMessage.type === "session") {
-				await this.queue.add(() => this.applySessionInternal(hash, binaryMessage))
-			} else {
-				signalInvalidType(binaryMessage)
-			}
-		} catch (err) {
-			console.log(chalk.red("[canvas-core] Error applying peer message"), err)
-		}
-	}
-
-	private streamHandler: StreamHandler = async ({ connection, stream }) => {
-		if (this.mst === null) {
-			return
-		}
-
-		if (this.options.verbose) {
-			console.log(`[canvas-core] Handling incoming stream ${stream.id} from peer ${connection.remotePeer.toString()}`)
-		}
-
-		await handleIncomingStream(stream, this.messageStore, this.mst)
-		if (this.options.verbose) {
-			console.log(`[canvas-core] Closed incoming stream ${stream.id}`)
-		}
-	}
-
-	private async wait(interval: number) {
-		await wait({ signal: this.controller.signal, interval })
-	}
-
-	private async startAnnounceService() {
-		if (this.options.verbose) {
-			console.log("[canvas-core] Staring announce service")
-		}
-
-		const queryController = new AbortController()
-		const abort = () => queryController.abort()
-		this.controller.signal.addEventListener("abort", abort)
-		try {
-			await this.wait(constants.ANNOUNCE_DELAY)
-			while (!queryController.signal.aborted) {
-				await retry(
-					() => this.announce(),
-					(err) => console.log(chalk.red(`[canvas-core] Failed to publish DHT rendezvous record.`), err.message),
-					{ signal: queryController.signal, interval: constants.ANNOUNCE_RETRY_INTERVAL }
-				)
-				await this.wait(constants.ANNOUNCE_INTERVAL)
-			}
-		} catch (err) {
-			if (err instanceof AbortError) {
-				if (this.options.verbose) {
-					console.log(`[canvas-core] Aborting announce service.`)
-				}
-			} else {
-				console.log(chalk.red(`[canvas-core] Announce service crashed.`))
-				console.log(err)
-			}
-		} finally {
-			this.controller.signal.removeEventListener("abort", abort)
-			queryController.abort()
-		}
-	}
-
-	private async announce(): Promise<void> {
-		if (this.libp2p === null) {
-			return
-		}
-
-		if (this.options.verbose) {
-			console.log(chalk.green(`[canvas-core] Publishing DHT rendezvous record ${this.cid.toString()}`))
-		}
-
-		const queryController = new AbortController()
-		const abort = () => queryController.abort()
-		this.controller.signal.addEventListener("abort", abort)
-		try {
-			await this.libp2p.contentRouting.provide(this.cid, { signal: queryController.signal })
-		} finally {
-			this.controller.signal.removeEventListener("abort", abort)
-		}
-
-		if (this.options.verbose) {
-			console.log(chalk.green(`[canvas-core] Successfully published DHT rendezvous record.`))
-		}
-	}
-
-	private async startSyncService() {
-		if (this.options.verbose) {
-			console.log("[canvas-core] Staring sync service")
-		}
-
-		try {
-			await this.wait(constants.SYNC_DELAY)
-			while (!this.controller.signal.aborted) {
-				// Also save recently seen gossipsub peers.
-				// TODO: move this to its own service, maybe when we start pruning
-				// gossipsub peers based on accepted/rejected actions in canvas
-				try {
-					for (const [i, peer] of this.libp2p?.pubsub.getSubscribers(this.uri).entries() ?? []) {
-						this.recentGossipSubPeers.set(peer.toString(), { lastSeen: +new Date() })
-					}
-				} catch (err) {
-					console.log(chalk.red(`[canvas-core] Failed to identify gossipsub peers.`))
-				}
-
-				const peers = await retry(
-					() => this.findSyncPeers(),
-					(err) => console.log(chalk.red(`[canvas-core] Failed to locate application peers.`), err.message),
-					{ signal: this.controller.signal, interval: constants.SYNC_RETRY_INTERVAL }
-				)
-
-				if (this.options.verbose) {
-					console.log(chalk.green(`[canvas-core] Found ${peers.length} peers for ${this.uri}`))
-				}
-
-				for (const [i, peer] of peers.entries()) {
-					if (this.options.verbose) {
-						console.log(chalk.green(`[canvas-core] Initiating sync with ${peer.toString()} (${i + 1}/${peers.length})`))
-					}
-					this.recentBacklogSyncPeers.set(peer.toString(), { lastSeen: +new Date() })
-
-					await this.sync(peer)
-				}
-
-				await this.wait(constants.SYNC_INTERVAL)
-			}
-		} catch (err) {
-			if (err instanceof AbortError) {
-				if (this.options.verbose) {
-					console.log("[canvas-core] Aborting sync service.")
-				}
-			} else {
-				console.log(chalk.red(`[canvas-core] Sync service crashed.`))
-				console.log(err)
-			}
-		}
-	}
-
-	async findSyncPeers(): Promise<PeerId[]> {
-		if (this.libp2p === null) {
-			return []
-		}
-
-		const queryController = new AbortController()
-		const abort = () => queryController.abort()
-		this.controller.signal.addEventListener("abort", abort)
-
-		const { contentRouting } = this.libp2p
-		try {
-			const peers: PeerId[] = []
-			for await (const { id } of contentRouting.findProviders(this.cid, { signal: queryController.signal })) {
-				if (id.equals(this.libp2p.peerId)) {
-					continue
-				} else {
-					peers.push(id)
-				}
-			}
-			return peers
-		} finally {
-			this.controller.signal.removeEventListener("abort", abort)
-		}
-	}
-
-	private async sync(peer: PeerId) {
-		if (this.libp2p === null || this.mst === null) {
-			return
-		}
-
-		const queryController = new AbortController()
-		const abort = () => queryController.abort()
-		this.controller.signal.addEventListener("abort", abort)
-
-		let stream: Stream
-		try {
-			stream = await this.libp2p.dialProtocol(peer, this.syncProtocol, { signal: queryController.signal })
-		} catch (err: any) {
-			// show all errors, if we receive an AggregateError
-			console.log(chalk.red(`[canvas-core] Failed to sync with ${peer.toString()}`, err.errors ?? err))
-			return
-		} finally {
-			this.controller.signal.removeEventListener("abort", abort)
-		}
-
-		if (this.options.verbose) {
-			console.log(`[canvas-core] Opened outgoing stream ${stream.id} to ${peer.toString()}`)
-		}
-
-		const closeStream = () => stream.close()
-		this.controller.signal.addEventListener("abort", closeStream)
-
-		let successCount = 0
-		let failureCount = 0
-
-		const applyBatch = (messages: [Buffer, BinaryMessage][]) =>
-			this.queue.add(async () => {
-				for (const [hash, message] of messages) {
-					if (this.options.verbose) {
-						console.log(chalk.green(`[canvas-core] Received missing ${message.type} ${hash}`))
-					}
-
-					if (message.type === "session") {
-						try {
-							await this.applySessionInternal(hash, message)
-							successCount += 1
-						} catch (err) {
-							console.log(chalk.red(`[canvas-core] Failed to apply session ${hash}`), err)
-							failureCount += 1
-						}
-					} else if (message.type === "action") {
-						try {
-							await this.applyActionInternal(hash, message)
-							successCount += 1
-						} catch (err) {
-							console.log(chalk.red(`[canvas-core] Failed to apply action ${hash}`), err)
-							failureCount += 1
-						}
-					} else {
-						signalInvalidType(message)
-					}
-				}
-			})
-
-		try {
-			await sync(this.mst, stream, applyBatch)
-		} catch (err) {
-			console.log(chalk.red(`[canvas-core] ${err}`))
-		} finally {
-			this.controller.signal.removeEventListener("abort", closeStream)
-		}
-
-		console.log(
-			`[canvas-core] Sync with ${peer.toString()} completed. Applied ${successCount} new messages with ${failureCount} failures.`
-		)
-
-		if (this.options.verbose) {
-			console.log(`[canvas-core] Closed outgoing stream ${stream.id}`)
-		}
+	/**
+	 * Helper for verifying the blockhash for an action or session.
+	 */
+	private async validateBlock({ chain, chainId, blockhash }: { chain: Chain; chainId: ChainId; blockhash: string }) {
+		assert(this.blockResolver !== null, "missing blockResolver")
+		const block = await this.blockResolver(chain, chainId, blockhash)
+		// TODO: add blocknums to messages, verify blocknum and blockhash match
 	}
 }

--- a/packages/core/src/rpc/server.ts
+++ b/packages/core/src/rpc/server.ts
@@ -11,9 +11,14 @@ import * as okra from "node-okra"
 
 import RPC from "../../rpc/sync/index.cjs"
 
-import type { MessageStore } from "../messageStore.js"
-import { encodeBinaryMessage } from "../encoding.js"
+import { BinaryAction, BinarySession, encodeBinaryMessage } from "../encoding.js"
 import { toBuffer, toHex } from "../utils.js"
+
+// We declare this interface to enforce that handleIncomingStream only has read access to the message store.
+interface MessageStore {
+	getSessionByHash(hash: Buffer): BinarySession | null
+	getActionByHash(hash: Buffer): BinaryAction | null
+}
 
 export async function handleIncomingStream(
 	stream: Duplex<Uint8ArrayList, Uint8ArrayList | Uint8Array>,

--- a/packages/core/src/rpc/sync.ts
+++ b/packages/core/src/rpc/sync.ts
@@ -14,7 +14,6 @@ export async function sync(
 	mst: okra.Tree,
 	stream: Duplex<Uint8ArrayList, Uint8ArrayList | Uint8Array>,
 	handleMessage: (hash: Buffer, data: Uint8Array, message: BinaryMessage) => Promise<void>
-	// applyBatch: (messages: [hash: Buffer, data: Uint8Array, message: BinaryMessage][]) => Promise<void>
 ): Promise<void> {
 	const target = new okra.Target(mst)
 	const client = new Client(stream)
@@ -46,17 +45,12 @@ export async function sync(
 			const values = await client.getValues(leaves)
 			assert(values.length === leaves.length, "expected values.length to match leaves.length")
 
-			// const messages: [hash: Buffer, data: Uint8Array, message: BinaryMessage][] = []
-
 			for (const [i, data] of values.entries()) {
 				const { hash } = leaves[i]
 				assert(createHash("sha256").update(data).digest().equals(hash), "received bad value for hash")
 				const message = decodeBinaryMessage(data)
 				await handleMessage(hash, data, message)
-				// messages.push([hash, value, decodeBinaryMessage(value)])
 			}
-
-			// await applyBatch(messages)
 		}
 	}
 

--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -191,6 +191,7 @@ export class Source {
 					(err) => console.log(chalk.red("[canvas-core] Failed to publish DHT provider record."), err.message),
 					{ signal: queryController.signal, interval: constants.ANNOUNCE_RETRY_INTERVAL }
 				)
+
 				await this.wait(constants.ANNOUNCE_INTERVAL)
 			}
 		} catch (err) {

--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -1,0 +1,382 @@
+import assert from "node:assert"
+import { createHash } from "node:crypto"
+
+import chalk from "chalk"
+import { CID } from "multiformats/cid"
+
+import { Libp2p } from "libp2p"
+import type { SignedMessage, UnsignedMessage } from "@libp2p/interface-pubsub"
+import type { Stream } from "@libp2p/interface-connection"
+import type { PeerId } from "@libp2p/interface-peer-id"
+import type { StreamHandler } from "@libp2p/interface-registrar"
+
+import * as okra from "node-okra"
+
+import { wait, retry, AbortError, toHex, signalInvalidType } from "./utils.js"
+import { BinaryAction, BinaryMessage, BinarySession, decodeBinaryMessage } from "./encoding.js"
+import { sync, handleIncomingStream } from "./rpc/index.js"
+import * as constants from "./constants.js"
+
+// We declare this interface to enforce that Source only has read access to the message store.
+// All the writes still happen in Core.
+interface MessageStore {
+	getSessionByHash(hash: Buffer): BinarySession | null
+	getActionByHash(hash: Buffer): BinaryAction | null
+}
+
+export interface SourceOptions {
+	verbose?: boolean
+	offline?: boolean
+}
+
+export interface SourceConfig extends SourceOptions {
+	path: string
+	cid: CID
+	applyMessage: (hash: Buffer, message: BinaryMessage) => Promise<void>
+	messageStore: MessageStore
+	libp2p: Libp2p | null
+}
+
+export class Source {
+	public readonly mst: okra.Tree
+
+	private readonly uri: string
+	private readonly syncProtocol: string
+	private readonly controller = new AbortController()
+
+	public static initialize(config: SourceConfig) {
+		const { path, cid, libp2p, applyMessage, messageStore, ...options } = config
+		return new Source(path, cid, applyMessage, messageStore, libp2p, options)
+	}
+
+	private constructor(
+		path: string,
+		private readonly cid: CID,
+		private readonly applyMessage: (hash: Buffer, message: BinaryMessage) => Promise<void>,
+		private readonly messageStore: MessageStore,
+		private readonly libp2p: Libp2p | null,
+		private readonly options: SourceOptions
+	) {
+		this.uri = `ipfs://${cid.toString()}`
+		this.syncProtocol = `/x/canvas/sync/${cid.toString()}`
+
+		this.mst = new okra.Tree(path)
+
+		if (libp2p !== null && !this.options.offline) {
+			libp2p.pubsub.subscribe(this.uri)
+			libp2p.pubsub.addEventListener("message", this.handleMessage)
+			if (this.options.verbose) {
+				console.log(`[canvas-core] Subscribed to pubsub topic ${this.uri}.`)
+			}
+
+			libp2p.handle(this.syncProtocol, this.streamHandler)
+			this.startSyncService()
+			this.startAnnounceService()
+		}
+	}
+
+	public async close() {
+		this.controller.abort()
+
+		if (this.libp2p !== null && !this.options.offline) {
+			this.libp2p.unhandle(this.syncProtocol)
+			this.libp2p.pubsub.unsubscribe(this.uri)
+			this.libp2p.pubsub.removeEventListener("message", this.handleMessage)
+		}
+
+		this.mst.close()
+	}
+
+	/**
+	 * Insert the message into the MST.
+	 * This is synchronous and internally opens a locking write transaction.
+	 */
+	public insertMessage(hash: Buffer, message: BinaryMessage) {
+		const leaf = Buffer.alloc(14)
+		if (message.type === "action") {
+			leaf.writeUintBE(message.payload.timestamp * 2 + 1, 0, 6)
+		} else if (message.type === "session") {
+			leaf.writeUintBE(message.payload.timestamp * 2, 0, 6)
+		} else {
+			signalInvalidType(message)
+		}
+
+		hash.copy(leaf, 6, 0, 8)
+		this.mst.insert(leaf, hash)
+	}
+
+	/**
+	 * Publish a message to the GossipSub topic.
+	 */
+	public async publishMessage(hash: Buffer, data: Uint8Array) {
+		if (this.libp2p === null || this.options.offline) {
+			return
+		}
+
+		if (this.options.verbose) {
+			console.log(`[canvas-core] Publishing message ${toHex(hash)} to GossipSub...`)
+		}
+
+		await this.libp2p.pubsub
+			.publish(this.uri, data)
+			.then(({ recipients }) => {
+				if (this.options.verbose) {
+					console.log(`[canvas-core] Published ${toHex(hash)} to ${recipients.length} peers.`)
+				}
+			})
+			.catch((err) => {
+				console.log(chalk.red(`[canvas-core] Failed to publish ${toHex(hash)} to GossipSub.`), err)
+			})
+	}
+
+	/**
+	 * handleMessage is attached as a listener to *all* libp2p GosssipSub messages
+	 */
+	private handleMessage = async ({ detail: message }: CustomEvent<SignedMessage | UnsignedMessage>) => {
+		// the first step is to check if the message is even for our topic in the first place.
+		if (message.type !== "signed" || message.topic !== this.uri) {
+			return
+		}
+
+		try {
+			const binaryMessage = decodeBinaryMessage(message.data)
+			const hash = createHash("sha256").update(message.data).digest()
+			await this.applyMessage(hash, binaryMessage)
+			this.insertMessage(hash, binaryMessage)
+		} catch (err) {
+			console.log(chalk.red("[canvas-core] Error applying GossipSub message."), err)
+		}
+	}
+
+	/**
+	 * Handle incoming libp2p streams on the /x/canvas/sync/${cid} protocol.
+	 * Incoming streams are simple; we essentially just open a read-only
+	 * MST transaction and respond to as many getChildren requests as the
+	 * client needs to make.
+	 */
+	private streamHandler: StreamHandler = async ({ connection, stream }) => {
+		if (this.options.verbose) {
+			const peerId = connection.remotePeer.toString()
+			console.log(`[canvas-core] Opened incoming stream ${stream.id} from peer ${peerId}.`)
+		}
+
+		await handleIncomingStream(stream, this.messageStore, this.mst)
+		if (this.options.verbose) {
+			console.log(`[canvas-core] Closed incoming stream ${stream.id}.`)
+		}
+	}
+
+	private async wait(interval: number) {
+		await wait({ signal: this.controller.signal, interval })
+	}
+
+	/**
+	 * This starts the "announce service", an async while loop that calls this.announce()
+	 * every constants.ANNOUNCE_INTERVAL milliseconds
+	 */
+	private async startAnnounceService() {
+		if (this.options.verbose) {
+			console.log("[canvas-core] Staring announce service.")
+		}
+
+		const queryController = new AbortController()
+		const abort = () => queryController.abort()
+		this.controller.signal.addEventListener("abort", abort)
+
+		try {
+			await this.wait(constants.ANNOUNCE_DELAY)
+			while (!queryController.signal.aborted) {
+				await retry(
+					() => this.announce(),
+					(err) => console.log(chalk.red("[canvas-core] Failed to publish DHT provider record."), err.message),
+					{ signal: queryController.signal, interval: constants.ANNOUNCE_RETRY_INTERVAL }
+				)
+				await this.wait(constants.ANNOUNCE_INTERVAL)
+			}
+		} catch (err) {
+			if (err instanceof AbortError) {
+				if (this.options.verbose) {
+					console.log(`[canvas-core] Aborting announce service.`)
+				}
+			} else {
+				console.log(chalk.red(`[canvas-core] Announce service crashed.`))
+				console.log(err)
+			}
+		} finally {
+			this.controller.signal.removeEventListener("abort", abort)
+			queryController.abort()
+		}
+	}
+
+	/**
+	 * Publish a provider record to the DHT announcing us as an application peer.
+	 */
+	private async announce(): Promise<void> {
+		assert(this.libp2p !== null)
+		if (this.options.verbose) {
+			console.log(chalk.green(`[canvas-core] Publishing DHT provider record ${this.cid.toString()}...`))
+		}
+
+		const queryController = new AbortController()
+		const abort = () => queryController.abort()
+		this.controller.signal.addEventListener("abort", abort)
+		try {
+			await this.libp2p.contentRouting.provide(this.cid, { signal: queryController.signal })
+		} finally {
+			this.controller.signal.removeEventListener("abort", abort)
+		}
+
+		if (this.options.verbose) {
+			console.log(chalk.green(`[canvas-core] Successfully published DHT provider record.`))
+		}
+	}
+
+	/**
+	 * This starts the "sync service", an async while loop that looks up application peers
+	 * and calls this.sync(peerId) for each of them every constants.SYNC_INTERVAL milliseconds
+	 */
+	private async startSyncService() {
+		if (this.options.verbose) {
+			console.log("[canvas-core] Staring sync service.")
+		}
+
+		try {
+			await this.wait(constants.SYNC_DELAY)
+			while (!this.controller.signal.aborted) {
+				const peers = await retry(
+					() => this.findSyncPeers(),
+					(err) => console.log(chalk.red(`[canvas-core] Failed to locate application peers.`), err.message),
+					{ signal: this.controller.signal, interval: constants.SYNC_RETRY_INTERVAL }
+				)
+
+				if (this.options.verbose) {
+					console.log(chalk.green(`[canvas-core] Found ${peers.length} peers for ${this.uri}.`))
+				}
+
+				for (const [i, peer] of peers.entries()) {
+					if (this.options.verbose) {
+						console.log(
+							chalk.green(`[canvas-core] Initiating sync with ${peer.toString()}. (${i + 1}/${peers.length})`)
+						)
+					}
+
+					await this.sync(peer)
+				}
+
+				await this.wait(constants.SYNC_INTERVAL)
+			}
+		} catch (err) {
+			if (err instanceof AbortError) {
+				if (this.options.verbose) {
+					console.log("[canvas-core] Aborting sync service.")
+				}
+			} else {
+				console.log(chalk.red(`[canvas-core] Sync service crashed.`))
+				console.log(err)
+			}
+		}
+	}
+
+	/**
+	 * Locates application peers to sync with.
+	 * There are two ways we could do this: using the DHT with a findProviders query,
+	 * or using the current set of direct GossipSub peers. Right now we use the DHT
+	 * method, which has the added benefit of exposing the GossipSub component to additional
+	 * peers it might not have seen yet.
+	 */
+	private async findSyncPeers(): Promise<PeerId[]> {
+		assert(this.libp2p !== null)
+
+		if (this.options.verbose) {
+			console.log("[canvas-core] Querying DHT for application peers...")
+		}
+
+		const queryController = new AbortController()
+		const abort = () => queryController.abort()
+		this.controller.signal.addEventListener("abort", abort)
+
+		const { contentRouting } = this.libp2p
+		try {
+			const peers: PeerId[] = []
+			for await (const { id } of contentRouting.findProviders(this.cid, { signal: queryController.signal })) {
+				if (id.equals(this.libp2p.peerId)) {
+					continue
+				} else {
+					peers.push(id)
+				}
+			}
+
+			return peers
+		} finally {
+			this.controller.signal.removeEventListener("abort", abort)
+		}
+	}
+
+	/**
+	 * Initiate an MST sync with the target peer. Syncs are one-directional; we dial a
+	 * peer and treat them as a server, scanning a read-only snapshot of their MST.
+	 * They have to independently dial us back to access our MST.
+	 */
+	private async sync(peer: PeerId) {
+		assert(this.libp2p !== null)
+
+		const queryController = new AbortController()
+		const abort = () => queryController.abort()
+		this.controller.signal.addEventListener("abort", abort)
+
+		let stream: Stream
+		try {
+			stream = await this.libp2p.dialProtocol(peer, this.syncProtocol, { signal: queryController.signal })
+		} catch (err: any) {
+			// show all errors, if we receive an AggregateError
+			console.log(chalk.red(`[canvas-core] Failed to dial peer ${peer.toString()}.`, err.errors ?? err))
+			return
+		} finally {
+			this.controller.signal.removeEventListener("abort", abort)
+		}
+
+		if (this.options.verbose) {
+			console.log(`[canvas-core] Opened outgoing stream ${stream.id} to ${peer.toString()}.`)
+		}
+
+		const closeStream = () => stream.close()
+		this.controller.signal.addEventListener("abort", closeStream)
+
+		let successCount = 0
+		let failureCount = 0
+
+		// this is the callback passed to `sync`, invoked per MST sync message
+		const handleMessage = async (hash: Buffer, data: Uint8Array, message: BinaryMessage) => {
+			const id = toHex(hash)
+			if (this.options.verbose) {
+				console.log(chalk.green(`[canvas-core] Received missing ${message.type} ${id}.`))
+			}
+
+			try {
+				await this.applyMessage(hash, message)
+				this.insertMessage(hash, message)
+				await this.publishMessage(hash, data)
+				successCount += 1
+			} catch (err) {
+				console.log(chalk.red(`[canvas-core] Failed to apply message ${id}.`), err)
+				failureCount += 1
+			}
+		}
+
+		try {
+			await sync(this.mst, stream, handleMessage)
+		} catch (err) {
+			console.log(chalk.red(`[canvas-core] Failed to sync with peer ${peer.toString()}.`), err)
+		} finally {
+			this.controller.signal.removeEventListener("abort", closeStream)
+		}
+
+		console.log(
+			`[canvas-core] Sync with ${peer.toString()} completed. Applied ${successCount} new messages with ${failureCount} failures.`
+		)
+
+		if (this.options.verbose) {
+			console.log(`[canvas-core] Closed outgoing stream ${stream.id}.`)
+		}
+	}
+}

--- a/packages/core/src/vm/vm.ts
+++ b/packages/core/src/vm/vm.ts
@@ -509,17 +509,5 @@ function validate<T>(type: t.Type<T>, value: any, message?: string): T {
 	}
 }
 
-function parseFunctionParameters(source: string): string[] {
-	return source
-		.replace(/[/][/].*$/gm, "") // strip single-line comments
-		.replace(/\s+/g, "") // strip white space
-		.replace(/[/][*][^/*]*[*][/]/g, "") // strip multi-line comments
-		.split("){", 1)[0]
-		.replace(/^[^(]*[(]/, "") // extract the parameters
-		.replace(/=[^,]+/g, "") // strip any ES6 defaults
-		.split(",")
-		.filter(Boolean) // split & filter [""]
-}
-
 const assertPattern = (value: string, pattern: RegExp, message: string) =>
 	assert(pattern.test(value), `${message}: ${JSON.stringify(value)} does not match pattern ${pattern.source}`)

--- a/packages/core/src/websockets.ts
+++ b/packages/core/src/websockets.ts
@@ -64,12 +64,10 @@ export function setupWebsockets(server: Server, core: Core): Server {
 				component,
 				actions,
 				routes: Object.keys(routes),
-				peers: core.libp2p
-					? {
-							gossip: Object.fromEntries(core.recentGossipSubPeers),
-							backlog: Object.fromEntries(core.recentBacklogSyncPeers),
-					  }
-					: null,
+				peers: core.libp2p && {
+					gossip: Object.fromEntries(core.recentGossipPeers),
+					sync: Object.fromEntries(core.recentSyncPeers),
+				},
 			},
 		})
 		ws.send(message)

--- a/packages/core/test/source.test.ts
+++ b/packages/core/test/source.test.ts
@@ -1,0 +1,3 @@
+import test from "ava"
+
+test("Nothin", (t) => t.pass())

--- a/packages/hooks/src/CanvasContext.ts
+++ b/packages/hooks/src/CanvasContext.ts
@@ -10,8 +10,8 @@ export interface ApplicationData {
 	routes: string[]
 	peers: {
 		gossip: Record<string, { lastSeen: number }>
-		backlog: Record<string, { lastSeen: number }>
-	}
+		sync: Record<string, { lastSeen: number }>
+	} | null
 }
 
 export interface CanvasContextValue {

--- a/packages/interfaces/src/sessions.ts
+++ b/packages/interfaces/src/sessions.ts
@@ -13,9 +13,9 @@ export type SessionPayload = {
 	timestamp: number
 	address: string
 	duration: number
-	blockhash: string | null
 	chain: Chain
 	chainId: ChainId
+	blockhash: string | null
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Split the p2p and MST sync services out of `Core` and into a `Source` class that can be instantiated for multiple sources. Unit tests pass and I tested chat-webpack on two local machines.

## How has this been tested?
- [x] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This includes a **breaking change to the message store schema**, adding a nullable `source BLOB` / `{ ... source: Buffer | null }` property to both actions and sessions. The plan is for this to be null for all actions and sessions signed for the "root" spec, and for messages signed for a source for it to be the bytes of the source's CID.