### PR TITLE
Add appName export to specs and signers/verifiers

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -25,6 +25,7 @@ export function getAPI(core: Core, options: Partial<Options> = {}): express.Expr
 		const { component, routes, actions } = core.vm
 		return res.json({
 			uri: core.uri,
+			appName: core.appName,
 			cid: core.cid.toString(),
 			peerId: core.libp2p?.peerId.toString(),
 			component,

--- a/packages/core/src/codecs.ts
+++ b/packages/core/src/codecs.ts
@@ -36,6 +36,7 @@ export const actionArgumentType: t.Type<ActionArgument> = t.union([t.null, t.boo
 export const actionPayloadType: t.Type<ActionPayload> = t.type({
 	from: t.string,
 	app: t.string,
+	appName: t.string,
 	timestamp: t.number,
 	call: t.string,
 	callArgs: t.record(t.string, actionArgumentType),
@@ -54,6 +55,7 @@ export const actionType: t.Type<Action> = t.type({
 export const sessionPayloadType: t.Type<SessionPayload> = t.type({
 	from: t.string,
 	app: t.string,
+	appName: t.string,
 	sessionAddress: t.string,
 	sessionDuration: t.number,
 	sessionIssued: t.number,

--- a/packages/core/src/encoding.ts
+++ b/packages/core/src/encoding.ts
@@ -13,15 +13,15 @@ import { signalInvalidType } from "./utils.js"
 const { hexlify, arrayify } = ethers.utils
 
 const binaryActionPayloadType = t.type({
-	call: t.string,
-	callArgs: t.record(t.string, actionArgumentType),
-	from: uint8ArrayType,
 	app: t.string,
 	appName: t.string,
-	timestamp: t.number,
+	block: t.union([t.null, uint8ArrayType]),
+	call: t.string,
+	callArgs: t.record(t.string, actionArgumentType),
 	chain: chainType,
 	chainId: chainIdType,
-	block: t.union([t.null, uint8ArrayType]),
+	from: uint8ArrayType,
+	timestamp: t.number,
 })
 
 export const binaryActionType = t.type({
@@ -34,15 +34,15 @@ export const binaryActionType = t.type({
 export type BinaryAction = t.TypeOf<typeof binaryActionType>
 
 const binarySessionPayloadType = t.type({
-	from: uint8ArrayType,
 	app: t.string,
 	appName: t.string,
+	block: t.union([t.null, uint8ArrayType]),
+	chain: chainType,
+	chainId: chainIdType,
+	from: uint8ArrayType,
 	sessionAddress: uint8ArrayType,
 	sessionDuration: t.number,
 	sessionIssued: t.number,
-	chain: chainType,
-	chainId: chainIdType,
-	block: t.union([t.null, uint8ArrayType]),
 })
 
 export const binarySessionType = t.type({
@@ -127,14 +127,18 @@ export function fromBinaryMessage(binaryMessage: BinaryMessage): Message {
 	}
 }
 
-export const encodeBinaryMessage = (message: BinaryMessage) => cbor.encode(message)
+export function encodeBinaryMessage(binaryMessage: BinaryMessage): Uint8Array {
+	if (!binaryMessageType.is(binaryMessage)) {
+		throw new Error("invalid message")
+	}
+	return cbor.encode(binaryMessage)
+}
 
 export function decodeBinaryMessage(data: Uint8Array): BinaryMessage {
 	const binaryMessage = cbor.decode(data)
 	if (!binaryMessageType.is(binaryMessage)) {
 		throw new Error("invalid message")
 	}
-
 	return binaryMessage
 }
 

--- a/packages/core/src/encoding.ts
+++ b/packages/core/src/encoding.ts
@@ -17,6 +17,7 @@ const binaryActionPayloadType = t.type({
 	callArgs: t.record(t.string, actionArgumentType),
 	from: uint8ArrayType,
 	app: t.string,
+	appName: t.string,
 	timestamp: t.number,
 	chain: chainType,
 	chainId: chainIdType,
@@ -35,6 +36,7 @@ export type BinaryAction = t.TypeOf<typeof binaryActionType>
 const binarySessionPayloadType = t.type({
 	from: uint8ArrayType,
 	app: t.string,
+	appName: t.string,
 	sessionAddress: uint8ArrayType,
 	sessionDuration: t.number,
 	sessionIssued: t.number,

--- a/packages/core/src/messageStore.ts
+++ b/packages/core/src/messageStore.ts
@@ -12,6 +12,7 @@ import { encodeAddress } from "./chains/index.js"
 type ActionRecord = {
 	hash: Buffer
 	signature: Buffer
+	// action payload
 	from_address: Buffer
 	session_address: Buffer | null
 	timestamp: number
@@ -20,12 +21,14 @@ type ActionRecord = {
 	chain: Chain
 	chain_id: ChainId
 	block: Buffer | null
-	source: Buffer | null
+	source: Buffer | null // source instead of app hash
+	app_name: string
 }
 
 type SessionRecord = {
 	hash: Buffer
 	signature: Buffer
+	// session payload
 	from_address: Buffer
 	session_address: Buffer
 	session_duration: number
@@ -33,7 +36,8 @@ type SessionRecord = {
 	chain: Chain
 	chain_id: ChainId
 	block: Buffer | null
-	source: Buffer | null
+	source: Buffer | null // source instead of app hash
+	app_name: string
 }
 
 /**
@@ -109,6 +113,7 @@ export class MessageStore {
 			chain_id: action.payload.chainId,
 			block: action.payload.block ? toBuffer(action.payload.block) : null,
 			source: sourceCID ? toBuffer(sourceCID.bytes) : null,
+			app_name: action.payload.appName,
 		}
 
 		this.statements.insertAction.run(record)
@@ -132,6 +137,7 @@ export class MessageStore {
 			chain: session.payload.chain,
 			chain_id: session.payload.chainId,
 			source: sourceCID ? toBuffer(sourceCID.bytes) : null,
+			app_name: session.payload.appName,
 		}
 
 		this.statements.insertSession.run(record)
@@ -149,6 +155,7 @@ export class MessageStore {
 			session: record.session_address,
 			payload: {
 				app: this.uri,
+				appName: record.app_name,
 				from: record.from_address,
 				call: record.call,
 				callArgs: cbor.decode(record.call_args) as Record<string, ActionArgument>,
@@ -197,6 +204,7 @@ export class MessageStore {
 			signature: record.signature,
 			payload: {
 				app: this.uri,
+				appName: record.app_name,
 				from: record.from_address,
 				sessionAddress: record.session_address,
 				sessionDuration: record.session_duration,

--- a/packages/core/src/messageStore.ts
+++ b/packages/core/src/messageStore.ts
@@ -249,7 +249,8 @@ export class MessageStore {
 		chain           TEXT    NOT NULL,
     chain_id        TEXT    NOT NULL,
     block           BLOB,
-		source          BLOB
+    source          BLOB,
+    app_name        TEXT    NOT NULL
   );`
 
 	private static createSessionsTable = `CREATE TABLE IF NOT EXISTS sessions (
@@ -263,19 +264,20 @@ export class MessageStore {
 		chain            TEXT    NOT NULL,
     chain_id         TEXT    NOT NULL,
     block            BLOB,
-		source           BLOB
+		source           BLOB,
+    app_name         TEXT    NOT NULL
   );`
 
 	private static statements = {
 		insertAction: `INSERT INTO actions (
-      hash, signature, session_address, from_address, timestamp, call, call_args, chain, chain_id, block, source
+      hash, signature, session_address, from_address, timestamp, call, call_args, chain, chain_id, block, source, app_name
     ) VALUES (
-      :hash, :signature, :session_address, :from_address, :timestamp, :call, :call_args, :chain, :chain_id, :block, :source
+      :hash, :signature, :session_address, :from_address, :timestamp, :call, :call_args, :chain, :chain_id, :block, :source, :app_name
     )`,
 		insertSession: `INSERT INTO sessions (
-      hash, signature, from_address, session_address, session_duration, session_issued, chain, chain_id, block, source
+      hash, signature, from_address, session_address, session_duration, session_issued, chain, chain_id, block, source, app_name
     ) VALUES (
-      :hash, :signature, :from_address, :session_address, :session_duration, :session_issued, :chain, :chain_id, :block, :source
+      :hash, :signature, :from_address, :session_address, :session_duration, :session_issued, :chain, :chain_id, :block, :source, :app_name
     )`,
 		getActionByHash: `SELECT * FROM actions WHERE hash = :hash`,
 		getSessionByHash: `SELECT * FROM sessions WHERE hash = :hash`,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -101,13 +101,16 @@ function compileActionHandlers<Models extends Record<string, Model>>(actions: Re
 }
 
 export async function compileSpec<Models extends Record<string, Model>>(exports: {
+	name: string
 	models: Models
 	actions: Record<string, ActionHandler<Models>>
 	routes?: Record<string, (params: Record<string, string>, db: RouteContext) => Query>
 	contracts?: Record<string, { chain: Chain; chainId: ChainId; address: string; abi: string[] }>
 	sources?: Record<string, Record<string, ActionHandler<Models>>>
-}): Promise<{ uri: string; app: string }> {
-	const { models, actions, routes, contracts, sources } = exports
+}): Promise<{ uri: string; app: string; appName: string }> {
+	const { name, models, actions, routes, contracts, sources } = exports
+
+	const appName = name || "Canvas App"
 
 	const actionEntries = compileActionHandlers(actions)
 
@@ -119,6 +122,7 @@ export async function compileSpec<Models extends Record<string, Model>>(exports:
 	})
 
 	const lines = [
+		`export const name = ${JSON.stringify(appName)};`,
 		`export const models = ${JSON.stringify(models, null, "\t")};`,
 		`export const actions = {\n${actionEntries.join(",\n")}};`,
 	]
@@ -142,7 +146,7 @@ export async function compileSpec<Models extends Record<string, Model>>(exports:
 
 	const app = lines.join("\n")
 	const cid = await Hash.of(app)
-	return { uri: `ipfs://${cid}`, app }
+	return { uri: `ipfs://${cid}`, app, appName }
 }
 
 export class AbortError extends Error {

--- a/packages/core/src/vm/exports.ts
+++ b/packages/core/src/vm/exports.ts
@@ -3,6 +3,7 @@ import { ContractMetadata, Model } from "@canvas-js/interfaces"
 import { QuickJSHandle } from "quickjs-emscripten"
 
 export type Exports = {
+	name: string | null
 	actionHandles: Record<string, QuickJSHandle>
 	contractMetadata: Record<string, ContractMetadata>
 	component: string | null

--- a/packages/core/src/vm/validate.ts
+++ b/packages/core/src/vm/validate.ts
@@ -17,6 +17,7 @@ export function validateCanvasSpec(
 	moduleHandle: QuickJSHandle
 ): { exports: Exports | null; errors: string[]; warnings: string[] } {
 	const {
+		name: nameHandle,
 		models: modelsHandle,
 		routes: routesHandle,
 		actions: actionsHandle,
@@ -41,6 +42,7 @@ export function validateCanvasSpec(
 	}
 
 	const exports: Exports = {
+		name: null,
 		models: {},
 		contractMetadata: {},
 		component: null,
@@ -52,6 +54,14 @@ export function validateCanvasSpec(
 	for (const [name, handle] of Object.entries(rest)) {
 		warnings.push(`extraneous export \`${name}\``)
 		handle.dispose()
+	}
+
+	// validate name
+	if (nameHandle) {
+		assertLogError(context.typeof(nameHandle) === "string", "`name` export must be a string if provided")
+		exports.name = nameHandle.consume(context.dump)
+	} else {
+		exports.name = null
 	}
 
 	// validate models

--- a/packages/core/src/vm/vm.ts
+++ b/packages/core/src/vm/vm.ts
@@ -122,6 +122,7 @@ export class VM {
 		return result
 	}
 
+	public readonly appName: string
 	public readonly models: Record<string, Model>
 	public readonly actions: string[]
 	public readonly component: string | null
@@ -152,6 +153,8 @@ export class VM {
 		this.routeHandles = exports.routeHandles
 		this.actionHandles = exports.actionHandles
 		this.sourceHandles = exports.sourceHandles
+
+		this.appName = exports.name || "Canvas"
 		this.component = exports.component
 
 		// Generate public fields that are derived from the passed in arguments
@@ -292,6 +295,7 @@ export class VM {
 		this.contractsHandle.dispose()
 
 		disposeExports({
+			name: this.appName,
 			actionHandles: this.actionHandles,
 			component: this.component,
 			contractMetadata: this.contractMetadata,

--- a/packages/core/src/websockets.ts
+++ b/packages/core/src/websockets.ts
@@ -59,6 +59,7 @@ export function setupWebsockets(server: Server, core: Core): Server {
 			action: "application",
 			data: {
 				uri: core.uri,
+				appName: core.appName,
 				cid: core.cid.toString(),
 				peerId: core.libp2p?.peerId.toString(),
 				component,

--- a/packages/core/test/contracts.test.ts
+++ b/packages/core/test/contracts.test.ts
@@ -17,7 +17,8 @@ test("contracts (milady balanceOf)", async (t) => {
 		return
 	}
 
-	const { uri, app } = await compileSpec({
+	const { uri, app, appName } = await compileSpec({
+		name: "Test App",
 		models: {},
 		actions: {
 			async verify({}, { contracts, from }) {
@@ -41,7 +42,7 @@ test("contracts (milady balanceOf)", async (t) => {
 	const providers = { [`ethereum:${ETH_CHAIN_ID}`]: provider }
 	const core = await Core.initialize({ directory: null, uri, app, providers, offline: true })
 
-	const signer = new TestSigner(uri, provider)
+	const signer = new TestSigner(uri, appName, provider)
 
 	const action = await signer.sign("verify", {})
 	await t.throwsAsync(core.applyAction(action), { message: "balance is zero!" })

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -6,7 +6,8 @@ import { Core, ApplicationError, compileSpec } from "@canvas-js/core"
 
 import { TestSessionSigner, TestSigner } from "./utils.js"
 
-const { app, uri } = await compileSpec({
+const { app, uri, appName } = await compileSpec({
+	name: "Test App",
 	models: {
 		threads: { id: "string", title: "string", link: "string", creator: "string", updated_at: "datetime" },
 		thread_votes: {
@@ -35,7 +36,7 @@ const { app, uri } = await compileSpec({
 	},
 })
 
-const signer = new TestSigner(uri)
+const signer = new TestSigner(uri, appName)
 const sessionSigner = new TestSessionSigner(signer)
 
 test("Apply signed action", async (t) => {
@@ -161,7 +162,7 @@ test("Apply an action that throws an error", async (t) => {
 
 test("Create an in-memory Core with a file:// URI", async (t) => {
 	const uri = "file:///dev/null"
-	const signer = new TestSigner(uri)
+	const signer = new TestSigner(uri, appName)
 	const core = await Core.initialize({ uri, app, directory: null, unchecked: true })
 	const newThreadAction = await signer.sign("newThread", { title: "Hacker News", link: "https://news.ycombinator.com" })
 	const { hash: threadId } = await core.applyAction(newThreadAction)

--- a/packages/core/test/deletes.test.ts
+++ b/packages/core/test/deletes.test.ts
@@ -4,7 +4,8 @@ import { Core, compileSpec } from "@canvas-js/core"
 
 import { TestSigner } from "./utils.js"
 
-const { uri, app } = await compileSpec({
+const { uri, app, appName } = await compileSpec({
+	name: "Test App",
 	models: { threads: { id: "string", title: "string", link: "string", creator: "string", updated_at: "datetime" } },
 	actions: {
 		newThread({ title, link }, { db, hash, from }) {
@@ -19,7 +20,7 @@ const { uri, app } = await compileSpec({
 		},
 	},
 })
-const signer = new TestSigner(uri)
+const signer = new TestSigner(uri, appName)
 
 test("Test setting and then deleting a record", async (t) => {
 	const core = await Core.initialize({ uri, directory: null, app, unchecked: true, offline: true })

--- a/packages/core/test/globals.test.ts
+++ b/packages/core/test/globals.test.ts
@@ -5,7 +5,8 @@ import { compileSpec, Core } from "@canvas-js/core"
 
 import { TestSigner } from "./utils.js"
 
-const { app, uri } = await compileSpec({
+const { app, uri, appName } = await compileSpec({
+	name: "Test App",
 	models: {},
 	actions: {
 		async logIP() {
@@ -20,7 +21,7 @@ const { app, uri } = await compileSpec({
 	},
 })
 
-const signer = new TestSigner(uri)
+const signer = new TestSigner(uri, appName)
 
 test("test fetch() and log IP address", async (t) => {
 	const core = await Core.initialize({ uri, app, directory: null, unchecked: true, offline: true })

--- a/packages/core/test/sources.test.ts
+++ b/packages/core/test/sources.test.ts
@@ -8,6 +8,7 @@ import { TestSigner } from "./utils.js"
 import { fromHex, parseIPFSURI, toBuffer } from "@canvas-js/core/lib/utils.js"
 
 const MessageBoard = await compileSpec({
+	name: "Test App",
 	models: {
 		posts: { id: "string", content: "string", from: "string", updated_at: "datetime" },
 	},
@@ -20,6 +21,7 @@ const MessageBoard = await compileSpec({
 })
 
 const MessageBoardWithVotes = await compileSpec({
+	name: "Test App 2",
 	models: {
 		posts: { id: "string", content: "string", from: "string", updated_at: "datetime" },
 		votes: {
@@ -50,8 +52,8 @@ const MessageBoardWithVotes = await compileSpec({
 	},
 })
 
-const signer = new TestSigner(MessageBoardWithVotes.uri)
-const sourceSigner = new TestSigner(MessageBoard.uri)
+const signer = new TestSigner(MessageBoardWithVotes.uri, MessageBoardWithVotes.appName)
+const sourceSigner = new TestSigner(MessageBoard.uri, MessageBoard.appName)
 
 test("Apply source actions", async (t) => {
 	const core = await Core.initialize({

--- a/packages/core/test/sources.test.ts
+++ b/packages/core/test/sources.test.ts
@@ -120,6 +120,7 @@ test("Apply source actions", async (t) => {
 			chain_id: "1",
 			block: null,
 			source: toBuffer(sourceCID.bytes),
+			app_name: "Test App",
 		},
 		{
 			id: 2,
@@ -134,6 +135,7 @@ test("Apply source actions", async (t) => {
 			chain_id: "1",
 			block: null,
 			source: null,
+			app_name: "Test App 2",
 		},
 		{
 			id: 3,
@@ -148,6 +150,7 @@ test("Apply source actions", async (t) => {
 			chain_id: "1",
 			block: null,
 			source: null,
+			app_name: "Test App 2",
 		},
 		{
 			id: 4,
@@ -162,6 +165,7 @@ test("Apply source actions", async (t) => {
 			chain_id: "1",
 			block: null,
 			source: null,
+			app_name: "Test App 2",
 		},
 	])
 

--- a/packages/core/test/sqlite.test.ts
+++ b/packages/core/test/sqlite.test.ts
@@ -4,7 +4,8 @@ import { Core, compileSpec } from "@canvas-js/core"
 
 import { TestSigner } from "./utils.js"
 
-const { app, uri } = await compileSpec({
+const { app, uri, appName } = await compileSpec({
+	name: "Test App",
 	models: {
 		threads: { id: "string", title: "string", link: "string", creator: "string", updated_at: "datetime" },
 		thread_votes: {
@@ -55,7 +56,7 @@ const { app, uri } = await compileSpec({
 	},
 })
 
-const signer = new TestSigner(uri)
+const signer = new TestSigner(uri, appName)
 
 test("get /all", async (t) => {
 	const core = await Core.initialize({ uri, app, directory: null, unchecked: true, offline: true })

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -21,7 +21,8 @@ import { handleIncomingStream, sync } from "@canvas-js/core/lib/rpc/index.js"
 
 import { TestSigner } from "./utils.js"
 
-const { uri, app } = await compileSpec({
+const { uri, app, appName } = await compileSpec({
+	name: "Test App",
 	models: {},
 	actions: { log: ({ message }, {}) => console.log(message) },
 })
@@ -97,7 +98,7 @@ async function testSync(sourceMessages: Message[], targetMessages: Message[]): P
 	}
 }
 
-const signer = new TestSigner(uri)
+const signer = new TestSigner(uri, appName)
 
 test("sync two MSTs", async (t) => {
 	const a = await signer.sign("log", { message: "a" })

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -14,7 +14,7 @@ export class TestSigner {
 			appName: this.appName,
 			call,
 			callArgs,
-			timestamp: Date.now(),
+			timestamp: +Date.now(),
 			chain: "ethereum",
 			chainId: "1",
 			block: null,
@@ -38,8 +38,8 @@ export class TestSessionSigner {
 	async session(): Promise<Session> {
 		const sessionPayload: SessionPayload = {
 			sessionAddress: this.wallet.address,
-			sessionDuration: 60 * 60 * 24,
-			sessionIssued: Date.now(),
+			sessionDuration: 60 * 60 * 24 * 1000,
+			sessionIssued: +Date.now(),
 			from: this.signer.wallet.address,
 			app: this.signer.uri,
 			appName: this.signer.appName,

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -5,12 +5,13 @@ import { ethers } from "ethers"
 
 export class TestSigner {
 	readonly wallet = ethers.Wallet.createRandom()
-	constructor(readonly uri: string, readonly provider?: EthereumBlockProvider) {}
+	constructor(readonly uri: string, readonly appName: string, readonly provider?: EthereumBlockProvider) {}
 
 	async sign(call: string, callArgs: Record<string, ActionArgument>): Promise<Action> {
 		const actionPayload: ActionPayload = {
 			from: this.wallet.address,
 			app: this.uri,
+			appName: this.appName,
 			call,
 			callArgs,
 			timestamp: Date.now(),
@@ -41,6 +42,7 @@ export class TestSessionSigner {
 			sessionIssued: Date.now(),
 			from: this.signer.wallet.address,
 			app: this.signer.uri,
+			appName: this.signer.appName,
 			chain: "ethereum",
 			chainId: "1",
 			block: null,
@@ -60,6 +62,7 @@ export class TestSessionSigner {
 		const actionPayload: ActionPayload = {
 			from: this.signer.wallet.address,
 			app: this.signer.uri,
+			appName: this.signer.appName,
 			call,
 			callArgs,
 			timestamp: Date.now(),

--- a/packages/hooks/src/CanvasContext.ts
+++ b/packages/hooks/src/CanvasContext.ts
@@ -4,6 +4,7 @@ import { createContext } from "react"
 export interface ApplicationData {
 	cid: string
 	uri: string
+	appName: string
 	peerId: string | null
 	component: string | null
 	actions: string[]

--- a/packages/hooks/src/useCanvas.ts
+++ b/packages/hooks/src/useCanvas.ts
@@ -68,6 +68,7 @@ export function useCanvas(): {
 				const payload: ActionPayload = {
 					from: address,
 					app: data.uri,
+					appName: data.appName,
 					call,
 					callArgs: args,
 					timestamp,

--- a/packages/hooks/src/useSession.ts
+++ b/packages/hooks/src/useSession.ts
@@ -113,6 +113,7 @@ export function useSession(signer: SessionSigner | null): {
 			const payload: SessionPayload = {
 				from: signerAddress,
 				app: data.uri,
+				appName: data.appName,
 				sessionAddress: actionSigner.address,
 				sessionDuration,
 				sessionIssued: timestamp,

--- a/packages/interfaces/src/actions.ts
+++ b/packages/interfaces/src/actions.ts
@@ -19,6 +19,7 @@ export type Action = {
 	type: "action"
 	payload: {
 		app: string
+		appName: string
 		block: string | null
 		call: string
 		callArgs: Record<string, ActionArgument>

--- a/packages/interfaces/src/sessions.ts
+++ b/packages/interfaces/src/sessions.ts
@@ -10,6 +10,7 @@ export type Session = {
 	type: "session"
 	payload: {
 		app: string
+		appName: string
 		block: string | null
 		chain: Chain
 		chainId: string

--- a/packages/signers/test/ethereum.test.ts
+++ b/packages/signers/test/ethereum.test.ts
@@ -10,9 +10,11 @@ test("Sign an action for ethereum", async (t) => {
 	const childWallet = ethers.Wallet.createRandom()
 	const signer = new EthereumActionSigner(childWallet)
 
+	const appName = "Test App"
 	const payload: ActionPayload = {
 		from: parentWallet.address,
 		app: "ipfs://something.spec.js",
+		appName: "Test App",
 		call: "post",
 		callArgs: { title: "Hello world!", text: "Lorem ipsum dolor sit amet" },
 		timestamp: 123456789,

--- a/packages/verifiers/src/ethereum/verify_ethereum.ts
+++ b/packages/verifiers/src/ethereum/verify_ethereum.ts
@@ -79,13 +79,10 @@ type SignatureData<PayloadType> = [TypedDataDomain, Record<string, TypedDataFiel
 /**
  * `getSessionSignatureData` gets EIP-712 signing data to start a session
  */
-export function getSessionSignatureData(
-	payload: SessionPayload,
-	appName: string = "Canvas"
-): SignatureData<SessionPayload> {
+export function getSessionSignatureData(payload: SessionPayload): SignatureData<SessionPayload> {
 	const domain = {
-		name: appName,
-		salt: utils.hexlify(utils.zeroPad(utils.arrayify(payload.from), 32)),
+		name: payload.appName,
+		salt: utils.hexlify(utils.zeroPad(utils.arrayify(0), 32)),
 	}
 
 	// Rewrite fields with custom serializations. EIP-712 does not

--- a/packages/verifiers/src/ethereum/verify_ethereum.ts
+++ b/packages/verifiers/src/ethereum/verify_ethereum.ts
@@ -22,6 +22,7 @@ import {
 const actionDataFields = {
 	Message: [
 		{ name: "app", type: "string" },
+		{ name: "appName", type: "string" },
 		{ name: "block", type: "string" },
 		{ name: "call", type: "string" },
 		{ name: "callArgs", type: "string" },
@@ -35,11 +36,11 @@ const actionDataFields = {
 /**
  * `getActionSignatureData` gets EIP-712 signing data for an individual action
  */
-export function getActionSignatureData(
-	payload: ActionPayload
-): SignatureData<Omit<ActionPayload, "callArgs"> & { callArgs: string }> {
+type ActionPayloadSignable = Omit<ActionPayload, "callArgs"> & { callArgs: string }
+
+export function getActionSignatureData(payload: ActionPayload): SignatureData<ActionPayloadSignable> {
 	const domain = {
-		name: "Canvas",
+		name: payload.appName,
 		salt: utils.hexlify(utils.zeroPad(utils.arrayify(0), 32)),
 	}
 
@@ -62,6 +63,7 @@ export function getActionSignatureData(
 const sessionDataFields = {
 	Message: [
 		{ name: "app", type: "string" },
+		{ name: "appName", type: "string" },
 		{ name: "block", type: "string" },
 		{ name: "chain", type: "string" },
 		{ name: "chainId", type: "string" },
@@ -77,9 +79,12 @@ type SignatureData<PayloadType> = [TypedDataDomain, Record<string, TypedDataFiel
 /**
  * `getSessionSignatureData` gets EIP-712 signing data to start a session
  */
-export function getSessionSignatureData(payload: SessionPayload): SignatureData<SessionPayload> {
+export function getSessionSignatureData(
+	payload: SessionPayload,
+	appName: string = "Canvas"
+): SignatureData<SessionPayload> {
 	const domain = {
-		name: "Canvas",
+		name: appName,
 		salt: utils.hexlify(utils.zeroPad(utils.arrayify(payload.from), 32)),
 	}
 


### PR DESCRIPTION
Adds an `appName` export to specs, which is used to populate the domain field in EIP712 signing, and the app name field in SIWE/SIWx signing.

The appName is also included in ActionPayload and SessionPayload and made visible to the user in EIP712 (so the user actually signs data which contains it twice). If the user is signing a JSON payload, then it appears in the payload next to `app: [hash]`.

We do not check the appName when importing actions from sources (right now). 

## How has this been tested?
- [X] CI tests pass
- [X] Tested with chat-next (including login, all signers, and exchanging messages)
- [X] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other: