### PR TITLE
Upgrade okra

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13598,9 +13598,9 @@
       }
     },
     "node_modules/node-okra": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/node-okra/-/node-okra-0.0.1.tgz",
-      "integrity": "sha512-NnLUTfiduHQmS6KMBqDZMDgVd2E+0aykIsQtYUyDQe2OuoJcTffJayNLGJJn/v90vRXkDKLKlutqVl3O3Cz5gg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/node-okra/-/node-okra-0.1.0.tgz",
+      "integrity": "sha512-k0eP0TgF5DOat/rC7SRcLLHUaKIDj5WmVe/HeoQ1rKHVTmye98Pw+rryRFjRuXSe5BUuj5vVw+Dxwc7FEWqBJw==",
       "dependencies": {
         "detect-libc": "^2.0.1"
       }
@@ -18773,7 +18773,7 @@
         "it-stream-types": "^1.0.5",
         "libp2p": "^0.42.0",
         "multiformats": "^11.0.0",
-        "node-okra": "^0.0.1",
+        "node-okra": "^0.1.0",
         "p-queue": "^7.3.0",
         "prom-client": "^14.1.1",
         "protobufjs": "~7.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13598,9 +13598,9 @@
       }
     },
     "node_modules/node-okra": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/node-okra/-/node-okra-0.1.0.tgz",
-      "integrity": "sha512-k0eP0TgF5DOat/rC7SRcLLHUaKIDj5WmVe/HeoQ1rKHVTmye98Pw+rryRFjRuXSe5BUuj5vVw+Dxwc7FEWqBJw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-okra/-/node-okra-0.2.0.tgz",
+      "integrity": "sha512-NmFpreNoWzYeXnFq3TyFW5j8ICUJiZ277tiDg/fhvgErQTAs0hZ3AXjxquxsGpsoWmS9hZCUb+zP+NgKIy7fnA==",
       "dependencies": {
         "detect-libc": "^2.0.1"
       }
@@ -18773,7 +18773,7 @@
         "it-stream-types": "^1.0.5",
         "libp2p": "^0.42.0",
         "multiformats": "^11.0.0",
-        "node-okra": "^0.1.0",
+        "node-okra": "^0.2.0",
         "p-queue": "^7.3.0",
         "prom-client": "^14.1.1",
         "protobufjs": "~7.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13598,9 +13598,9 @@
       }
     },
     "node_modules/node-okra": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/node-okra/-/node-okra-0.2.0.tgz",
-      "integrity": "sha512-NmFpreNoWzYeXnFq3TyFW5j8ICUJiZ277tiDg/fhvgErQTAs0hZ3AXjxquxsGpsoWmS9hZCUb+zP+NgKIy7fnA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/node-okra/-/node-okra-0.3.0.tgz",
+      "integrity": "sha512-pLBuULaNedTs+GNI1Pmr4BtpZrHJmpecnPg1RzyXiwxum7I/kHQ6X0929D9g2orUgEIZRuZ90elEo1ozk7CsgQ==",
       "dependencies": {
         "detect-libc": "^2.0.1"
       }
@@ -18773,7 +18773,7 @@
         "it-stream-types": "^1.0.5",
         "libp2p": "^0.42.0",
         "multiformats": "^11.0.0",
