### PR TITLE
Add first pass at chain-solana, chain-cosmos implementations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,19 @@
         "packages/next",
         "packages/hooks",
         "packages/chain-ethereum",
+        "packages/chain-cosmos",
         "packages/chain-solana",
         "examples/app-store",
         "examples/chat-webpack",
         "examples/chat-next"
-      ]
+      ],
+      "dependencies": {
+        "@cosmjs/amino": "^0.29.5",
+        "@cosmjs/crypto": "^0.29.5"
+      },
+      "devDependencies": {
+        "@keplr-wallet/types": "^0.11.38"
+      }
     },
     "examples/app-store": {
       "name": "@canvas-js/example-app-store",
@@ -1831,6 +1839,10 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@canvas-js/chain-cosmos": {
+      "resolved": "packages/chain-cosmos",
+      "link": true
+    },
     "node_modules/@canvas-js/chain-ethereum": {
       "resolved": "packages/chain-ethereum",
       "link": true
@@ -2020,6 +2032,54 @@
       "engines": {
         "node": ">=0.1.90"
       }
+    },
+    "node_modules/@cosmjs/amino": {
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.5.tgz",
+      "integrity": "sha512-Qo8jpC0BiziTSUqpkNatBcwtKNhCovUnFul9SlT/74JUCdLYaeG5hxr3q1cssQt++l4LvlcpF+OUXL48XjNjLw==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.29.5",
+        "@cosmjs/encoding": "^0.29.5",
+        "@cosmjs/math": "^0.29.5",
+        "@cosmjs/utils": "^0.29.5"
+      }
+    },
+    "node_modules/@cosmjs/crypto": {
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
+      "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.29.5",
+        "@cosmjs/math": "^0.29.5",
+        "@cosmjs/utils": "^0.29.5",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.4",
+        "libsodium-wrappers": "^0.7.6"
+      }
+    },
+    "node_modules/@cosmjs/encoding": {
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
+      "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "node_modules/@cosmjs/math": {
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
+      "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
+    "node_modules/@cosmjs/utils": {
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
+      "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2867,6 +2927,32 @@
         "@json-rpc-tools/types": "^1.7.6",
         "@pedrouid/environment": "^1.0.1"
       }
+    },
+    "node_modules/@keplr-wallet/types": {
+      "version": "0.11.38",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.38.tgz",
+      "integrity": "sha512-Lcfkh3OsQMdZ9zKQeV/P4tz+ig7SjKDIY9u5MdqairDAPLPCk4qenh9wDZguNW4CWzlW/FI1A/RqltqtJQGyLg==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.27.2",
+        "long": "^4.0.0"
+      }
+    },
+    "node_modules/@keplr-wallet/types/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@keplr-wallet/types/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "node_modules/@ledgerhq/connect-kit-loader": {
       "version": "1.0.2",
@@ -6330,6 +6416,12 @@
         "tslib": "^2.0.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -7384,6 +7476,18 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -8201,6 +8305,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -9413,6 +9526,20 @@
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -11377,6 +11504,19 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libsodium": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
+      "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
+      "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
+      "dependencies": {
+        "libsodium": "^0.7.0"
       }
     },
     "node_modules/lilconfig": {
@@ -14557,6 +14697,11 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readonly-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz",
+      "integrity": "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ=="
+    },
     "node_modules/real-require": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
@@ -17685,6 +17830,16 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "packages/chain-cosmos": {
+      "name": "@canvas-js/chain-cosmos",
+      "version": "0.0.50-pre4",
+      "dependencies": {
+        "safe-stable-stringify": "^2.4.2"
+      },
+      "devDependencies": {
+        "typescript": "^4.9.4"
       }
     },
     "packages/chain-ethereum": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "packages/next",
         "packages/hooks",
         "packages/chain-ethereum",
+        "packages/chain-solana",
         "examples/app-store",
         "examples/chat-webpack",
         "examples/chat-next"
