### PR TITLE
linearize transactions

### DIFF
--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -315,7 +315,7 @@ class Daemon {
 					})
 
 					this.apps.set(name, { core, api })
-					console.log(`[canvas-cli] Started ${core.uri}`)
+					console.log(`[canvas-cli] Started ${core.app}`)
 					res.status(StatusCodes.OK).end()
 				} catch (err) {
 					const message = err instanceof Error ? err.message : (err as any).toString()
@@ -335,7 +335,7 @@ class Daemon {
 
 				try {
 					await app.core.close()
-					console.log(`[canvas-cli] Stopped ${name} (${app.core.uri})`)
+					console.log(`[canvas-cli] Stopped ${name} (${app.core.app})`)
 					res.status(StatusCodes.OK).end()
 				} catch (err) {
 					const message = err instanceof Error ? err.message : (err as any).toString()

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -27,7 +27,7 @@ export async function handler(args: Args) {
 	try {
 		const vm = await VM.initialize({ app: uri, spec, chains: [], unchecked: true })
 		const { models, routes, actions, contractMetadata } = vm
-		vm.dispose()
+		await vm.close()
 
 		console.log(`name: ${uri}\n`)
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -249,10 +249,10 @@ export async function handler(args: Args) {
 			const apiPrefix = args.static ? `api/` : ""
 			if (args.static) {
 				console.log(`Serving static bundle: http://localhost:${args.port}/`)
-				console.log(`Serving API for ${core.uri}:`)
+				console.log(`Serving API for ${core.app}:`)
 				console.log(`└ GET http://localhost:${args.port}/api`)
 			} else {
-				console.log(`Serving API for ${core.uri}:`)
+				console.log(`Serving API for ${core.app}:`)
 				console.log(`└ GET http://localhost:${args.port}`)
 			}
 			for (const name of Object.keys(core.vm.routes)) {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -4,7 +4,7 @@ import chalk from "chalk"
 import express from "express"
 import { StatusCodes } from "http-status-codes"
 
-import type { Chain, ModelValue } from "@canvas-js/interfaces"
+import type { ModelValue } from "@canvas-js/interfaces"
 import { Core } from "./core.js"
 import { getMetrics } from "./metrics.js"
 import { toHex } from "./utils.js"
@@ -25,7 +25,7 @@ export function getAPI(core: Core, options: Partial<Options> = {}): express.Expr
 	api.get("/", (req, res) => {
 		const { component, routes, actions } = core.vm
 		return res.json({
-			uri: core.uri,
+			uri: core.app,
 			appName: core.appName,
 			cid: core.cid.toString(),
 			peerId: core.libp2p?.peerId.toString(),

--- a/packages/core/src/libp2p.ts
+++ b/packages/core/src/libp2p.ts
@@ -64,7 +64,7 @@ export function getLibp2pInit(config: {
 		}),
 		metrics: prometheusMetrics({ registry: libp2pRegister }),
 		pubsub: gossipsub({
-			emitSelf: true,
+			emitSelf: false,
 			doPX: true,
 			fallbackToFloodsub: false,
 			allowPublishToZeroPeers: true,

--- a/packages/core/src/libp2p.ts
+++ b/packages/core/src/libp2p.ts
@@ -139,12 +139,14 @@ export async function startPingService(
 				successCount += 1
 			} catch (err) {
 				if (err instanceof Error) {
-					if (verbose) {
-						console.log(`[canvas-core] Ping ${peer.toString()} failed (${err.message})`)
-					}
+					if (routingTable.isStarted()) {
+						if (verbose) {
+							console.log(`[canvas-core] Ping ${peer.toString()} failed (${err.message})`)
+						}
 
-					failureCount += 1
-					await routingTable.remove(peer)
+						failureCount += 1
+						await routingTable.remove(peer)
+					}
 				} else {
 					throw err
 				}
@@ -174,11 +176,13 @@ export async function startPingService(
 				}
 			} catch (err) {
 				if (err instanceof Error) {
-					if (verbose) {
-						console.log(`[canvas-core] Ping ${peer.toString()} failed (${err.message})`)
-					}
+					if (wanRoutingTable.isStarted()) {
+						if (verbose) {
+							console.log(`[canvas-core] Ping ${peer.toString()} failed (${err.message})`)
+						}
 
-					await wanRoutingTable.remove(peer)
+						await wanRoutingTable.remove(peer)
+					}
 				} else {
 					throw err
 				}
@@ -203,11 +207,13 @@ export async function startPingService(
 				}
 			} catch (err) {
 				if (err instanceof Error) {
-					if (verbose) {
-						console.log(`[canvas-core] Ping ${peer.toString()} failed (${err.message})`)
-					}
+					if (lanRoutingTable.isStarted()) {
+						if (verbose) {
+							console.log(`[canvas-core] Ping ${peer.toString()} failed (${err.message})`)
+						}
 
-					await lanRoutingTable.remove(peer)
+						await lanRoutingTable.remove(peer)
+					}
 				} else {
 					throw err
 				}

--- a/packages/core/src/messageStore.ts
+++ b/packages/core/src/messageStore.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert"
+import path from "node:path"
 import Database, * as sqlite from "better-sqlite3"
 
 import type { Action, Session, ActionArgument, Chain, ChainId, Message } from "@canvas-js/interfaces"
 
 import { mapEntries, fromHex, toHex, signalInvalidType, stringify } from "./utils.js"
+import { MESSAGE_DATABASE_FILENAME } from "./constants.js"
 
 type ActionRecord = {
 	hash: Buffer
@@ -47,22 +49,24 @@ export class MessageStore {
 
 	constructor(
 		private readonly app: string,
-		private readonly path: string | null,
+		private readonly directory: string | null,
 		private readonly sources: Set<string> = new Set([]),
 		private readonly options: { verbose?: boolean } = {}
 	) {
-		if (path === null) {
+		if (directory === null) {
 			if (options.verbose) {
 				console.log("[canvas-core] Initializing in-memory message store")
 			}
 
 			this.database = new Database(":memory:")
 		} else {
+			const databasePath = path.resolve(directory, MESSAGE_DATABASE_FILENAME)
+
 			if (options.verbose) {
-				console.log(`[canvas-core] Initializing message store at ${path}`)
+				console.log(`[canvas-core] Initializing message store at ${databasePath}`)
 			}
 
-			this.database = new Database(path)
+			this.database = new Database(databasePath)
 		}
 
 		this.database.exec(MessageStore.createSessionsTable)

--- a/packages/core/src/modelStore.ts
+++ b/packages/core/src/modelStore.ts
@@ -1,3 +1,4 @@
+import path from "node:path"
 import assert from "node:assert"
 import Database, * as sqlite from "better-sqlite3"
 import chalk from "chalk"
@@ -5,6 +6,7 @@ import chalk from "chalk"
 import type { ActionContext, Model, ModelType, ModelValue, Query } from "@canvas-js/interfaces"
 import { mapEntries, signalInvalidType } from "./utils.js"
 import type { VM } from "./vm/index.js"
+import { MODEL_DATABASE_FILENAME } from "./constants.js"
 
 export type Effect =
 	| { type: "set"; model: string; id: string; values: Record<string, ModelValue> }
@@ -20,8 +22,8 @@ export class ModelStore {
 		Record<keyof ReturnType<typeof ModelStore.getModelStatements>, sqlite.Statement>
 	> = {}
 
-	constructor(path: string | null, vm: VM, options: { verbose?: boolean } = {}) {
-		if (path === null) {
+	constructor(directory: string | null, vm: VM, options: { verbose?: boolean } = {}) {
+		if (directory === null) {
 			if (options.verbose) {
 				console.log("[canvas-core] Initializing new in-memory database")
 				console.warn(chalk.yellow("[canvas-core] All data will be lost on close!"))
@@ -29,11 +31,13 @@ export class ModelStore {
 
 			this.database = new Database(":memory:")
 		} else {
+			const databasePath = path.resolve(directory, MODEL_DATABASE_FILENAME)
+
 			if (options.verbose) {
-				console.log(`[canvas-core] Initializing database at ${path}`)
+				console.log(`[canvas-core] Initializing model store at ${databasePath}`)
 			}
 
-			this.database = new Database(path)
+			this.database = new Database(databasePath)
 		}
 
 		this.vm = vm

--- a/packages/core/src/mst.ts
+++ b/packages/core/src/mst.ts
@@ -1,0 +1,76 @@
+import path from "node:path"
+import fs from "node:fs"
+
+import PQueue from "p-queue"
+import { Tree, Transaction } from "node-okra"
+
+import { Message } from "@canvas-js/interfaces"
+
+import { getMessageKey } from "./rpc/index.js"
+import { MST_DIRECTORY_NAME } from "./constants.js"
+
+export class MST {
+	private readonly tree: Tree
+	private readonly queue = new PQueue({ concurrency: 1 })
+
+	public static async initialize(
+		directory: string,
+		dbs: string[],
+		importMessages: (dbi: string) => AsyncIterable<[Buffer, Message]>,
+		options: { verbose?: boolean } = {}
+	) {
+		const treePath = path.resolve(directory, MST_DIRECTORY_NAME)
+		if (options.verbose) {
+			console.log(`[canvas-core] Initializing MST index at ${treePath}`)
+		}
+
+		if (fs.existsSync(treePath)) {
+			return new MST(treePath, dbs)
+		} else {
+			fs.mkdirSync(treePath)
+			const mst = new MST(treePath, dbs)
+			for (const dbi of dbs) {
+				await mst.write(dbi, async (txn) => {
+					for await (const [hash, message] of importMessages(dbi)) {
+						txn.set(getMessageKey(hash, message), hash)
+					}
+				})
+			}
+
+			return mst
+		}
+	}
+
+	private constructor(treePath: string, dbs: string[]) {
+		this.tree = new Tree(treePath, { dbs })
+	}
+
+	public async read(dbi: string, callback: (txn: Transaction) => void | Promise<void>) {
+		const txn = new Transaction(this.tree, { readOnly: true, dbi })
+		try {
+			await callback(txn)
+		} finally {
+			txn.abort()
+		}
+	}
+
+	public async write(dbi: string, callback: (txn: Transaction) => void | Promise<void>) {
+		await this.queue.add(async () => {
+			const txn = new Transaction(this.tree, { readOnly: false, dbi })
+
+			try {
+				await callback(txn)
+			} catch (err) {
+				txn.abort()
+				throw err
+			}
+
+			txn.commit()
+		})
+	}
+
+	public async close() {
+		await this.queue.onIdle()
+		this.tree.close()
+	}
+}

--- a/packages/core/src/rpc/client.ts
+++ b/packages/core/src/rpc/client.ts
@@ -6,7 +6,7 @@ import * as lp from "it-length-prefixed"
 import { pipe } from "it-pipe"
 import { pushable, Pushable } from "it-pushable"
 
-import type * as okra from "node-okra"
+import type { Node } from "node-okra"
 
 import RPC from "../../rpc/sync/index.cjs"
 
@@ -34,7 +34,7 @@ export class Client {
 		return { level, hash: toBuffer(hash) }
 	}
 
-	public async getChildren(level: number, key: Uint8Array | null): Promise<okra.Node[]> {
+	public async getChildren(level: number, key: Uint8Array | null): Promise<Node[]> {
 		const { getChildren } = await this.get({ getChildren: { level, key } })
 		assert(getChildren, "Invalid RPC response")
 		const { nodes } = RPC.Response.GetChildrenResponse.create(getChildren)

--- a/packages/core/src/rpc/utils.ts
+++ b/packages/core/src/rpc/utils.ts
@@ -1,4 +1,4 @@
-import type * as okra from "node-okra"
+import type { Node } from "node-okra"
 
 import type { Action, Message, Session } from "@canvas-js/interfaces"
 
@@ -37,7 +37,7 @@ export const getMessageKey = (hash: Buffer | string, message: Message) => {
 
 export const toKey = (array: Uint8Array) => (array.length === 0 ? null : toBuffer(array))
 
-export const toNode = ({ level, key, hash, value }: RPC.Node): okra.Node => {
+export const toNode = ({ level, key, hash, value }: RPC.Node): Node => {
 	if (value) {
 		return { level, key: toKey(key), hash: toBuffer(hash), value: toBuffer(value) }
 	} else {
@@ -48,5 +48,4 @@ export const toNode = ({ level, key, hash, value }: RPC.Node): okra.Node => {
 export const equalKeys = (a: Buffer | null, b: Buffer | null) =>
 	(a === null && b === null) || (a !== null && b !== null && a.equals(b))
 
-export const equalNodes = (a: okra.Node, b: okra.Node) =>
-	a.level === b.level && equalKeys(a.key, b.key) && a.hash.equals(b.hash)
+export const equalNodes = (a: Node, b: Node) => a.level === b.level && equalKeys(a.key, b.key) && a.hash.equals(b.hash)

--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -405,6 +405,19 @@ export class Source {
 		try {
 			await this.mst.write(this.uri, async (txn) => {
 				await sync(this.messageStore, txn, stream, handleSyncMessage)
+				const root = txn.getRoot()
+				const rootHash = toHex(root.hash)
+
+				console.log(
+					chalk.green(
+						`[canvas-core] [${cid}] Sync with ${peer.toString()} completed. Applied ${successCount} new messages with ${failureCount} failures.`
+					)
+				)
+
+				if (this.options.verbose) {
+					console.log(`[canvas-core] [${cid}] The current merkle root is ${rootHash}`)
+				}
+
 				timer({ uri: this.uri, status: "success" })
 			})
 		} catch (err) {
@@ -417,12 +430,6 @@ export class Source {
 				throw err
 			}
 		}
-
-		console.log(
-			chalk.green(
-				`[canvas-core] [${cid}] Sync with ${peer.toString()} completed. Applied ${successCount} new messages with ${failureCount} failures.`
-			)
-		)
 
 		if (this.options.verbose) {
 			console.log(`[canvas-core] [${cid}] Closing outgoing stream ${stream.id}`)

--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -389,16 +389,18 @@ export class Source {
 		const timer = metrics.canvas_sync_time.startTimer()
 		try {
 			await this.mst.write(this.uri, async (txn) => {
-				await sync(this.messageStore, txn, stream, handleSyncMessage)
-				const { hash: rootHash } = txn.getRoot()
+				const { hash: oldRoot } = txn.getRoot()
+				console.log(`[canvas-core] [${this.cid}] The old merkle root is ${chalk.bold(toHex(oldRoot))}`)
 
+				await sync(this.messageStore, txn, stream, handleSyncMessage)
+
+				const { hash: newRoot } = txn.getRoot()
+				console.log(`[canvas-core] [${this.cid}] The new merkle root is ${chalk.bold(toHex(newRoot))}`)
 				console.log(
 					chalk.green(
 						`[canvas-core] [${this.cid}] Sync with ${peer} completed. Applied ${successCount} new messages with ${failureCount} failures.`
 					)
 				)
-
-				console.log(`[canvas-core] [${this.cid}] The current merkle root is ${toHex(rootHash)}`)
 
 				timer({ uri: this.uri, status: "success" })
 			})

--- a/packages/core/src/websockets.ts
+++ b/packages/core/src/websockets.ts
@@ -61,7 +61,7 @@ export function setupWebsockets(server: Server, core: Core): Server {
 		const message = JSON.stringify({
 			action: "application",
 			data: {
-				uri: core.uri,
+				uri: core.app,
 				appName: core.appName,
 				cid: core.cid.toString(),
 				peerId: core.libp2p?.peerId.toString(),

--- a/packages/core/src/websockets.ts
+++ b/packages/core/src/websockets.ts
@@ -53,7 +53,10 @@ export function setupWebsockets(server: Server, core: Core): Server {
 	}
 
 	const sendApplicationData = (ws: WebSocket & WebSocketID) => {
-		console.log(chalk.green(`[canvas-core] ws-${ws.id}: sent application status`))
+		if (core.options.verbose) {
+			console.log(chalk.green(`[canvas-core] ws-${ws.id}: sent application status`))
+		}
+
 		const { component, routes, actions } = core.vm
 		const message = JSON.stringify({
 			action: "application",
@@ -76,8 +79,10 @@ export function setupWebsockets(server: Server, core: Core): Server {
 
 	wss.on("connect", (ws, request) => {
 		ws.id = uuidv4()
-		ws.lastMessage = +new Date()
-		console.log(chalk.green(`[canvas-core] ws-${ws.id}: opened connection`))
+		ws.lastMessage = Date.now()
+		if (core.options.verbose) {
+			console.log(chalk.green(`[canvas-core] ws-${ws.id}: opened connection`))
+		}
 		sendApplicationData(ws)
 
 		ws.timer = setInterval(() => {
@@ -100,7 +105,10 @@ export function setupWebsockets(server: Server, core: Core): Server {
 			}
 
 			// Allow clients to subscribe to routes
-			console.log(chalk.green(`[canvas-core] ws-${ws.id}: received message`))
+			if (core.options.verbose) {
+				console.log(chalk.green(`[canvas-core] ws-${ws.id}: received message`))
+			}
+
 			try {
 				const message = JSON.parse(data.toString())
 				if (message.action === "subscribe") {
@@ -122,7 +130,10 @@ export function setupWebsockets(server: Server, core: Core): Server {
 
 		// Clean up subscriptions when connection closes
 		ws.on("close", (data: Message) => {
-			console.log(chalk.red(`[canvas-core] ws-${ws.id}: closed connection`))
+			if (core.options.verbose) {
+				console.log(`[canvas-core] ws-${ws.id}: closed connection`)
+			}
+
 			if (listeners[ws.id]) {
 				Object.entries(listeners[ws.id]).map(([route, listenersByParams]) => {
 					Object.entries(listenersByParams).map(([params, listener]) => {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -57,12 +57,14 @@ function initialize(messageStore: MessageStore, mst: okra.Tree, messages: Iterab
 }
 
 async function testSync(sourceMessages: Iterable<Message>, targetMessages: Iterable<Message>): Promise<Message[]> {
-	const directory = path.resolve(os.tmpdir(), nanoid())
-	fs.mkdirSync(directory)
+	const sourceDirectory = path.resolve(os.tmpdir(), nanoid())
+	const targetDirectory = path.resolve(os.tmpdir(), nanoid())
+	fs.mkdirSync(sourceDirectory)
+	fs.mkdirSync(targetDirectory)
 
-	const sourceMessageStore = new MessageStore(app, path.resolve(directory, "source.sqlite"))
-	const targetMessageStore = new MessageStore(app, path.resolve(directory, "target.sqlite"))
-	const [sourceMSTPath, targetMSTPath] = [path.resolve(directory, "source"), path.resolve(directory, "target")]
+	const sourceMessageStore = new MessageStore(app, sourceDirectory)
+	const targetMessageStore = new MessageStore(app, targetDirectory)
+	const [sourceMSTPath, targetMSTPath] = [path.resolve(sourceDirectory, "mst"), path.resolve(targetDirectory, "mst")]
 	fs.mkdirSync(sourceMSTPath)
 	fs.mkdirSync(targetMSTPath)
 	const sourceMST = new okra.Tree(sourceMSTPath)
@@ -91,7 +93,8 @@ async function testSync(sourceMessages: Iterable<Message>, targetMessages: Itera
 		sourceMST.close()
 		sourceMessageStore.close()
 		targetMessageStore.close()
-		fs.rmSync(directory, { recursive: true })
+		fs.rmSync(sourceDirectory, { recursive: true })
+		fs.rmSync(targetDirectory, { recursive: true })
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This reorganizes the core components a little bit to fix deadlock issues with MST syncing.

## Description

<!--- Describe your changes in detail -->

The central change here is creating a separate `MST` class in packages/core/src/mst.ts that wraps the `okra.Tree` class with some simplified managed transaction utilities and most importantly its own async `p-queue` instance so that write transactions are forced to wait for each other. The `Core.queue` p-queue is moved to `VM.queue`. The approach is now to let each component manage its own concurrency instead of holding one big queue in Core.

Some other miscellaneous cleanup got packaged into here as well, mostly related to logging, the relationship between the `Source` and `Core` classes, and renaming `Core.uri` to `Core.app`.

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

**`Core.uri` is now named  `Core.app`.**


<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