-        "node-okra": "^0.2.0",
+        "node-okra": "^0.3.0",
         "p-queue": "^7.3.0",
         "prom-client": "^14.1.1",
         "protobufjs": "~7.1.2",

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -94,9 +94,9 @@ export async function handler(args: Args) {
 		console.log("[canvas-cli] Using PeerId", peerId.toString())
 
 		if (args.announce) {
-			libp2p = await createLibp2p(getLibp2pInit(peerId, args.listen, [args.announce]))
+			libp2p = await createLibp2p(getLibp2pInit({ peerId, port: args.listen, announce: [args.announce] }))
 		} else {
-			libp2p = await createLibp2p(getLibp2pInit(peerId, args.listen))
+			libp2p = await createLibp2p(getLibp2pInit({ peerId, port: args.listen }))
 		}
 
 		startPingService(libp2p, controller, { verbose: args.verbose })

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -23,6 +23,9 @@ import {
 	CANVAS_HOME,
 } from "../utils.js"
 import { EthereumChainImplementation } from "@canvas-js/chain-ethereum"
+import { ethers } from "ethers"
+
+const { hexlify } = ethers.utils
 
 export const command = "run <app>"
 export const desc = "Run an app, by path or IPFS hash"
@@ -129,19 +132,10 @@ export async function handler(args: Args) {
 			console.log(`[canvas-cli] Deleted ${modelsPath}`)
 		}
 
-		const mstPath = path.resolve(directory, constants.MST_FILENAME)
+		const mstPath = path.resolve(directory, constants.MST_DIRECTORY_NAME)
 		if (fs.existsSync(mstPath)) {
-			fs.rmSync(mstPath)
+			fs.rmSync(mstPath, { recursive: true })
 			console.log(`[canvas-cli] Deleted ${mstPath}`)
-		}
-
-		const sourceMSTPattern = /^[a-zA-Z0-9]+\.okra$/
-		for (const name of fs.readdirSync(directory)) {
-			if (sourceMSTPattern.test(name)) {
-				const sourceMSTPath = path.resolve(directory, name)
-				fs.rmSync(sourceMSTPath)
-				console.log(`[canvas-cli] Deleted ${sourceMSTPath}`)
-			}
 		}
 	} else if (args.replay) {
 		await confirmOrExit(`Are you sure you want to ${chalk.bold("regenerate all model tables")} in ${directory}?`)
@@ -226,7 +220,7 @@ export async function handler(args: Args) {
 				throw new Error("Invalid action value in action log")
 			}
 
-			const effects = await vm.execute(id, action.payload)
+			const effects = await vm.execute(hexlify(id), action.payload)
 			modelStore.applyEffects(action.payload, effects)
 			i++
 		}

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -191,9 +191,9 @@ export async function handler(args: Args) {
 	if (!offline) {
 		if (announce !== undefined) {
 			console.log(`[canvas-cli] Announcing on ${announce}`)
-			libp2p = await createLibp2p(getLibp2pInit(peerId, peeringPort, [announce]))
+			libp2p = await createLibp2p(getLibp2pInit({ peerId, port: peeringPort, announce: [announce] }))
 		} else {
-			libp2p = await createLibp2p(getLibp2pInit(peerId, peeringPort))
+			libp2p = await createLibp2p(getLibp2pInit({ peerId, port: peeringPort }))
 		}
 
 		if (verbose) {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -23,9 +23,6 @@ import {
 	CANVAS_HOME,
 } from "../utils.js"
 import { EthereumChainImplementation } from "@canvas-js/chain-ethereum"
-import { ethers } from "ethers"
-
-const { hexlify } = ethers.utils
 
 export const command = "run <app>"
 export const desc = "Run an app, by path or IPFS hash"
@@ -220,7 +217,7 @@ export async function handler(args: Args) {
 				throw new Error("Invalid action value in action log")
 			}
 
-			const effects = await vm.execute(hexlify(id), action.payload)
+			const effects = await vm.execute(id, action.payload)
 			modelStore.applyEffects(action.payload, effects)
 			i++
 		}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "it-stream-types": "^1.0.5",
     "libp2p": "^0.42.0",
     "multiformats": "^11.0.0",
-    "node-okra": "^0.1.0",
+    "node-okra": "^0.2.0",
     "p-queue": "^7.3.0",
     "prom-client": "^14.1.1",
     "protobufjs": "~7.1.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,8 +20,8 @@
     "test": "ava"
   },
   "dependencies": {
-    "@canvas-js/interfaces": "0.0.50-pre4",
     "@canvas-js/chain-ethereum": "0.0.50-pre4",
+    "@canvas-js/interfaces": "0.0.50-pre4",
     "@chainsafe/libp2p-gossipsub": "^6.0.0",
     "@chainsafe/libp2p-noise": "^11.0.0",
     "@libp2p/bootstrap": "^6.0.0",
@@ -49,7 +49,7 @@
     "it-stream-types": "^1.0.5",
     "libp2p": "^0.42.0",
     "multiformats": "^11.0.0",
-    "node-okra": "^0.0.1",
+    "node-okra": "^0.1.0",
     "p-queue": "^7.3.0",
     "prom-client": "^14.1.1",
     "protobufjs": "~7.1.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "it-stream-types": "^1.0.5",
     "libp2p": "^0.42.0",
     "multiformats": "^11.0.0",
-    "node-okra": "^0.2.0",
+    "node-okra": "^0.3.0",
     "p-queue": "^7.3.0",
     "prom-client": "^14.1.1",
     "protobufjs": "~7.1.2",

--- a/packages/core/rpc/sync/index.d.cts
+++ b/packages/core/rpc/sync/index.d.cts
@@ -3,11 +3,17 @@ import Long = require("long");
 /** Properties of a Node. */
 export interface INode {
 
-    /** Node leaf */
-    leaf?: (Uint8Array|null);
+    /** Node level */
+    level?: (number|null);
+
+    /** Node key */
+    key?: (Uint8Array|null);
 
     /** Node hash */
     hash?: (Uint8Array|null);
+
+    /** Node value */
+    value?: (Uint8Array|null);
 }
 
 /** Represents a Node. */
@@ -19,11 +25,20 @@ export class Node implements INode {
      */
     constructor(properties?: INode);
 
-    /** Node leaf. */
-    public leaf: Uint8Array;
+    /** Node level. */
+    public level: number;
+
+    /** Node key. */
+    public key: Uint8Array;
 
     /** Node hash. */
     public hash: Uint8Array;
+
+    /** Node value. */
+    public value?: (Uint8Array|null);
+
+    /** Node _value. */
+    public _value?: "value";
 
     /**
      * Creates a new Node instance using the specified properties.
@@ -103,6 +118,118 @@ export class Node implements INode {
     public static getTypeUrl(typeUrlPrefix?: string): string;
 }
 
+/** Properties of a MessageRequest. */
+export interface IMessageRequest {
+
+    /** MessageRequest type */
+    type?: (MessageRequest.MessageType|null);
+
+    /** MessageRequest id */
+    id?: (Uint8Array|null);
+}
+
+/** Represents a MessageRequest. */
+export class MessageRequest implements IMessageRequest {
+
+    /**
+     * Constructs a new MessageRequest.
+     * @param [properties] Properties to set
+     */
+    constructor(properties?: IMessageRequest);
+
+    /** MessageRequest type. */
+    public type: MessageRequest.MessageType;
+
+    /** MessageRequest id. */
+    public id: Uint8Array;
+
+    /**
+     * Creates a new MessageRequest instance using the specified properties.
+     * @param [properties] Properties to set
+     * @returns MessageRequest instance
+     */
+    public static create(properties?: IMessageRequest): MessageRequest;
+
+    /**
+     * Encodes the specified MessageRequest message. Does not implicitly {@link MessageRequest.verify|verify} messages.
+     * @param message MessageRequest message or plain object to encode
+     * @param [writer] Writer to encode to
+     * @returns Writer
+     */
+    public static encode(message: IMessageRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+    /**
+     * Encodes the specified MessageRequest message, length delimited. Does not implicitly {@link MessageRequest.verify|verify} messages.
+     * @param message MessageRequest message or plain object to encode
+     * @param [writer] Writer to encode to
+     * @returns Writer
+     */
+    public static encodeDelimited(message: IMessageRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+    /**
+     * Decodes a MessageRequest message from the specified reader or buffer.
+     * @param reader Reader or buffer to decode from
+     * @param [length] Message length if known beforehand
+     * @returns MessageRequest
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): MessageRequest;
+
+    /**
+     * Decodes a MessageRequest message from the specified reader or buffer, length delimited.
+     * @param reader Reader or buffer to decode from
+     * @returns MessageRequest
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): MessageRequest;
+
+    /**
+     * Verifies a MessageRequest message.
+     * @param message Plain object to verify
+     * @returns `null` if valid, otherwise the reason why it is not
+     */
+    public static verify(message: { [k: string]: any }): (string|null);
+
+    /**
+     * Creates a MessageRequest message from a plain object. Also converts values to their respective internal types.
+     * @param object Plain object
+     * @returns MessageRequest
+     */
+    public static fromObject(object: { [k: string]: any }): MessageRequest;
+
+    /**
+     * Creates a plain object from a MessageRequest message. Also converts values to other types if specified.
+     * @param message MessageRequest
+     * @param [options] Conversion options
+     * @returns Plain object
+     */
+    public static toObject(message: MessageRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+    /**
+     * Converts this MessageRequest to JSON.
+     * @returns JSON object
+     */
+    public toJSON(): { [k: string]: any };
+
+    /**
+     * Gets the default type url for MessageRequest
+     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+     * @returns The default type url
+     */
+    public static getTypeUrl(typeUrlPrefix?: string): string;
+}
+
+export namespace MessageRequest {
+
+    /** MessageType enum. */
+    enum MessageType {
+        CANVAS_SESSION = 0,
+        CANVAS_ACTION = 1
+    }
+}
+
 /** Properties of a Request. */
 export interface IRequest {
 
@@ -115,8 +242,8 @@ export interface IRequest {
     /** Request getChildren */
     getChildren?: (Request.IGetChildrenRequest|null);
 
-    /** Request getValues */
-    getValues?: (Request.IGetValuesRequest|null);
+    /** Request getMessages */
+    getMessages?: (Request.IGetMessagesRequest|null);
 }
 
 /** Represents a Request. */
@@ -137,11 +264,11 @@ export class Request implements IRequest {
     /** Request getChildren. */
     public getChildren?: (Request.IGetChildrenRequest|null);
 
-    /** Request getValues. */
-    public getValues?: (Request.IGetValuesRequest|null);
+    /** Request getMessages. */
+    public getMessages?: (Request.IGetMessagesRequest|null);
 
     /** Request request. */
-    public request?: ("getRoot"|"getChildren"|"getValues");
+    public request?: ("getRoot"|"getChildren"|"getMessages");
 
     /**
      * Creates a new Request instance using the specified properties.
@@ -320,8 +447,8 @@ export namespace Request {
         /** GetChildrenRequest level */
         level?: (number|null);
 
-        /** GetChildrenRequest leaf */
-        leaf?: (Uint8Array|null);
+        /** GetChildrenRequest key */
+        key?: (Uint8Array|null);
     }
 
     /** Represents a GetChildrenRequest. */
@@ -336,8 +463,8 @@ export namespace Request {
         /** GetChildrenRequest level. */
         public level: number;
 
-        /** GetChildrenRequest leaf. */
-        public leaf: Uint8Array;
+        /** GetChildrenRequest key. */
+        public key: Uint8Array;
 
         /**
          * Creates a new GetChildrenRequest instance using the specified properties.
@@ -417,97 +544,97 @@ export namespace Request {
         public static getTypeUrl(typeUrlPrefix?: string): string;
     }
 
-    /** Properties of a GetValuesRequest. */
-    interface IGetValuesRequest {
+    /** Properties of a GetMessagesRequest. */
+    interface IGetMessagesRequest {
 
-        /** GetValuesRequest nodes */
-        nodes?: (INode[]|null);
+        /** GetMessagesRequest messages */
+        messages?: (IMessageRequest[]|null);
     }
 
-    /** Represents a GetValuesRequest. */
-    class GetValuesRequest implements IGetValuesRequest {
+    /** Represents a GetMessagesRequest. */
+    class GetMessagesRequest implements IGetMessagesRequest {
 
         /**
-         * Constructs a new GetValuesRequest.
+         * Constructs a new GetMessagesRequest.
          * @param [properties] Properties to set
          */
-        constructor(properties?: Request.IGetValuesRequest);
+        constructor(properties?: Request.IGetMessagesRequest);
 
-        /** GetValuesRequest nodes. */
-        public nodes: INode[];
+        /** GetMessagesRequest messages. */
+        public messages: IMessageRequest[];
 
         /**
-         * Creates a new GetValuesRequest instance using the specified properties.
+         * Creates a new GetMessagesRequest instance using the specified properties.
          * @param [properties] Properties to set
-         * @returns GetValuesRequest instance
+         * @returns GetMessagesRequest instance
          */
-        public static create(properties?: Request.IGetValuesRequest): Request.GetValuesRequest;
+        public static create(properties?: Request.IGetMessagesRequest): Request.GetMessagesRequest;
 
         /**
-         * Encodes the specified GetValuesRequest message. Does not implicitly {@link Request.GetValuesRequest.verify|verify} messages.
-         * @param message GetValuesRequest message or plain object to encode
+         * Encodes the specified GetMessagesRequest message. Does not implicitly {@link Request.GetMessagesRequest.verify|verify} messages.
+         * @param message GetMessagesRequest message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encode(message: Request.IGetValuesRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encode(message: Request.IGetMessagesRequest, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Encodes the specified GetValuesRequest message, length delimited. Does not implicitly {@link Request.GetValuesRequest.verify|verify} messages.
-         * @param message GetValuesRequest message or plain object to encode
+         * Encodes the specified GetMessagesRequest message, length delimited. Does not implicitly {@link Request.GetMessagesRequest.verify|verify} messages.
+         * @param message GetMessagesRequest message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encodeDelimited(message: Request.IGetValuesRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encodeDelimited(message: Request.IGetMessagesRequest, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Decodes a GetValuesRequest message from the specified reader or buffer.
+         * Decodes a GetMessagesRequest message from the specified reader or buffer.
          * @param reader Reader or buffer to decode from
          * @param [length] Message length if known beforehand
-         * @returns GetValuesRequest
+         * @returns GetMessagesRequest
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Request.GetValuesRequest;
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Request.GetMessagesRequest;
 
         /**
-         * Decodes a GetValuesRequest message from the specified reader or buffer, length delimited.
+         * Decodes a GetMessagesRequest message from the specified reader or buffer, length delimited.
          * @param reader Reader or buffer to decode from
-         * @returns GetValuesRequest
+         * @returns GetMessagesRequest
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Request.GetValuesRequest;
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Request.GetMessagesRequest;
 
         /**
-         * Verifies a GetValuesRequest message.
+         * Verifies a GetMessagesRequest message.
          * @param message Plain object to verify
          * @returns `null` if valid, otherwise the reason why it is not
          */
         public static verify(message: { [k: string]: any }): (string|null);
 
         /**
-         * Creates a GetValuesRequest message from a plain object. Also converts values to their respective internal types.
+         * Creates a GetMessagesRequest message from a plain object. Also converts values to their respective internal types.
          * @param object Plain object
-         * @returns GetValuesRequest
+         * @returns GetMessagesRequest
          */
-        public static fromObject(object: { [k: string]: any }): Request.GetValuesRequest;
+        public static fromObject(object: { [k: string]: any }): Request.GetMessagesRequest;
 
         /**
-         * Creates a plain object from a GetValuesRequest message. Also converts values to other types if specified.
-         * @param message GetValuesRequest
+         * Creates a plain object from a GetMessagesRequest message. Also converts values to other types if specified.
+         * @param message GetMessagesRequest
          * @param [options] Conversion options
          * @returns Plain object
          */
-        public static toObject(message: Request.GetValuesRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+        public static toObject(message: Request.GetMessagesRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
 
         /**
-         * Converts this GetValuesRequest to JSON.
+         * Converts this GetMessagesRequest to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
 
         /**
-         * Gets the default type url for GetValuesRequest
+         * Gets the default type url for GetMessagesRequest
          * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
          * @returns The default type url
          */
@@ -527,8 +654,8 @@ export interface IResponse {
     /** Response getChildren */
     getChildren?: (Response.IGetChildrenResponse|null);
 
-    /** Response getValues */
-    getValues?: (Response.IGetValuesResponse|null);
+    /** Response getMessages */
+    getMessages?: (Response.IGetMessagesResponse|null);
 }
 
 /** Represents a Response. */
@@ -549,11 +676,11 @@ export class Response implements IResponse {
     /** Response getChildren. */
     public getChildren?: (Response.IGetChildrenResponse|null);
 
-    /** Response getValues. */
-    public getValues?: (Response.IGetValuesResponse|null);
+    /** Response getMessages. */
+    public getMessages?: (Response.IGetMessagesResponse|null);
 
     /** Response response. */
-    public response?: ("getRoot"|"getChildren"|"getValues");
+    public response?: ("getRoot"|"getChildren"|"getMessages");
 
     /**
      * Creates a new Response instance using the specified properties.
@@ -835,97 +962,97 @@ export namespace Response {
         public static getTypeUrl(typeUrlPrefix?: string): string;
     }
 
-    /** Properties of a GetValuesResponse. */
-    interface IGetValuesResponse {
+    /** Properties of a GetMessagesResponse. */
+    interface IGetMessagesResponse {
 
-        /** GetValuesResponse values */
-        values?: (Uint8Array[]|null);
+        /** GetMessagesResponse messages */
+        messages?: (Uint8Array[]|null);
     }
 
-    /** Represents a GetValuesResponse. */
-    class GetValuesResponse implements IGetValuesResponse {
+    /** Represents a GetMessagesResponse. */
+    class GetMessagesResponse implements IGetMessagesResponse {
 
         /**
-         * Constructs a new GetValuesResponse.
+         * Constructs a new GetMessagesResponse.
          * @param [properties] Properties to set
          */
-        constructor(properties?: Response.IGetValuesResponse);
+        constructor(properties?: Response.IGetMessagesResponse);
 
-        /** GetValuesResponse values. */
-        public values: Uint8Array[];
+        /** GetMessagesResponse messages. */
+        public messages: Uint8Array[];
 
         /**
-         * Creates a new GetValuesResponse instance using the specified properties.
+         * Creates a new GetMessagesResponse instance using the specified properties.
          * @param [properties] Properties to set
-         * @returns GetValuesResponse instance
+         * @returns GetMessagesResponse instance
          */
-        public static create(properties?: Response.IGetValuesResponse): Response.GetValuesResponse;
+        public static create(properties?: Response.IGetMessagesResponse): Response.GetMessagesResponse;
 
         /**
-         * Encodes the specified GetValuesResponse message. Does not implicitly {@link Response.GetValuesResponse.verify|verify} messages.
-         * @param message GetValuesResponse message or plain object to encode
+         * Encodes the specified GetMessagesResponse message. Does not implicitly {@link Response.GetMessagesResponse.verify|verify} messages.
+         * @param message GetMessagesResponse message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encode(message: Response.IGetValuesResponse, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encode(message: Response.IGetMessagesResponse, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Encodes the specified GetValuesResponse message, length delimited. Does not implicitly {@link Response.GetValuesResponse.verify|verify} messages.
-         * @param message GetValuesResponse message or plain object to encode
+         * Encodes the specified GetMessagesResponse message, length delimited. Does not implicitly {@link Response.GetMessagesResponse.verify|verify} messages.
+         * @param message GetMessagesResponse message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encodeDelimited(message: Response.IGetValuesResponse, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encodeDelimited(message: Response.IGetMessagesResponse, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Decodes a GetValuesResponse message from the specified reader or buffer.
+         * Decodes a GetMessagesResponse message from the specified reader or buffer.
          * @param reader Reader or buffer to decode from
          * @param [length] Message length if known beforehand
-         * @returns GetValuesResponse
+         * @returns GetMessagesResponse
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Response.GetValuesResponse;
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Response.GetMessagesResponse;
 
         /**
-         * Decodes a GetValuesResponse message from the specified reader or buffer, length delimited.
+         * Decodes a GetMessagesResponse message from the specified reader or buffer, length delimited.
          * @param reader Reader or buffer to decode from
-         * @returns GetValuesResponse
+         * @returns GetMessagesResponse
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Response.GetValuesResponse;
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Response.GetMessagesResponse;
 
         /**
-         * Verifies a GetValuesResponse message.
+         * Verifies a GetMessagesResponse message.
          * @param message Plain object to verify
          * @returns `null` if valid, otherwise the reason why it is not
          */
         public static verify(message: { [k: string]: any }): (string|null);
 
         /**
-         * Creates a GetValuesResponse message from a plain object. Also converts values to their respective internal types.
+         * Creates a GetMessagesResponse message from a plain object. Also converts values to their respective internal types.
          * @param object Plain object
-         * @returns GetValuesResponse
+         * @returns GetMessagesResponse
          */
-        public static fromObject(object: { [k: string]: any }): Response.GetValuesResponse;
+        public static fromObject(object: { [k: string]: any }): Response.GetMessagesResponse;
 
         /**
-         * Creates a plain object from a GetValuesResponse message. Also converts values to other types if specified.
-         * @param message GetValuesResponse
+         * Creates a plain object from a GetMessagesResponse message. Also converts values to other types if specified.
+         * @param message GetMessagesResponse
          * @param [options] Conversion options
          * @returns Plain object
          */
-        public static toObject(message: Response.GetValuesResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
+        public static toObject(message: Response.GetMessagesResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
 
         /**
-         * Converts this GetValuesResponse to JSON.
+         * Converts this GetMessagesResponse to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
 
         /**
-         * Gets the default type url for GetValuesResponse
+         * Gets the default type url for GetMessagesResponse
          * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
          * @returns The default type url
          */

--- a/packages/core/rpc/sync/index.proto
+++ b/packages/core/rpc/sync/index.proto
@@ -1,27 +1,39 @@
 syntax = "proto3";
 
 message Node {
-  bytes leaf = 1;
-  bytes hash = 2;
+  uint32 level = 1;
+  bytes key = 2;
+  bytes hash = 3;
+  optional bytes value = 4;
+}
+
+message MessageRequest {
+  enum MessageType {
+    CANVAS_SESSION = 0;
+    CANVAS_ACTION = 1;
+  }
+
+  MessageType type = 1;
+  bytes id = 2;
 }
 
 message Request {
   message GetRootRequest {}
 
   message GetChildrenRequest {
-    uint32 level = 3;
-    bytes leaf = 4;
+    uint32 level = 2;
+    bytes key = 3;
   }
 
-  message GetValuesRequest {
-    repeated Node nodes = 2;
+  message GetMessagesRequest {
+    repeated MessageRequest messages = 2;
   }
 
   uint32 seq = 1;
   oneof request {
     GetRootRequest get_root = 2;
     GetChildrenRequest get_children = 3;
-    GetValuesRequest get_values = 4;
+    GetMessagesRequest get_messages = 4;
   }
 }
 
@@ -35,14 +47,14 @@ message Response {
     repeated Node nodes = 2;
   }
 
-  message GetValuesResponse {
-    repeated bytes values = 2;
+  message GetMessagesResponse {
+    repeated bytes messages = 2;
   }
 
   uint32 seq = 1;
   oneof response {
     GetRootResponse get_root = 2;
     GetChildrenResponse get_children = 3;
-    GetValuesResponse get_values = 4;
+    GetMessagesResponse get_messages = 4;
   }
 }

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -7,6 +7,7 @@ import { StatusCodes } from "http-status-codes"
 import type { Chain, ModelValue } from "@canvas-js/interfaces"
 import { Core } from "./core.js"
 import { getMetrics } from "./metrics.js"
+import { toHex } from "./utils.js"
 
 interface Options {
 	exposeMetrics: boolean
@@ -103,8 +104,8 @@ export function getAPI(core: Core, options: Partial<Options> = {}): express.Expr
 		// TODO: pagination
 		api.get("/actions", (req, res) => {
 			const actions = []
-			for (const entry of core.messageStore.getActionStream()) {
-				actions.push(entry)
+			for (const [hash, action] of core.messageStore.getActionStream()) {
+				actions.push([toHex(hash), action])
 			}
 
 			return res.status(StatusCodes.OK).json(actions)
@@ -115,8 +116,8 @@ export function getAPI(core: Core, options: Partial<Options> = {}): express.Expr
 		// TODO: pagination
 		api.get("/sessions", (req, res) => {
 			const sessions = []
-			for (const entry of core.messageStore.getSessionStream()) {
-				sessions.push(entry)
+			for (const [hash, session] of core.messageStore.getSessionStream()) {
+				sessions.push([toHex(hash), session])
 			}
 
 			return res.status(StatusCodes.OK).json(sessions)

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,6 +1,6 @@
 export const PEER_ID_FILENAME = "peer.id"
 export const SPEC_FILENAME = "spec.canvas.js"
-export const MST_FILENAME = "mst.okra"
+export const MST_DIRECTORY_NAME = "mst"
 export const MODEL_DATABASE_FILENAME = "models.sqlite"
 export const MESSAGE_DATABASE_FILENAME = "messages.sqlite"
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -119,16 +119,16 @@ export class Core extends EventEmitter<CoreEvents> {
 				for (const [uri, cid] of Object.entries(sources)) {
 					const txn = new okra.Transaction(this.mst, { readOnly: false, dbi: cid.toString() })
 					try {
-						let actionCount = 0
+						let sessionCount = 0
 						for (const [hash, session] of this.messageStore.getSessionStream({ app: uri })) {
 							txn.set(getMessageKey(hash, session), hash)
-							actionCount++
+							sessionCount++
 						}
 
-						let sessionCount = 0
+						let actionCount = 0
 						for (const [hash, action] of this.messageStore.getActionStream({ app: uri })) {
 							txn.set(getMessageKey(hash, action), hash)
-							sessionCount++
+							actionCount++
 						}
 
 						txn.commit()

--- a/packages/core/src/libp2p.ts
+++ b/packages/core/src/libp2p.ts
@@ -132,13 +132,16 @@ export async function startPingService(
 
 				successCount += 1
 			} catch (err) {
-				if (verbose) {
-					console.log(`[canvas-core] Ping ${peer.toString()} failed`)
-					console.error(err)
-				}
+				if (err instanceof Error) {
+					if (verbose) {
+						console.log(`[canvas-core] Ping ${peer.toString()} failed (${err.message})`)
+					}
 
-				failureCount += 1
-				await routingTable.remove(peer)
+					failureCount += 1
+					await routingTable.remove(peer)
+				} else {
+					throw err
+				}
 			}
 		}
 
@@ -164,11 +167,15 @@ export async function startPingService(
 					console.log(`[canvas-core] Ping ${peer.toString()} succeeded`)
 				}
 			} catch (err) {
-				if (verbose) {
-					console.log(`[canvas-core] Ping ${peer.toString()} failed`)
-					console.error(err)
+				if (err instanceof Error) {
+					if (verbose) {
+						console.log(`[canvas-core] Ping ${peer.toString()} failed (${err.message})`)
+					}
+
+					await wanRoutingTable.remove(peer)
+				} else {
+					throw err
 				}
-				await wanRoutingTable.remove(peer)
 			}
 		})
 	})
@@ -189,11 +196,15 @@ export async function startPingService(
 					console.log(`[canvas-core] Ping ${peer.toString()} succeeded`)
 				}
 			} catch (err) {
-				if (verbose) {
-					console.log(`[canvas-core] Ping ${peer.toString()} failed`)
-					console.error(err)
+				if (err instanceof Error) {
+					if (verbose) {
+						console.log(`[canvas-core] Ping ${peer.toString()} failed (${err.message})`)
+					}
+
+					await lanRoutingTable.remove(peer)
+				} else {
+					throw err
 				}
-				await lanRoutingTable.remove(peer)
 			}
 		})
 	})
@@ -223,8 +234,10 @@ export async function startPingService(
 	} catch (err) {
 		if (err instanceof AbortError) {
 			console.log("[canvas-core] Aborting ping service")
+		} else if (err instanceof Error) {
+			console.error(`[canvas-core] Ping service crashed (${err.message})`)
 		} else {
-			console.error("[canvas-core] Ping service crashed", err)
+			throw err
 		}
 	}
 }

--- a/packages/core/src/libp2p.ts
+++ b/packages/core/src/libp2p.ts
@@ -30,7 +30,7 @@ const bootstrapList = [
 const announceFilter = (multiaddrs: Multiaddr[]) =>
 	multiaddrs.filter((multiaddr) => !isLoopback(multiaddr) && !isPrivate(multiaddr))
 
-// const denyDialMultiaddr = async (peerId: PeerId, multiaddr: Multiaddr) => isLoopback(multiaddr)
+const denyDialMultiaddr = async (peerId: PeerId, multiaddr: Multiaddr) => isLoopback(multiaddr)
 
 const second = 1000
 const minute = 60 * second
@@ -50,7 +50,7 @@ export function getLibp2pInit(config: {
 	}
 
 	return {
-		// connectionGater: { denyDialMultiaddr },
+		connectionGater: { denyDialMultiaddr },
 		peerId: config.peerId,
 		addresses: { listen: listenAddresses, announce: announceAddresses, announceFilter },
 		transports: [webSockets()],
@@ -64,6 +64,7 @@ export function getLibp2pInit(config: {
 		}),
 		metrics: prometheusMetrics({ registry: libp2pRegister }),
 		pubsub: gossipsub({
+			emitSelf: true,
 			doPX: true,
 			fallbackToFloodsub: false,
 			allowPublishToZeroPeers: true,

--- a/packages/core/src/messageStore.ts
+++ b/packages/core/src/messageStore.ts
@@ -200,15 +200,27 @@ export class MessageStore {
 
 	// we can use statement.iterate() instead of paging manually
 	// https://github.com/WiseLibs/better-sqlite3/issues/406
-	public *getActionStream(): Iterable<[string, Action]> {
-		for (const record of this.statements.getActions.iterate({}) as Iterable<ActionRecord>) {
-			yield [toHex(record.hash), MessageStore.parseActionRecord(record)]
+	public *getActionStream({ app }: { app?: string } = {}): Iterable<[string, Action]> {
+		if (app === undefined) {
+			for (const record of this.statements.getActions.iterate({}) as Iterable<ActionRecord>) {
+				yield [toHex(record.hash), MessageStore.parseActionRecord(record)]
+			}
+		} else {
+			for (const record of this.statements.getActionsByApp.iterate({ app }) as Iterable<ActionRecord>) {
+				yield [toHex(record.hash), MessageStore.parseActionRecord(record)]
+			}
 		}
 	}
 
-	public *getSessionStream(): Iterable<[string, Session]> {
-		for (const record of this.statements.getSessions.iterate({}) as Iterable<SessionRecord>) {
-			yield [toHex(record.hash), MessageStore.parseSessionRecord(record)]
+	public *getSessionStream({ app }: { app?: string } = {}): Iterable<[string, Session]> {
+		if (app === undefined) {
+			for (const record of this.statements.getSessions.iterate({}) as Iterable<SessionRecord>) {
+				yield [toHex(record.hash), MessageStore.parseSessionRecord(record)]
+			}
+		} else {
+			for (const record of this.statements.getSessionsByApp.iterate({ app }) as Iterable<SessionRecord>) {
+				yield [toHex(record.hash), MessageStore.parseSessionRecord(record)]
+			}
 		}
 	}
 
@@ -258,5 +270,7 @@ export class MessageStore {
 		getSessionByAddress: `SELECT * FROM sessions WHERE session_address = :session_address`,
 		getSessions: `SELECT * FROM sessions`,
 		getActions: `SELECT * FROM actions`,
+		getSessionsByApp: `SELECT * FROM sessions WHERE app = :app`,
+		getActionsByApp: `SELECT * FROM actions WHERE app = :app`,
 	}
 }

--- a/packages/core/src/messageStore.ts
+++ b/packages/core/src/messageStore.ts
@@ -200,26 +200,26 @@ export class MessageStore {
 
 	// we can use statement.iterate() instead of paging manually
 	// https://github.com/WiseLibs/better-sqlite3/issues/406
-	public *getActionStream({ app }: { app?: string } = {}): Iterable<[string, Action]> {
+	public *getActionStream({ app }: { app?: string } = {}): Iterable<[Buffer, Action]> {
 		if (app === undefined) {
 			for (const record of this.statements.getActions.iterate({}) as Iterable<ActionRecord>) {
-				yield [toHex(record.hash), MessageStore.parseActionRecord(record)]
+				yield [record.hash, MessageStore.parseActionRecord(record)]
 			}
 		} else {
 			for (const record of this.statements.getActionsByApp.iterate({ app }) as Iterable<ActionRecord>) {
-				yield [toHex(record.hash), MessageStore.parseActionRecord(record)]
+				yield [record.hash, MessageStore.parseActionRecord(record)]
 			}
 		}
 	}
 
-	public *getSessionStream({ app }: { app?: string } = {}): Iterable<[string, Session]> {
+	public *getSessionStream({ app }: { app?: string } = {}): Iterable<[Buffer, Session]> {
 		if (app === undefined) {
 			for (const record of this.statements.getSessions.iterate({}) as Iterable<SessionRecord>) {
-				yield [toHex(record.hash), MessageStore.parseSessionRecord(record)]
+				yield [record.hash, MessageStore.parseSessionRecord(record)]
 			}
 		} else {
 			for (const record of this.statements.getSessionsByApp.iterate({ app }) as Iterable<SessionRecord>) {
-				yield [toHex(record.hash), MessageStore.parseSessionRecord(record)]
+				yield [record.hash, MessageStore.parseSessionRecord(record)]
 			}
 		}
 	}

--- a/packages/core/src/rpc/client.ts
+++ b/packages/core/src/rpc/client.ts
@@ -6,9 +6,17 @@ import * as lp from "it-length-prefixed"
 import { pipe } from "it-pipe"
 import { pushable, Pushable } from "it-pushable"
 
+import type * as okra from "node-okra"
+
 import RPC from "../../rpc/sync/index.cjs"
 
-import { toBuffer } from "../utils.js"
+import { signalInvalidType, toBuffer } from "../utils.js"
+import { toNode } from "./utils.js"
+import { Message } from "@canvas-js/interfaces"
+import { actionType, sessionType } from "../codecs.js"
+import { createHash } from "node:crypto"
+
+const { CANVAS_SESSION, CANVAS_ACTION } = RPC.MessageRequest.MessageType
 
 export class Client {
 	private seq = 0
@@ -24,25 +32,26 @@ export class Client {
 		this.requests.end()
 	}
 
-	public async getRoot() {
+	public async getRoot(): Promise<{ level: number; hash: Buffer }> {
 		const { getRoot } = await this.get({ getRoot: {} })
 		assert(getRoot, "Invalid RPC response")
 		const { level, hash } = RPC.Response.GetRootResponse.create(getRoot)
 		return { level, hash: toBuffer(hash) }
 	}
 
-	public async getChildren(level: number, leaf: Uint8Array) {
-		const { getChildren } = await this.get({ getChildren: { level, leaf } })
+	public async getChildren(level: number, key: Uint8Array | null): Promise<okra.Node[]> {
+		const { getChildren } = await this.get({ getChildren: { level, key } })
 		assert(getChildren, "Invalid RPC response")
 		const { nodes } = RPC.Response.GetChildrenResponse.create(getChildren)
-		return nodes.map(RPC.Node.create).map(({ leaf, hash }) => ({ leaf: toBuffer(leaf), hash: toBuffer(hash) }))
+		return nodes.map(RPC.Node.create).map(toNode)
 	}
 
-	public async getValues(nodes: { leaf: Uint8Array; hash: Uint8Array }[]) {
-		const { getValues } = await this.get({ getValues: { nodes } })
-		assert(getValues, "Invalid RPC response")
-		const { values } = RPC.Response.GetValuesResponse.create(getValues)
-		return values
+	public async getMessages(requests: { type: RPC.MessageRequest.MessageType; id: Buffer }[]): Promise<Buffer[]> {
+		const { getMessages } = await this.get({ getMessages: { messages: requests } })
+		assert(getMessages, "Invalid RPC response")
+		const { messages: responses } = RPC.Response.GetMessagesResponse.create(getMessages)
+		assert(responses.length === requests.length, "expected responses.length to match requests.length")
+		return responses.map(toBuffer)
 	}
 
 	private async get(req: RPC.IRequest) {

--- a/packages/core/src/rpc/client.ts
+++ b/packages/core/src/rpc/client.ts
@@ -10,13 +10,8 @@ import type * as okra from "node-okra"
 
 import RPC from "../../rpc/sync/index.cjs"
 
-import { signalInvalidType, toBuffer } from "../utils.js"
+import { toBuffer } from "../utils.js"
 import { toNode } from "./utils.js"
-import { Message } from "@canvas-js/interfaces"
-import { actionType, sessionType } from "../codecs.js"
-import { createHash } from "node:crypto"
-
-const { CANVAS_SESSION, CANVAS_ACTION } = RPC.MessageRequest.MessageType
 
 export class Client {
 	private seq = 0

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -1,2 +1,3 @@
 export { handleIncomingStream } from "./server.js"
 export { sync } from "./sync.js"
+export { getMessageKey } from "./utils.js"

--- a/packages/core/src/rpc/server.ts
+++ b/packages/core/src/rpc/server.ts
@@ -35,7 +35,11 @@ export async function handleIncomingStream(
 	try {
 		await pipe(stream, lp.decode(), handle, lp.encode(), stream)
 	} catch (err) {
-		console.log(chalk.red(`[canvas-core] Error handling incoming sync:`), err)
+		if (err instanceof Error) {
+			console.log(chalk.red(`[canvas-core] Error handling incoming sync (${err.message})`))
+		} else {
+			throw err
+		}
 	} finally {
 		txn.abort()
 	}

--- a/packages/core/src/rpc/sync.ts
+++ b/packages/core/src/rpc/sync.ts
@@ -104,9 +104,14 @@ export async function sync(
 		cursor.close()
 		txn.commit()
 	} catch (err) {
-		console.log(chalk.red(`[canvas-core] Error performing outgoing sync:`), err)
 		cursor.close()
 		txn.abort()
+
+		if (err instanceof Error) {
+			console.log(chalk.red(`[canvas-core] Error performing outgoing sync (${err.message})`))
+		} else {
+			throw err
+		}
 	} finally {
 		client.end()
 	}

--- a/packages/core/src/rpc/sync.ts
+++ b/packages/core/src/rpc/sync.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto"
 import assert from "node:assert"
 
-import chalk from "chalk"
 import type { Duplex } from "it-stream-types"
 import type { Uint8ArrayList } from "uint8arraylist"
 
@@ -21,36 +20,69 @@ const { CANVAS_SESSION, CANVAS_ACTION } = RPC.MessageRequest.MessageType
 
 export async function sync(
 	messageStore: MessageStore,
-	mst: okra.Tree,
+	txn: okra.Transaction,
 	stream: Duplex<Uint8ArrayList, Uint8ArrayList | Uint8Array>,
 	handleMessage: (hash: Buffer, data: Uint8Array, message: Message) => Promise<void>
 ): Promise<void> {
-	const txn = new okra.Transaction(mst, { readOnly: false })
-	const cursor = new okra.Cursor(txn)
-	const client = new Client(stream)
+	const driver = new Driver(messageStore, txn, handleMessage, stream)
+	try {
+		await driver.sync()
+	} finally {
+		driver.close()
+	}
+}
 
-	async function enter(targetLevel: number, sourceNode: okra.Node) {
-		if (sourceNode.level > targetLevel) {
-			const children = await client.getChildren(sourceNode.level, sourceNode.key)
-			for (const sourceChild of children) {
-				await enter(targetLevel, sourceChild)
-			}
+class Driver {
+	private readonly client: Client
+	private readonly cursor: okra.Cursor
+	constructor(
+		private readonly messageStore: MessageStore,
+		private readonly txn: okra.Transaction,
+		private readonly handleMessage: (hash: Buffer, data: Uint8Array, message: Message) => Promise<void>,
+		stream: Duplex<Uint8ArrayList, Uint8ArrayList | Uint8Array>
+	) {
+		this.client = new Client(stream)
+		this.cursor = new okra.Cursor(txn)
+	}
+
+	public close() {
+		this.cursor.close()
+		this.client.end()
+	}
+
+	public async sync() {
+		const { level: sourceLevel, hash: sourceHash } = await this.client.getRoot()
+		const { level: targetLevel, hash: targetHash } = this.txn.getRoot()
+
+		if (sourceLevel === targetLevel && sourceHash.equals(targetHash)) {
+			return
 		} else {
-			await scan(sourceNode)
+			await this.enter(targetLevel, { level: sourceLevel, key: null, hash: sourceHash })
 		}
 	}
 
-	async function scan(sourceNode: okra.Node) {
-		const targetNode = cursor.seek(sourceNode.level, sourceNode.key)
-		assert(targetNode !== null, "expected targetNode to not be null")
-		if (equalNodes(sourceNode, targetNode)) {
+	private async enter(targetLevel: number, sourceNode: okra.Node) {
+		if (sourceNode.level > targetLevel) {
+			const children = await this.client.getChildren(sourceNode.level, sourceNode.key)
+			for (const sourceChild of children) {
+				await this.enter(targetLevel, sourceChild)
+			}
+		} else {
+			await this.scan(sourceNode)
+		}
+	}
+
+	private async scan(sourceNode: okra.Node) {
+		const targetNode = this.cursor.seek(sourceNode.level, sourceNode.key)
+		// assert(targetNode !== null, "expected targetNode to not be null")
+		if (targetNode !== null && equalNodes(sourceNode, targetNode)) {
 			return
 		}
 
-		const children = await client.getChildren(sourceNode.level, sourceNode.key)
+		const children = await this.client.getChildren(sourceNode.level, sourceNode.key)
 		if (sourceNode.level > 1) {
 			for (const sourceChild of children) {
-				await scan(sourceChild)
+				await this.scan(sourceChild)
 			}
 		} else {
 			const requests: { type: RPC.MessageRequest.MessageType; id: Buffer }[] = []
@@ -62,11 +94,11 @@ export async function sync(
 				assert(value !== undefined, "expected leaf nodes to have a Buffer .value")
 				const type = getMessageType(key)
 				if (type === CANVAS_SESSION) {
-					if (messageStore.getSessionByHash(value) === null) {
+					if (this.messageStore.getSessionByHash(value) === null) {
 						requests.push({ type, id: value })
 					}
 				} else if (type === CANVAS_ACTION) {
-					if (messageStore.getActionByHash(value) === null) {
+					if (this.messageStore.getActionByHash(value) === null) {
 						requests.push({ type, id: value })
 					}
 				} else {
@@ -76,7 +108,7 @@ export async function sync(
 
 			const decoder = new TextDecoder()
 
-			const messages = await client.getMessages(requests)
+			const messages = await this.client.getMessages(requests)
 
 			for (const [i, data] of messages.entries()) {
 				const { id, type } = requests[i]
@@ -91,28 +123,9 @@ export async function sync(
 					signalInvalidType(type)
 				}
 
-				await handleMessage(id, data, message)
-				txn.set(getMessageKey(id, message), id)
+				await this.handleMessage(id, data, message)
+				this.txn.set(getMessageKey(id, message), id)
 			}
 		}
-	}
-
-	try {
-		const { level: sourceLevel, hash: sourceHash } = await client.getRoot()
-		const { level: targetLevel } = txn.getRoot()
-		await enter(targetLevel, { level: sourceLevel, key: null, hash: sourceHash })
-		cursor.close()
-		txn.commit()
-	} catch (err) {
-		cursor.close()
-		txn.abort()
-
-		if (err instanceof Error) {
-			console.log(chalk.red(`[canvas-core] Error performing outgoing sync (${err.message})`))
-		} else {
-			throw err
-		}
-	} finally {
-		client.end()
 	}
 }

--- a/packages/core/src/rpc/utils.ts
+++ b/packages/core/src/rpc/utils.ts
@@ -1,0 +1,47 @@
+import type * as okra from "node-okra"
+
+import type { Action, Message, Session } from "@canvas-js/interfaces"
+
+import RPC from "../../rpc/sync/index.cjs"
+
+import { signalInvalidType, toBuffer } from "../utils.js"
+
+// We declare this interface to enforce that handleIncomingStream only has read access to the message store.
+export interface MessageStore {
+	getSessionByHash(hash: Buffer): Session | null
+	getActionByHash(hash: Buffer): Action | null
+}
+
+const { CANVAS_SESSION, CANVAS_ACTION } = RPC.MessageRequest.MessageType
+
+export const getMessageType = (key: Buffer) => (key.readUintBE(0, 6) % 2 === 0 ? CANVAS_SESSION : CANVAS_ACTION)
+
+export const getMessageKey = (hash: Buffer, message: Message) => {
+	const key = Buffer.alloc(14)
+	if (message.type === "action") {
+		key.writeUintBE(message.payload.timestamp * 2 + 1, 0, 6)
+	} else if (message.type === "session") {
+		key.writeUintBE(message.payload.sessionIssued * 2, 0, 6)
+	} else {
+		signalInvalidType(message)
+	}
+
+	hash.copy(key, 6, 0, 8)
+	return key
+}
+
+export const toKey = (array: Uint8Array) => (array.length === 0 ? null : toBuffer(array))
+
+export const toNode = ({ level, key, hash, value }: RPC.Node): okra.Node => {
+	if (value) {
+		return { level, key: toKey(key), hash: toBuffer(hash), value: toBuffer(value) }
+	} else {
+		return { level, key: toKey(key), hash: toBuffer(hash) }
+	}
+}
+
+export const equalKeys = (a: Buffer | null, b: Buffer | null) =>
+	(a === null && b === null) || (a !== null && b !== null && a.equals(b))
+
+export const equalNodes = (a: okra.Node, b: okra.Node) =>
+	a.level === b.level && equalKeys(a.key, b.key) && a.hash.equals(b.hash)

--- a/packages/core/src/rpc/utils.ts
+++ b/packages/core/src/rpc/utils.ts
@@ -4,7 +4,7 @@ import type { Action, Message, Session } from "@canvas-js/interfaces"
 
 import RPC from "../../rpc/sync/index.cjs"
 
-import { signalInvalidType, toBuffer } from "../utils.js"
+import { fromHex, signalInvalidType, toBuffer } from "../utils.js"
 
 // We declare this interface to enforce that handleIncomingStream only has read access to the message store.
 export interface MessageStore {
@@ -16,7 +16,7 @@ const { CANVAS_SESSION, CANVAS_ACTION } = RPC.MessageRequest.MessageType
 
 export const getMessageType = (key: Buffer) => (key.readUintBE(0, 6) % 2 === 0 ? CANVAS_SESSION : CANVAS_ACTION)
 
-export const getMessageKey = (hash: Buffer, message: Message) => {
+export const getMessageKey = (hash: Buffer | string, message: Message) => {
 	const key = Buffer.alloc(14)
 	if (message.type === "action") {
 		key.writeUintBE(message.payload.timestamp * 2 + 1, 0, 6)
@@ -26,7 +26,12 @@ export const getMessageKey = (hash: Buffer, message: Message) => {
 		signalInvalidType(message)
 	}
 
-	hash.copy(key, 6, 0, 8)
+	if (typeof hash === "string") {
+		fromHex(hash).copy(key, 6, 0, 8)
+	} else {
+		hash.copy(key, 6, 0, 8)
+	}
+
 	return key
 }
 

--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -70,6 +70,10 @@ export class Source {
 			}
 
 			libp2p.handle(this.syncProtocol, this.streamHandler)
+			if (this.options.verbose) {
+				console.log(`[canvas-core] [${cid.toString()}] Attached stream handler for protocol ${this.syncProtocol}`)
+			}
+
 			this.startSyncService()
 			this.startAnnounceService()
 		}

--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -13,20 +13,14 @@ import type { StreamHandler } from "@libp2p/interface-registrar"
 
 import * as okra from "node-okra"
 
-import { Action, Message, Session } from "@canvas-js/interfaces"
+import { Message } from "@canvas-js/interfaces"
+import type { MessageStore } from "./messageStore.js"
 
-import { wait, retry, AbortError, toHex, signalInvalidType, CacheMap } from "./utils.js"
+import { wait, retry, AbortError, toHex, CacheMap } from "./utils.js"
 import { sync, handleIncomingStream, getMessageKey } from "./rpc/index.js"
 import * as constants from "./constants.js"
 import { metrics } from "./metrics.js"
 import { messageType } from "./codecs.js"
-
-// We declare this interface to enforce that Source only has read access to the message store.
-// All the writes still happen in Core.
-interface MessageStore {
-	getSessionByHash(hash: Buffer): Session | null
-	getActionByHash(hash: Buffer): Action | null
-}
 
 export interface SourceOptions {
 	verbose?: boolean
@@ -64,7 +58,7 @@ export class Source {
 		private readonly options: SourceOptions
 	) {
 		this.uri = `ipfs://${cid.toString()}`
-		this.syncProtocol = `/x/canvas/sync/${cid.toString()}`
+		this.syncProtocol = `/x/canvas/sync/v1/${cid.toString()}`
 
 		this.mst = new okra.Tree(path)
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -20,13 +20,13 @@ export const stringify = configure({ bigint: false, circularValue: Error, strict
 
 export const ipfsURIPattern = /^ipfs:\/\/([a-zA-Z0-9]+)$/
 
-export function parseIPFSURI(uri: string): CID | null {
+export function parseIPFSURI(uri: string): CID {
 	const match = ipfsURIPattern.exec(uri)
 	if (match) {
 		const [_, cid] = match
 		return CID.parse(cid)
 	} else {
-		return null
+		throw new Error("invalid ipfs:// URI")
 	}
 }
 

--- a/packages/core/src/vm/vm.ts
+++ b/packages/core/src/vm/vm.ts
@@ -21,7 +21,7 @@ import {
 import * as constants from "../constants.js"
 import type { Effect } from "../modelStore.js"
 import { ApplicationError } from "../errors.js"
-import { mapEntries, signalInvalidType } from "../utils.js"
+import { mapEntries, signalInvalidType, toHex } from "../utils.js"
 
 import {
 	loadModule,
@@ -381,7 +381,7 @@ export class VM {
 	 * Given a call, get a list of effects to pass to `modelStore.applyEffects`, to be applied to the models.
 	 * Used by `.apply()` and when replaying actions.
 	 */
-	public async execute(hash: string, { call, callArgs, ...context }: ActionPayload): Promise<Effect[]> {
+	public async execute(hash: string | Buffer, { call, callArgs, ...context }: ActionPayload): Promise<Effect[]> {
 		assert(this.effects === null && this.actionContext === null, "cannot apply more than one action at once")
 
 		const actionHandle = this.getActionHandle(context.app, call)
@@ -393,7 +393,7 @@ export class VM {
 
 		const ctx = wrapJSON(this.context, {
 			app: context.app,
-			hash: hash,
+			hash: typeof hash === "string" ? hash : toHex(hash),
 			from: context.from,
 			block: context.block,
 			timestamp: context.timestamp,

--- a/packages/core/test/sources.test.ts
+++ b/packages/core/test/sources.test.ts
@@ -1,10 +1,19 @@
-import test from "ava"
+import os from "node:os"
+import fs from "node:fs"
+import path from "node:path"
 import assert from "node:assert"
+
+import test from "ava"
+
+import * as okra from "node-okra"
+import { nanoid } from "nanoid"
 
 import { Core, compileSpec } from "@canvas-js/core"
 
 import { TestSigner } from "./utils.js"
-import { fromHex, stringify } from "@canvas-js/core/lib/utils.js"
+import { fromHex, parseIPFSURI, stringify } from "@canvas-js/core/lib/utils.js"
+import { getMessageKey } from "@canvas-js/core/lib/rpc/utils.js"
+import * as constants from "@canvas-js/core/lib/constants.js"
 
 const MessageBoard = await compileSpec({
 	name: "Test App",
@@ -167,4 +176,81 @@ test("Apply source actions", async (t) => {
 	])
 
 	await core.close()
+})
+
+test("Build missing MST index on core startup", async (t) => {
+	const directory = path.resolve(os.tmpdir(), nanoid())
+	fs.mkdirSync(directory)
+
+	const messageKeys: Record<string, Buffer[]> = {}
+
+	try {
+		// apply a mix of source and direct actions
+		await t.notThrowsAsync(async () => {
+			const core = await Core.initialize({
+				directory,
+				uri: MessageBoardWithVotes.app,
+				spec: MessageBoardWithVotes.spec,
+				libp2p: null,
+				unchecked: true,
+			})
+
+			const sourceAction = await sourceSigner.sign("createPost", { content: "hello world" })
+			const { hash: sourceActionHash } = await core.applyAction(sourceAction)
+			const createAction = await signer.sign("create", { content: "lorem ipsum" })
+			const { hash: createActionHash } = await core.applyAction(createAction)
+			const voteAction = await signer.sign("vote", { post_id: createActionHash, value: 1 })
+			const { hash: voteActionHash } = await core.applyAction(voteAction)
+			const voteSourceAction = await signer.sign("vote", { post_id: sourceActionHash, value: -1 })
+			const { hash: voteSourceActionHash } = await core.applyAction(voteSourceAction)
+
+			await core.close()
+
+			const sourceDBI = parseIPFSURI(MessageBoard.app).toString()
+			messageKeys[sourceDBI] = [getMessageKey(sourceActionHash, sourceAction)]
+			const dbi = core.cid.toString()
+			messageKeys[dbi] = [
+				getMessageKey(createActionHash, createAction),
+				getMessageKey(voteActionHash, voteAction),
+				getMessageKey(voteSourceActionHash, voteSourceAction),
+			]
+		})
+
+		const mstPath = path.resolve(directory, constants.MST_DIRECTORY_NAME)
+		t.true(fs.existsSync(mstPath))
+		t.true(fs.statSync(mstPath).isDirectory())
+
+		// delete the MST directory
+		fs.rmSync(mstPath, { recursive: true })
+
+		// open the core again
+		const core = await Core.initialize({
+			directory,
+			uri: MessageBoardWithVotes.app,
+			spec: MessageBoardWithVotes.spec,
+			libp2p: null,
+			unchecked: true,
+		})
+
+		// expect the MST directory exists
+		t.true(fs.existsSync(mstPath))
+		t.true(fs.statSync(mstPath).isDirectory())
+
+		try {
+			for (const [dbi, keys] of Object.entries(messageKeys)) {
+				const txn = new okra.Transaction(core.mst!, { dbi, readOnly: true })
+				try {
+					for (const key of keys) {
+						t.true(txn.get(key) !== null)
+					}
+				} finally {
+					txn.abort()
+				}
+			}
+		} finally {
+			await core.close()
+		}
+	} finally {
+		fs.rmSync(directory, { recursive: true })
+	}
 })

--- a/packages/core/test/sources.test.ts
+++ b/packages/core/test/sources.test.ts
@@ -4,7 +4,7 @@ import assert from "node:assert"
 import { Core, compileSpec } from "@canvas-js/core"
 
 import { TestSigner } from "./utils.js"
-import { fromHex, parseIPFSURI, stringify } from "@canvas-js/core/lib/utils.js"
+import { fromHex, stringify } from "@canvas-js/core/lib/utils.js"
 
 const MessageBoard = await compileSpec({
 	name: "Test App",
@@ -101,9 +101,6 @@ test("Apply source actions", async (t) => {
 			updated_at: voteSourceAction.payload.timestamp,
 		},
 	])
-
-	const sourceCID = parseIPFSURI(MessageBoard.app)
-	assert(sourceCID !== null)
 
 	t.deepEqual(core.messageStore.database.prepare("SELECT * FROM actions").all(), [
 		{

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -62,8 +62,11 @@ async function testSync(sourceMessages: Iterable<Message>, targetMessages: Itera
 
 	const sourceMessageStore = new MessageStore(app, path.resolve(directory, "source.sqlite"))
 	const targetMessageStore = new MessageStore(app, path.resolve(directory, "target.sqlite"))
-	const sourceMST = new okra.Tree(path.resolve(directory, "source.okra"))
-	const targetMST = new okra.Tree(path.resolve(directory, "target.okra"))
+	const [sourceMSTPath, targetMSTPath] = [path.resolve(directory, "source"), path.resolve(directory, "target")]
+	fs.mkdirSync(sourceMSTPath)
+	fs.mkdirSync(targetMSTPath)
+	const sourceMST = new okra.Tree(sourceMSTPath)
+	const targetMST = new okra.Tree(targetMSTPath)
 
 	initialize(sourceMessageStore, sourceMST, sourceMessages)
 	initialize(targetMessageStore, targetMST, targetMessages)

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -86,8 +86,6 @@ async function testSync(sourceMessages: Iterable<Message>, targetMessages: Itera
 		targetTxn.commit()
 
 		return delta
-	} catch (err) {
-		throw err
 	} finally {
 		targetMST.close()
 		sourceMST.close()

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -5,6 +5,8 @@ import { EthereumChainImplementation } from "@canvas-js/chain-ethereum"
 
 export class TestSigner {
 	readonly wallet = ethers.Wallet.createRandom()
+	private timestamp = Date.now()
+
 	constructor(
 		readonly uri: string,
 		readonly appName: string,
@@ -18,7 +20,7 @@ export class TestSigner {
 			appName: this.appName,
 			call,
 			callArgs,
-			timestamp: Date.now(),
+			timestamp: this.timestamp++,
 			chain: "ethereum",
 			chainId: "1",
 			block: null,
@@ -35,13 +37,15 @@ export class TestSigner {
 
 export class TestSessionSigner {
 	readonly wallet = ethers.Wallet.createRandom()
+	private timestamp = Date.now()
+
 	constructor(readonly signer: TestSigner) {}
 
 	async session(): Promise<Session> {
 		const sessionPayload: SessionPayload = {
 			sessionAddress: this.wallet.address,
 			sessionDuration: 60 * 60 * 24 * 1000,
-			sessionIssued: Date.now(),
+			sessionIssued: this.timestamp++,
 			from: this.signer.wallet.address,
 			app: this.signer.uri,
 			appName: this.signer.appName,
@@ -65,7 +69,7 @@ export class TestSessionSigner {
 			appName: this.signer.appName,
 			call,
 			callArgs,
-			timestamp: Date.now(),
+			timestamp: this.timestamp++,
 			chain: "ethereum",
 			chainId: "1",
 			block: null,

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -57,9 +57,9 @@ if (NODE_ENV === "production") {
 
 	let libp2p: Libp2p
 	if (typeof ANNOUNCE === "string") {
-		libp2p = await createLibp2p(getLibp2pInit(peerId, peeringPort, [ANNOUNCE]))
+		libp2p = await createLibp2p(getLibp2pInit({ peerId, port: peeringPort, announce: [ANNOUNCE] }))
 	} else {
-		libp2p = await createLibp2p(getLibp2pInit(peerId, peeringPort))
+		libp2p = await createLibp2p(getLibp2pInit({ peerId, port: peeringPort }))
 	}
 
 	console.log("[canvas-next] Started libp2p")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Upgrade core's `node-okra` dependency to `v0.3.0`.

## Description

<!--- Describe your changes in detail -->

I've rewritten okra to use smaller hashes, a simpler and more general API, and more granular control over transactions and batching. It also now supports both `.set` and `.delete` (previously just `.insert` - we don't use `.delete` at the moment but likely will need it in the future) and isolated named sub-databases (we use these for separate MSTs for app sources).

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

This changes the format of the MST on disk and keeps it in a different place (inside a `./mst` directory instead of a `./mst.okra` file), so now inside the `Core` constructor we check for the existence of the `./mst` directory, and, if it doesn't exist, iterators over all the actions and sessions inside the message store and re-indexes them. Shouldn't affect external usage other than a negligible one-time re-indexing delay.

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
