### PR TITLE
disconnect button should deselect current session

### DIFF
--- a/packages/hooks/src/useCanvasSigner.ts
+++ b/packages/hooks/src/useCanvasSigner.ts
@@ -1,13 +1,12 @@
 import { useState, useEffect } from "react"
-import ethers from "ethers"
+import { ethers } from "ethers"
 import { SessionSigner, MetaMaskEthereumSigner } from "@canvas-js/signers"
 
-export const useCanvasSigner = (ethersSigner: ethers.providers.JsonRpcSigner, network: ethers.providers.Network) => {
+export const useCanvasSigner = (ethersSigner: ethers.providers.JsonRpcSigner, network?: ethers.providers.Network) => {
 	const [signer, setSigner] = useState<SessionSigner | null>(null)
 
 	useEffect(() => {
-		if (!ethersSigner || !network) return
-		const newSigner = new MetaMaskEthereumSigner(ethersSigner, network)
+		const newSigner = !ethersSigner || !network ? null : new MetaMaskEthereumSigner(ethersSigner, network)
 		setSigner(newSigner)
 	}, [ethersSigner, network !== undefined])
 


### PR DESCRIPTION
https://linear.app/canvasxyz/issue/CAN-45/disconnect-button-doesnt-log-out-session

## Description
The cause of this bug was that when we click "Disconnect", the session signer would stay selected in the `useCanvasSigner` hook.  

## How has this been tested?
- [x] CI tests pass
- [x] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