@@ -1832,6 +1833,10 @@
     },
     "node_modules/@canvas-js/chain-ethereum": {
       "resolved": "packages/chain-ethereum",
+      "link": true
+    },
+    "node_modules/@canvas-js/chain-solana": {
+      "resolved": "packages/chain-solana",
       "link": true
     },
     "node_modules/@canvas-js/cli": {
@@ -4388,6 +4393,15 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==",
+      "dev": true,
+      "dependencies": {
+        "base-x": "^3.0.6"
       }
     },
     "node_modules/@types/connect": {
@@ -16451,6 +16465,11 @@
         "node": "*"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -17675,6 +17694,18 @@
         "safe-stable-stringify": "^2.4.2"
       },
       "devDependencies": {
+        "typescript": "^4.9.4"
+      }
+    },
+    "packages/chain-solana": {
+      "name": "@canvas-js/chain-solana",
+      "version": "0.0.50-pre4",
+      "dependencies": {
+        "safe-stable-stringify": "^2.4.2",
+        "tweetnacl": "^1.0.3"
+      },
+      "devDependencies": {
+        "@types/bs58": "^4.0.1",
         "typescript": "^4.9.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,9 +17,17 @@
     "packages/next",
     "packages/hooks",
     "packages/chain-ethereum",
+    "packages/chain-cosmos",
     "packages/chain-solana",
     "examples/app-store",
     "examples/chat-webpack",
     "examples/chat-next"
-  ]
+  ],
+  "dependencies": {
+    "@cosmjs/amino": "^0.29.5",
+    "@cosmjs/crypto": "^0.29.5"
+  },
+  "devDependencies": {
+    "@keplr-wallet/types": "^0.11.38"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "packages/next",
     "packages/hooks",
     "packages/chain-ethereum",
+    "packages/chain-solana",
     "examples/app-store",
     "examples/chat-webpack",
     "examples/chat-next"

--- a/packages/chain-cosmos/package.json
+++ b/packages/chain-cosmos/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@canvas-js/chain-cosmos",
+  "version": "0.0.50-pre4",
+  "type": "module",
+  "author": "Canvas Technology Corporation (https://canvas.xyz)",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "dependencies": {
+    "safe-stable-stringify": "^2.4.2"
+  },
+  "devDependencies": {
+    "typescript": "^4.9.4"
+  }
+}

