### PR TITLE
implement a consistent interface for canvas session object

### DIFF
--- a/packages/hooks/src/sessionKeyStorage.ts
+++ b/packages/hooks/src/sessionKeyStorage.ts
@@ -1,0 +1,50 @@
+import { getCanvasSessionKey } from "./utils.js"
+
+export type SessionObject = { app: string; sessionPrivateKey: string; expiration: number }
+
+function isSessionObject(obj: any): obj is SessionObject {
+	return (
+		typeof obj === "object" &&
+		typeof obj.app === "string" &&
+		typeof obj.sessionPrivateKey === "string" &&
+		typeof obj.expiration === "number"
+	)
+}
+
+export function getSessionObject(data: { uri: string }, signerAddress: string): SessionObject | null {
+	const sessionKey = getCanvasSessionKey(signerAddress)
+	const item = localStorage.getItem(sessionKey)
+	if (item === null) {
+		return null
+	}
+
+	let sessionObject: any
+	try {
+		sessionObject = JSON.parse(item)
+	} catch (err) {
+		localStorage.removeItem(sessionKey)
+		return null
+	}
+
+	if (!isSessionObject(sessionObject)) {
+		localStorage.removeItem(sessionKey)
+		return null
+	}
+
+	const { app, expiration } = sessionObject
+	if (data.uri !== app || expiration < Date.now()) {
+		localStorage.removeItem(sessionKey)
+		return null
+	}
+	return sessionObject
+}
+
+export function setSessionObject(signerAddress: string, sessionObject: SessionObject) {
+	const sessionKey = getCanvasSessionKey(signerAddress)
+	localStorage.setItem(sessionKey, JSON.stringify(sessionObject))
+}
+
+export function removeSessionObject(signerAddress: string) {
+	const sessionKey = getCanvasSessionKey(signerAddress)
+	localStorage.removeItem(sessionKey)
+}


### PR DESCRIPTION
We currently have some code in `useSession` that loads the session object from localStorage. We should move this to its own file with a simple and consistent interface.

## Description
This PR doesn't change any behaviour, it just moves some code around and renames some things.

Changes:
- Extract code for accessing session objects in localStorage to functions in `sessionKeyStorage.ts`
- Move `SessionObject` and `isSessionObject` to `sessionKeyStorage.ts`
- The function names are `{get/set/remove}SessionObject`. The verbs were chosen to be consistent with the `{set/set/remove}Item` functions in the localStorage API.

## How has this been tested?
- [x] CI tests pass
- [x] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
