### PR TITLE
Bob/can 50 evmos chain implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17618,7 +17618,6 @@
       "version": "0.0.52",
       "dependencies": {
         "@canvas-js/interfaces": "0.0.52",
-        "@cosmjs/encoding": "^0.29.5",
         "@ethersproject/wallet": "^5.7.0",
         "ethers": "^5.7.1 <6",
         "safe-stable-stringify": "^2.4.2"
@@ -17632,6 +17631,9 @@
       "version": "0.0.52",
       "dependencies": {
         "@canvas-js/interfaces": "0.0.52",
+        "@cosmjs/amino": "^0.29.5",
+        "@cosmjs/crypto": "^0.29.5",
+        "@cosmjs/encoding": "^0.29.5",
         "@ethersproject/wallet": "^5.7.0",
         "ethers": "^5.7.1 <6",
         "safe-stable-stringify": "^2.4.2"
@@ -18855,7 +18857,6 @@
       "version": "file:packages/chain-ethereum",
       "requires": {
         "@canvas-js/interfaces": "0.0.52",
-        "@cosmjs/encoding": "^0.29.5",
         "@ethersproject/wallet": "^5.7.0",
         "ethers": "^5.7.1 <6",
         "safe-stable-stringify": "^2.4.2",
@@ -18866,6 +18867,9 @@
       "version": "file:packages/chain-evmos",
       "requires": {
         "@canvas-js/interfaces": "0.0.52",
+        "@cosmjs/amino": "^0.29.5",
+        "@cosmjs/crypto": "^0.29.5",
+        "@cosmjs/encoding": "^0.29.5",
         "@ethersproject/wallet": "^5.7.0",
         "ethers": "^5.7.1 <6",
         "safe-stable-stringify": "^2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "packages/hooks",
         "packages/chain-ethereum",
         "packages/chain-cosmos",
+        "packages/chain-evmos",
         "packages/chain-solana",
         "packages/chain-substrate",
         "packages/chain-terra",
@@ -1724,6 +1725,10 @@
     },
     "node_modules/@canvas-js/chain-ethereum": {
       "resolved": "packages/chain-ethereum",
+      "link": true
+    },
+    "node_modules/@canvas-js/chain-evmos": {
+      "resolved": "packages/chain-evmos",
       "link": true
     },
     "node_modules/@canvas-js/chain-solana": {
@@ -17613,6 +17618,20 @@
       "version": "0.0.52",
       "dependencies": {
         "@canvas-js/interfaces": "0.0.52",
+        "@cosmjs/encoding": "^0.29.5",
+        "@ethersproject/wallet": "^5.7.0",
+        "ethers": "^5.7.1 <6",
+        "safe-stable-stringify": "^2.4.2"
+      },
+      "devDependencies": {
+        "typescript": "^4.9.4"
+      }
+    },
+    "packages/chain-evmos": {
+      "name": "@canvas-js/chain-evmos",
+      "version": "0.0.52",
+      "dependencies": {
+        "@canvas-js/interfaces": "0.0.52",
         "@ethersproject/wallet": "^5.7.0",
         "ethers": "^5.7.1 <6",
         "safe-stable-stringify": "^2.4.2"
@@ -17808,6 +17827,7 @@
         "@ava/typescript": "^3.0.1",
         "@canvas-js/chain-cosmos": "0.0.52",
         "@canvas-js/chain-ethereum": "0.0.52",
+        "@canvas-js/chain-evmos": "0.0.52",
         "@canvas-js/chain-solana": "0.0.52",
         "@canvas-js/chain-substrate": "0.0.52",
         "@canvas-js/chain-terra": "0.0.52",
@@ -18835,6 +18855,17 @@
       "version": "file:packages/chain-ethereum",
       "requires": {
         "@canvas-js/interfaces": "0.0.52",
+        "@cosmjs/encoding": "^0.29.5",
+        "@ethersproject/wallet": "^5.7.0",
+        "ethers": "^5.7.1 <6",
+        "safe-stable-stringify": "^2.4.2",
+        "typescript": "^4.9.4"
+      }
+    },
+    "@canvas-js/chain-evmos": {
+      "version": "file:packages/chain-evmos",
+      "requires": {
+        "@canvas-js/interfaces": "0.0.52",
         "@ethersproject/wallet": "^5.7.0",
         "ethers": "^5.7.1 <6",
         "safe-stable-stringify": "^2.4.2",
@@ -19065,6 +19096,7 @@
         "@ava/typescript": "^3.0.1",
         "@canvas-js/chain-cosmos": "0.0.52",
         "@canvas-js/chain-ethereum": "0.0.52",
+        "@canvas-js/chain-evmos": "0.0.52",
         "@canvas-js/chain-solana": "0.0.52",
         "@canvas-js/chain-substrate": "0.0.52",
         "@canvas-js/chain-terra": "0.0.52",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "packages/hooks",
     "packages/chain-ethereum",
     "packages/chain-cosmos",
+    "packages/chain-evmos",
     "packages/chain-solana",
     "packages/chain-substrate",
     "packages/chain-terra",

--- a/packages/chain-evmos/package.json
+++ b/packages/chain-evmos/package.json
@@ -10,6 +10,9 @@
   ],
   "dependencies": {
     "@canvas-js/interfaces": "0.0.52",
+    "@cosmjs/amino": "^0.29.5",
+    "@cosmjs/crypto": "^0.29.5",
+    "@cosmjs/encoding": "^0.29.5",
     "@ethersproject/wallet": "^5.7.0",
     "ethers": "^5.7.1 <6",
     "safe-stable-stringify": "^2.4.2"

--- a/packages/chain-evmos/package.json
+++ b/packages/chain-evmos/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@canvas-js/chain-evmos",
+  "version": "0.0.52",
+  "type": "module",
+  "author": "Canvas Technology Corporation (https://canvas.xyz)",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "dependencies": {
+    "@canvas-js/interfaces": "0.0.52",
+    "@ethersproject/wallet": "^5.7.0",
+    "ethers": "^5.7.1 <6",
+    "safe-stable-stringify": "^2.4.2"
+  },
+  "devDependencies": {
+    "typescript": "^4.9.4"
+  }
+}

--- a/packages/chain-evmos/src/createMockSigner.ts
+++ b/packages/chain-evmos/src/createMockSigner.ts
@@ -1,0 +1,18 @@
+import { ethers } from "ethers"
+import { EvmMetaMaskSigner } from "./signerInterface.js"
+
+export async function createMockEvmosSigner(): Promise<EvmMetaMaskSigner> {
+	const wallet = ethers.Wallet.createRandom()
+	return {
+		eth: {
+			personal: {
+				sign: async (dataToSign: string, address: string, password: string) => {
+					return wallet.signMessage(dataToSign)
+				},
+			},
+			getAccounts: async () => {
+				return [wallet.address]
+			},
+		},
+	}
+}

--- a/packages/chain-evmos/src/implementation.ts
+++ b/packages/chain-evmos/src/implementation.ts
@@ -1,0 +1,136 @@
+import {
+	Action,
+	ActionPayload,
+	Chain,
+	ChainId,
+	ChainImplementation,
+	serializeSessionPayload,
+	Session,
+	SessionPayload,
+} from "@canvas-js/interfaces"
+import { ethers } from "ethers"
+import { configure as configureStableStringify } from "safe-stable-stringify"
+import { Secp256k1Wallet } from "@cosmjs/amino"
+import { Random } from "@cosmjs/crypto"
+import { toBech32 } from "@cosmjs/encoding"
+import { EvmMetaMaskSigner } from "./signerInterface.js"
+
+type Secp256k1WalletPrivateKey = Uint8Array
+
+const sortedStringify = configureStableStringify({
+	bigint: false,
+	circularValue: Error,
+	strict: true,
+	deterministic: true,
+})
+
+const encodeEthAddress = (bech32Prefix: string, address: string) =>
+	toBech32(bech32Prefix, ethers.utils.arrayify(address))
+
+export class EvmosChainImplementation implements ChainImplementation<EvmMetaMaskSigner, Secp256k1WalletPrivateKey> {
+	public readonly chain: Chain = "cosmos"
+
+	constructor(public readonly chainId: ChainId = "osmosis-1", public readonly bech32Prefix: string = "osmo") {}
+
+	async verifyAction(action: Action): Promise<void> {
+		// const actionSignerAddress = action.session ?? action.payload.from
+		// const signDocPayload = await getActionSignatureData(action.payload, actionSignerAddress)
+		// const signDocDigest = new Sha256(serializeSignDoc(signDocPayload)).digest()
+		// const prefix = "cosmos" // not: fromBech32(payload.from).prefix;
+
+		// const { pubkey, signature: decodedSignature } = decodeSignature(JSON.parse(action.signature))
+		// if (action.session && action.session !== toBech32(prefix, rawSecp256k1PubkeyToRawAddress(pubkey))) {
+		// 	// Delegated signatures: If session exists, pubkey should be the public key for `action.session`
+		// 	throw new Error("Action signed with a pubkey that doesn't match the session address")
+		// }
+		// if (!action.session && action.payload.from !== toBech32(prefix, rawSecp256k1PubkeyToRawAddress(pubkey))) {
+		// 	// Direct signatures: If session is null, pubkey should be the public key for `action.payload.from`
+		// 	throw new Error("Action signed with a pubkey that doesn't match the from address")
+		// }
+		// const secpSignature = Secp256k1Signature.fromFixedLength(decodedSignature)
+		// const valid = await Secp256k1.verifySignature(secpSignature, signDocDigest, pubkey)
+
+		// if (!valid) {
+		// 	throw new Error("Invalid session signature")
+		// }
+		throw Error("Not implemented!")
+	}
+
+	async verifySession(session: Session): Promise<void> {
+		//
+		// ethereum address handling on cosmos chains via metamask
+		//
+
+		const msgBuffer = Buffer.from(sortedStringify(session.payload))
+
+		// toBuffer() doesn't work if there is a newline
+		const msgHash = ethers.utils.hashMessage(msgBuffer)
+		const publicKey = ethers.utils.recoverPublicKey(msgHash, session.signature.trim())
+		const address = ethers.utils.computeAddress(publicKey)
+		const lowercaseAddress = address.toLowerCase()
+
+		let isValid
+		try {
+			if (session.payload.from === encodeEthAddress(this.bech32Prefix, lowercaseAddress)) isValid = true
+		} catch (e) {
+			isValid = false
+		}
+
+		if (!isValid) {
+			throw new Error("Invalid session signature")
+		}
+	}
+
+	getSignerAddress = async (signer: EvmMetaMaskSigner): Promise<string> => {
+		const accounts = await signer.eth.getAccounts()
+		const address = accounts[0]
+		// convert to cosmos address
+		return toBech32(this.bech32Prefix, ethers.utils.arrayify(address))
+	}
+	// encodeEthAddress(app.chain?.meta.bech32Prefix || 'inj', acc)
+	getDelegatedSignerAddress = async (privkey: Secp256k1WalletPrivateKey) => {
+		const wallet = await Secp256k1Wallet.fromKey(privkey)
+		return (await wallet.getAccounts())[0].address
+	}
+
+	isSigner(signer: unknown): signer is EvmMetaMaskSigner {
+		throw Error("Not implemented!")
+	}
+
+	isDelegatedSigner(delegatedSigner: unknown): delegatedSigner is Secp256k1WalletPrivateKey {
+		// copy from cosmos
+		throw Error("Not implemented!")
+	}
+
+	async signSession(signer: EvmMetaMaskSigner, payload: SessionPayload): Promise<Session> {
+		const address = await this.getSignerAddress(signer)
+		const dataToSign = serializeSessionPayload(payload)
+		const signature = await signer.eth.personal.sign(dataToSign, address, "")
+		return {
+			payload,
+			signature,
+			type: "session",
+		}
+	}
+
+	async signAction(signer: EvmMetaMaskSigner, payload: ActionPayload): Promise<Action> {
+		throw Error("Not implemented!")
+	}
+
+	async signDelegatedAction(privkey: Secp256k1WalletPrivateKey, payload: ActionPayload): Promise<Action> {
+		throw Error("Not implemented!")
+	}
+
+	importDelegatedSigner = (privkeyString: string) => Buffer.from(privkeyString, "hex")
+	exportDelegatedSigner = (privkey: Secp256k1WalletPrivateKey) => Buffer.from(privkey).toString("hex")
+	generateDelegatedSigner = async (): Promise<Secp256k1WalletPrivateKey> => {
+		// same entropy for generating private keys as @cosmjs/amino Secp256k1HdWallet
+		const entropyLength = 4 * Math.floor((11 * 24) / 33)
+		const privkeyBytes = Random.getBytes(entropyLength)
+		return privkeyBytes
+	}
+
+	async getLatestBlock(): Promise<string> {
+		throw Error("Not implemented!")
+	}
+}

--- a/packages/chain-evmos/src/implementation.ts
+++ b/packages/chain-evmos/src/implementation.ts
@@ -107,7 +107,7 @@ export class EvmosChainImplementation implements ChainImplementation<EvmMetaMask
 	}
 
 	isSigner(signer: unknown): signer is EvmMetaMaskSigner {
-		return !(delegatedSigner instanceof Uint8Array)
+		return !(signer instanceof Uint8Array)
 	}
 
 	isDelegatedSigner(delegatedSigner: unknown): delegatedSigner is Secp256k1WalletPrivateKey {

--- a/packages/chain-evmos/src/index.ts
+++ b/packages/chain-evmos/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./implementation.js"
+export * from "./createMockSigner.js"

--- a/packages/chain-evmos/src/signatureData.ts
+++ b/packages/chain-evmos/src/signatureData.ts
@@ -1,0 +1,48 @@
+import { configure } from "safe-stable-stringify"
+import type { AminoMsg, StdSignDoc, StdFee } from "@cosmjs/amino"
+import { makeSignDoc } from "@cosmjs/amino"
+import type { ActionPayload, SessionPayload } from "@canvas-js/interfaces"
+
+const jsonStableStringify = configure({ circularValue: Error, bigint: false, deterministic: true, strict: true })
+
+export const getActionSignatureData = async (actionPayload: ActionPayload, address: string): Promise<StdSignDoc> => {
+	const accountNumber = 0
+	const sequence = 0
+	const chainId = ""
+	const fee: StdFee = {
+		gas: "0",
+		amount: [],
+	}
+	const memo = ""
+
+	const jsonTx: AminoMsg = {
+		type: "sign/MsgSignData",
+		value: {
+			signer: address,
+			data: jsonStableStringify(actionPayload),
+		},
+	}
+	const signDoc = makeSignDoc([jsonTx], fee, chainId, memo, accountNumber, sequence)
+	return signDoc
+}
+
+export const getSessionSignatureData = async (sessionPayload: SessionPayload, address: string): Promise<StdSignDoc> => {
+	const accountNumber = 0
+	const sequence = 0
+	const chainId = ""
+	const fee: StdFee = {
+		gas: "0",
+		amount: [],
+	}
+	const memo = ""
+
+	const jsonTx: AminoMsg = {
+		type: "sign/MsgSignData",
+		value: {
+			signer: address,
+			data: jsonStableStringify(sessionPayload),
+		},
+	}
+	const signDoc = makeSignDoc([jsonTx], fee, chainId, memo, accountNumber, sequence)
+	return signDoc
+}

--- a/packages/chain-evmos/src/signerInterface.ts
+++ b/packages/chain-evmos/src/signerInterface.ts
@@ -1,0 +1,6 @@
+export interface EvmMetaMaskSigner {
+	eth: {
+		personal: { sign: (dataToSign: string, address: string, password: string) => Promise<string> }
+		getAccounts: () => Promise<string[]>
+	}
+}

--- a/packages/chain-evmos/tsconfig.json
+++ b/packages/chain-evmos/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["src"],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "references": [
+    {"path": "../interfaces"}
+  ]
+}

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -22,6 +22,7 @@
     "@canvas-js/chain-solana": "0.0.52",
     "@canvas-js/chain-substrate": "0.0.52",
     "@canvas-js/chain-terra": "0.0.52",
+    "@canvas-js/chain-evmos": "0.0.52",
     "@canvas-js/interfaces": "0.0.52",
     "@types/sha.js": "^2.4.0",
     "ava": "^5.1.0",

--- a/packages/interfaces/test/chain.test.ts
+++ b/packages/interfaces/test/chain.test.ts
@@ -14,31 +14,31 @@ interface MockedImplementation<CI extends ChainImplementation> {
 }
 
 const IMPLEMENTATIONS = [
-	// {
-	// 	implementationName: "ethereum",
-	// 	chainImplementation: new EthereumChainImplementation(),
-	// 	createMockSigner: createMockEthereumSigner,
-	// },
-	// {
-	// 	implementationName: "solana",
-	// 	chainImplementation: new SolanaChainImplementation(),
-	// 	createMockSigner: createMockSolanaSigner,
-	// },
-	// {
-	// 	implementationName: "substrate",
-	// 	chainImplementation: new SubstrateChainImplementation(),
-	// 	createMockSigner: createMockSubstrateSigner,
-	// },
-	// {
-	// 	implementationName: "cosmos",
-	// 	chainImplementation: new CosmosChainImplementation(),
-	// 	createMockSigner: createMockCosmosSigner,
-	// },
-	// {
-	// 	implementationName: "terra",
-	// 	chainImplementation: new TerraChainImplementation(),
-	// 	createMockSigner: createMockTerraSigner,
-	// },
+	{
+		implementationName: "ethereum",
+		chainImplementation: new EthereumChainImplementation(),
+		createMockSigner: createMockEthereumSigner,
+	},
+	{
+		implementationName: "solana",
+		chainImplementation: new SolanaChainImplementation(),
+		createMockSigner: createMockSolanaSigner,
+	},
+	{
+		implementationName: "substrate",
+		chainImplementation: new SubstrateChainImplementation(),
+		createMockSigner: createMockSubstrateSigner,
+	},
+	{
+		implementationName: "cosmos",
+		chainImplementation: new CosmosChainImplementation(),
+		createMockSigner: createMockCosmosSigner,
+	},
+	{
+		implementationName: "terra",
+		chainImplementation: new TerraChainImplementation(),
+		createMockSigner: createMockTerraSigner,
+	},
 	{
 		implementationName: "evmos",
 		chainImplementation: new EvmosChainImplementation(),

--- a/packages/interfaces/test/chain.test.ts
+++ b/packages/interfaces/test/chain.test.ts
@@ -5,6 +5,7 @@ import { createMockSolanaSigner, SolanaChainImplementation } from "@canvas-js/ch
 import { createMockSubstrateSigner, SubstrateChainImplementation } from "@canvas-js/chain-substrate"
 import { createMockCosmosSigner, CosmosChainImplementation } from "@canvas-js/chain-cosmos"
 import { createMockTerraSigner, TerraChainImplementation } from "@canvas-js/chain-terra"
+import { createMockEvmosSigner, EvmosChainImplementation } from "@canvas-js/chain-evmos"
 
 interface MockedImplementation<CI extends ChainImplementation> {
 	implementationName: string
@@ -13,30 +14,35 @@ interface MockedImplementation<CI extends ChainImplementation> {
 }
 
 const IMPLEMENTATIONS = [
+	// {
+	// 	implementationName: "ethereum",
+	// 	chainImplementation: new EthereumChainImplementation(),
+	// 	createMockSigner: createMockEthereumSigner,
+	// },
+	// {
+	// 	implementationName: "solana",
+	// 	chainImplementation: new SolanaChainImplementation(),
+	// 	createMockSigner: createMockSolanaSigner,
+	// },
+	// {
+	// 	implementationName: "substrate",
+	// 	chainImplementation: new SubstrateChainImplementation(),
+	// 	createMockSigner: createMockSubstrateSigner,
+	// },
+	// {
+	// 	implementationName: "cosmos",
+	// 	chainImplementation: new CosmosChainImplementation(),
+	// 	createMockSigner: createMockCosmosSigner,
+	// },
+	// {
+	// 	implementationName: "terra",
+	// 	chainImplementation: new TerraChainImplementation(),
+	// 	createMockSigner: createMockTerraSigner,
+	// },
 	{
-		implementationName: "ethereum",
-		chainImplementation: new EthereumChainImplementation(),
-		createMockSigner: createMockEthereumSigner,
-	},
-	{
-		implementationName: "solana",
-		chainImplementation: new SolanaChainImplementation(),
-		createMockSigner: createMockSolanaSigner,
-	},
-	{
-		implementationName: "substrate",
-		chainImplementation: new SubstrateChainImplementation(),
-		createMockSigner: createMockSubstrateSigner,
-	},
-	{
-		implementationName: "cosmos",
-		chainImplementation: new CosmosChainImplementation(),
-		createMockSigner: createMockCosmosSigner,
-	},
-	{
-		implementationName: "terra",
-		chainImplementation: new TerraChainImplementation(),
-		createMockSigner: createMockTerraSigner,
+		implementationName: "evmos",
+		chainImplementation: new EvmosChainImplementation(),
+		createMockSigner: createMockEvmosSigner,
 	},
 ] as MockedImplementation<any>[]
 

--- a/packages/interfaces/test/tsconfig.json
+++ b/packages/interfaces/test/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "../." },
     { "path": "../../interfaces" },
     { "path": "../../chain-ethereum" },
+    { "path": "../../chain-evmos" },
     { "path": "../../chain-solana" },
     { "path": "../../chain-substrate" },
     { "path": "../../chain-cosmos" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,9 @@
     { "path": "./packages/hooks" },
     { "path": "./packages/chain-ethereum" },
     { "path": "./packages/chain-cosmos" },
+    { "path": "./packages/chain-evmos" },
     { "path": "./packages/chain-solana" },
     { "path": "./packages/chain-substrate" },
-    { "path": "./packages/chain-terra" },
+    { "path": "./packages/chain-terra" }
   ]
 }


### PR DESCRIPTION
This PR adds a new chain implementation for metamask+evm+cosmos. It corresponds to this exist web wallet in the Commonwealth repo: https://github.com/hicommonwealth/commonwealth/blob/842f1fe1985997e93163cb2276d48949329fd726/packages/commonwealth/client/scripts/controllers/app/webWallets/cosmos_evm_metamask_web_wallet.ts


## Description

Add a new chain implementation and mock signer.

## How has this been tested?

- [X] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