--- a/packages/chain-cosmos/src/implementation.ts
+++ b/packages/chain-cosmos/src/implementation.ts
@@ -1,0 +1,135 @@
+import type { Window as KeplrWindow, OfflineAminoSigner } from "@keplr-wallet/types"
+import {
+	AminoMsg,
+	StdSignDoc,
+	StdFee,
+	Secp256k1Wallet,
+	serializeSignDoc,
+	decodeSignature,
+	rawSecp256k1PubkeyToRawAddress,
+} from "@cosmjs/amino"
+import { Secp256k1, Secp256k1Signature, Random, Sha256, ExtendedSecp256k1Signature } from "@cosmjs/crypto"
+import { Bech32 } from "@cosmjs/encoding"
+
+import type {
+	Action,
+	ActionPayload,
+	Chain,
+	ChainId,
+	ChainImplementation,
+	Session,
+	SessionPayload,
+} from "@canvas-js/interfaces"
+import { serializeActionPayload, serializeSessionPayload, getActionHash } from "@canvas-js/interfaces"
+import { getActionSignatureData, getSessionSignatureData } from "./signatureData"
+
+type Secp256k1WalletPrivateKey = Uint8Array
+
+/**
+ * Cosmos chain export.
+ */
+export class CosmosChainImplementation implements ChainImplementation<OfflineAminoSigner, Secp256k1WalletPrivateKey> {
+	public readonly chain: Chain = "cosmos"
+
+	constructor(public readonly chainId: ChainId = "mainnet") {}
+
+	async verifyAction(action: Action): Promise<void> {
+		const actionSignerAddress = action.session ?? action.payload.from
+		const signDocPayload = await getActionSignatureData(action.payload, actionSignerAddress)
+		const signDocDigest = new Sha256(serializeSignDoc(signDocPayload)).digest()
+		const prefix = "cosmos" // not: Bech32.decode(payload.from).prefix;
+
+		const signatureBytes = Buffer.from(action.signature, "hex")
+		const extendedSecp256k1Signature = ExtendedSecp256k1Signature.fromFixedLength(signatureBytes)
+		const pubkey = Secp256k1.compressPubkey(Secp256k1.recoverPubkey(extendedSecp256k1Signature, signDocDigest))
+
+		if (actionSignerAddress !== Bech32.encode(prefix, rawSecp256k1PubkeyToRawAddress(pubkey))) {
+			throw new Error("Invalid action signature")
+		}
+	}
+
+	async verifySession(session: Session): Promise<void> {
+		const signDocPayload = await getSessionSignatureData(session.payload, session.payload.from) // TODO
+		const signDocDigest = new Sha256(serializeSignDoc(signDocPayload)).digest()
+		const prefix = Bech32.decode(session.payload.from).prefix
+
+		// decode "{ pub_key, signature }" to an object with { pubkey, signature } using the amino helper
+		const { pubkey, signature: decodedSignature } = decodeSignature(JSON.parse(session.signature))
+		if (session.payload.from !== Bech32.encode(prefix, rawSecp256k1PubkeyToRawAddress(pubkey))) {
+			throw new Error("Session signed with a pubkey that doesn't match the session address")
+		}
+		const secpSignature = Secp256k1Signature.fromFixedLength(decodedSignature)
+		const valid = await Secp256k1.verifySignature(secpSignature, signDocDigest, pubkey)
+
+		if (!valid) {
+			throw new Error("Invalid session signature")
+		}
+	}
+
+	getSignerAddress = async (signer: OfflineAminoSigner) => {
+		return (await signer.getAccounts())[0].address
+	}
+	getDelegatedSignerAddress = async (privkey: Secp256k1WalletPrivateKey) => {
+		const wallet = await Secp256k1Wallet.fromKey(privkey)
+		return (await wallet.getAccounts())[0].address
+	}
+
+	isSigner(signer: unknown): signer is OfflineAminoSigner {
+		return !(signer instanceof ArrayBuffer)
+	}
+
+	isDelegatedSigner(delegatedSigner: unknown): delegatedSigner is Secp256k1WalletPrivateKey {
+		return delegatedSigner instanceof ArrayBuffer
+	}
+
+	async signSession(signer: OfflineAminoSigner, payload: SessionPayload): Promise<Session> {
+		const address = (await signer.getAccounts())[0].address
+		const signDoc = await getSessionSignatureData(payload, address)
+		// Note that this is a StdSignature, not an extended signature.
+		const {
+			signature: { pub_key, signature },
+		} = await signer.signAmino(address, signDoc)
+		const session: Session = { type: "session", signature, payload }
+		return session
+	}
+
+	async signAction(signer: OfflineAminoSigner, payload: ActionPayload): Promise<Action> {
+		const address = (await signer.getAccounts())[0].address
+		const signDoc = await getActionSignatureData(payload, address)
+		// Note that this is a StdSignature, not an extended signature.
+		// Delegated actions are signed with an extended signature. This method should return an
+		// extended signature too, so pubkey recovery is possible.
+		const {
+			signature: { pub_key, signature },
+		} = await signer.signAmino(address, signDoc)
+		const action: Action = { type: "action", payload, session: null, signature }
+		return action
+	}
+
+	async signDelegatedAction(privkey: Secp256k1WalletPrivateKey, payload: ActionPayload) {
+		const wallet = await Secp256k1Wallet.fromKey(privkey)
+		const accountData = (await wallet.getAccounts())[0]
+		if (accountData.address !== payload.from) {
+			throw new Error(`Signer address did not match payload.from: ${accountData.address} vs. ${payload.from}`)
+		}
+		const signDoc = serializeSignDoc(await getActionSignatureData(payload, accountData.address))
+		const digest = new Sha256(signDoc).digest()
+		const extendedSignature = await Secp256k1.createSignature(digest, privkey)
+		const signature = Buffer.from(extendedSignature.toFixedLength()).toString("hex")
+		const action: Action = { type: "action", payload, session: null, signature }
+		return action
+	}
+
+	importDelegatedSigner = (privkeyString: string) => Buffer.from(privkeyString, "hex")
+	exportDelegatedSigner = (privkey: Secp256k1WalletPrivateKey) => Buffer.from(privkey).toString("hex")
+	generateDelegatedSigner = async (): Promise<Secp256k1WalletPrivateKey> => {
+		// same entropy for generating private keys as @cosmjs/amino Secp256k1HdWallet
+		const entropyLength = 4 * Math.floor((11 * 24) / 33)
+		const privkeyBytes = Random.getBytes(entropyLength)
+		return privkeyBytes
+	}
+
+	async getLatestBlock(): Promise<string> {
+		throw new Error("Unimplemented")
+	}
+}

