### PR TITLE
Return appName in status endpoint

### DIFF
--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -170,6 +170,7 @@ type AppData = {
 	uri: string
 	cid: string
 	status: Status
+	appName?: string
 	models?: Record<string, Model>
 	actions?: string[]
 }
@@ -224,6 +225,7 @@ class Daemon {
 							uri: `ipfs://${cid}`,
 							cid,
 							status: app ? "running" : "stopped",
+							appName: app && app.core.vm.appName,
 							models: app && app.core.vm.models,
 							actions: app && app.core.vm.actions,
 						}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We need to make this change so that apps that generate sessions know what value to use in the `appName` field on the session payload.

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [x] Daemon API
- [ ] Command line arguments
- [ ] Contract language

Adds a new `appName` value to the `/app/` API endpoint response. This returns the `name` value that exported by the spec. This doesn't break anything because we are adding new data, but it's worth making a record of any changes we make to the API.