--- a/packages/chain-cosmos/src/index.ts
+++ b/packages/chain-cosmos/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./implementation.js"

--- a/packages/chain-cosmos/src/signatureData.ts
+++ b/packages/chain-cosmos/src/signatureData.ts
@@ -1,0 +1,48 @@
+import { configure } from "safe-stable-stringify"
+import type { AminoMsg, StdSignDoc, StdFee } from "@cosmjs/amino"
+import { makeSignDoc } from "@cosmjs/amino"
+import type { ActionPayload, SessionPayload } from "@canvas-js/interfaces"
+
+const jsonStableStringify = configure({ circularValue: Error, bigint: false, deterministic: true, strict: true })
+
+export const getActionSignatureData = async (actionPayload: ActionPayload, address: string): Promise<StdSignDoc> => {
+	const accountNumber = 0
+	const sequence = 0
+	const chainId = ""
+	const fee: StdFee = {
+		gas: "0",
+		amount: [],
+	}
+	const memo = ""
+
+	const jsonTx: AminoMsg = {
+		type: "sign/MsgSignData",
+		value: {
+			signer: address,
+			data: jsonStableStringify(actionPayload),
+		},
+	}
+	const signDoc = makeSignDoc([jsonTx], fee, chainId, memo, accountNumber, sequence)
+	return signDoc
+}
+
+export const getSessionSignatureData = async (sessionPayload: SessionPayload, address: string): Promise<StdSignDoc> => {
+	const accountNumber = 0
+	const sequence = 0
+	const chainId = ""
+	const fee: StdFee = {
+		gas: "0",
+		amount: [],
+	}
+	const memo = ""
+
+	const jsonTx: AminoMsg = {
+		type: "sign/MsgSignData",
+		value: {
+			signer: address,
+			data: jsonStableStringify(sessionPayload),
+		},
+	}
+	const signDoc = makeSignDoc([jsonTx], fee, chainId, memo, accountNumber, sequence)
+	return signDoc
+}

--- a/packages/chain-cosmos/tsconfig.json
+++ b/packages/chain-cosmos/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["src"],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "references": [
+    {"path": "../interfaces"}
+  ]
+}

--- a/packages/chain-ethereum/src/signatureData.ts
+++ b/packages/chain-ethereum/src/signatureData.ts
@@ -3,7 +3,7 @@ import { TypedDataDomain, TypedDataField, utils } from "ethers"
 import { ActionPayload, SessionPayload } from "@canvas-js/interfaces"
 
 import { configure } from "safe-stable-stringify"
-const serialize = configure({ circularValue: Error, bigint: false, deterministic: true, strict: true })
+const jsonStableStringify = configure({ circularValue: Error, bigint: false, deterministic: true, strict: true })
 
 /**
  * Ethereum compatible signer logic, used to generate and
@@ -44,7 +44,7 @@ export function getActionSignatureData(payload: ActionPayload): SignatureData<Ac
 	// enforced at runtime, call .toString() to be sure
 	const actionValue = {
 		...payload,
-		callArgs: serialize(payload.callArgs),
+		callArgs: jsonStableStringify(payload.callArgs),
 		chainId: payload.chainId.toString(),
 		block: payload.block || "",
 	}

--- a/packages/chain-solana/package.json
+++ b/packages/chain-solana/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@canvas-js/chain-solana",
+  "version": "0.0.50-pre4",
+  "type": "module",
+  "author": "Canvas Technology Corporation (https://canvas.xyz)",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "dependencies": {
+    "safe-stable-stringify": "^2.4.2",
+    "tweetnacl": "^1.0.3"
+  },
+  "devDependencies": {
+    "@types/bs58": "^4.0.1",
+    "typescript": "^4.9.4"
+  }
+}

--- a/packages/chain-solana/src/implementation.ts
+++ b/packages/chain-solana/src/implementation.ts
@@ -1,0 +1,119 @@
+import * as solw3 from "@solana/web3.js"
+import nacl from "tweetnacl"
+import bs58 from "bs58"
+
+import type {
+	Action,
+	ActionPayload,
+	Chain,
+	ChainId,
+	ChainImplementation,
+	Session,
+	SessionPayload,
+} from "@canvas-js/interfaces"
+import { serializeActionPayload, serializeSessionPayload, getActionHash } from "@canvas-js/interfaces"
+
+const getActionSignatureData = (payload: ActionPayload): Uint8Array => {
+	return new TextEncoder().encode(serializeActionPayload(payload))
+}
+const getSessionSignatureData = (payload: SessionPayload): Uint8Array => {
+	return new TextEncoder().encode(serializeSessionPayload(payload))
+}
+
+// Solana doesn't publish TypeScript signatures for injected wallets, but we can assume
+// most wallets expose a Phantom-like API and use their injected `window.solana` objects directly:
+// https://github.com/solana-labs/wallet-adapter/commit/5a274e0a32c55d4376d63a802f0d512947b087af
+interface SolanaWindowSigner {
+	isPhantom?: boolean
+	publicKey?: { toBytes(): Uint8Array }
+	isConnected: boolean
+	signMessage(message: Uint8Array): Promise<{ signature: Uint8Array }>
+	connect(): Promise<void>
+	disconnect(): Promise<void>
+	_handleDisconnect(...args: unknown[]): unknown
+}
+
+/**
+ * Solana chain export.
+ */
+export class SolanaChainImplementation implements ChainImplementation<SolanaWindowSigner, solw3.Keypair> {
+	public readonly chain: Chain = "solana"
+
+	constructor(public readonly chainId: ChainId = "mainnet") {}
+
+	async verifyAction(action: Action): Promise<void> {
+		const expectedAddress = action.session ?? action.payload.from
+		const message = getActionSignatureData(action.payload)
+		const signatureBytes = bs58.decode(action.signature)
+		const valid = nacl.sign.detached.verify(message, signatureBytes, bs58.decode(expectedAddress))
+		if (!valid) {
+			throw new Error("Invalid action signature")
+		}
+	}
+
+	async verifySession(session: Session): Promise<void> {
+		const expectedAddress = session.payload.from
+		const message = getSessionSignatureData(session.payload)
+		const signatureBytes = bs58.decode(session.signature)
+		const valid = nacl.sign.detached.verify(message, signatureBytes, bs58.decode(expectedAddress))
+		if (!valid) {
+			throw new Error("Invalid action signature")
+		}
+	}
+
+	getSignerAddress = async (signer: SolanaWindowSigner) => {
+		if (signer.publicKey === null || signer.publicKey === undefined) throw new Error("Wallet not connected")
+		return bs58.encode(signer.publicKey.toBytes())
+	}
+	getDelegatedSignerAddress = async (wallet: solw3.Keypair) => bs58.encode(wallet.publicKey.toBytes())
+
+	isSigner(signer: unknown): signer is SolanaWindowSigner {
+		return !(signer instanceof solw3.Keypair)
+	}
+
+	isDelegatedSigner(delegatedSigner: unknown): delegatedSigner is solw3.Keypair {
+		return delegatedSigner instanceof solw3.Keypair
+	}
+
+	async signSession(signer: SolanaWindowSigner, payload: SessionPayload): Promise<Session> {
+		if (signer.publicKey === null || signer.publicKey === undefined) throw new Error("Wallet not connected")
+		const address = bs58.encode(signer.publicKey.toBytes())
+		const message = getSessionSignatureData(payload)
+		const { signature: signatureBytes } = await signer.signMessage(message)
+
+		return { type: "session", payload, signature: bs58.encode(signatureBytes) }
+	}
+
+	async signAction(signer: SolanaWindowSigner, payload: ActionPayload): Promise<Action> {
+		if (signer.publicKey === null || signer.publicKey === undefined) throw new Error("Wallet not connected")
+		const address = bs58.encode(signer.publicKey.toBytes())
+		if (address !== payload.from) {
+			throw new Error("Signer address did not match payload.from")
+		}
+		const message = getActionSignatureData(payload)
+		const { signature: signatureBytes } = await signer.signMessage(message)
+
+		return { type: "action", payload: payload, session: null, signature: bs58.encode(signatureBytes) }
+	}
+
+	async signDelegatedAction(wallet: solw3.Keypair, payload: ActionPayload) {
+		const message = getActionSignatureData(payload)
+		const signatureBytes = nacl.sign.detached(message, wallet.secretKey)
+		const signature = bs58.encode(signatureBytes)
+		const action: Action = {
+			type: "action",
+			payload: payload,
+			session: bs58.encode(wallet.publicKey.toBytes()),
+			signature,
+		}
+		return action
+	}
+
+	importDelegatedSigner = (secretKey: string) => solw3.Keypair.fromSecretKey(bs58.decode(secretKey))
+	exportDelegatedSigner = (wallet: solw3.Keypair) => bs58.encode(wallet.secretKey)
+	generateDelegatedSigner = async (): Promise<solw3.Keypair> => solw3.Keypair.generate()
+
+	async getLatestBlock(): Promise<string> {
+		throw new Error("Unimplemented")
+	}
+}

--- a/packages/chain-solana/src/index.ts
+++ b/packages/chain-solana/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./implementation.js"

--- a/packages/chain-solana/tsconfig.json
+++ b/packages/chain-solana/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["src"],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "references": [
+    {"path": "../interfaces"}
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     { "path": "./packages/interfaces" },
     { "path": "./packages/hooks" },
     { "path": "./packages/chain-ethereum" },
+    { "path": "./packages/chain-cosmos" },
     { "path": "./packages/chain-solana" }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     { "path": "./packages/next" },
     { "path": "./packages/interfaces" },
     { "path": "./packages/hooks" },
-    { "path": "./packages/chain-ethereum" }
+    { "path": "./packages/chain-ethereum" },
+    { "path": "./packages/chain-solana" }
   ]
 }


### PR DESCRIPTION
Not tested yet, neither manually nor through automated tests.

Solana is the simplest ChainImplementation. We don't fetch blocks, and there is no unique signature format like Cosmos or Ethereum.

Based on Commonwealth code from https://github.com/hicommonwealth/commonwealth/pull/2430, including in particular:
- `packages/commonwealth/client/scripts/controllers/server/sessionSigners/solana.ts`
- `packages/commonwealth/client/scripts/controllers/app/webWallets/phantom_web_wallet.ts`


## Description

## How has this been tested?

- [X] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

This introduces new interfaces which have not yet been finalized (but hopefully will be within the next 1-2 weeks).
