### PR TITLE
add json-schema to package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16079,9 +16079,10 @@
         "@ava/typescript": "^3.0.1",
         "@canvas-js/chain-ethereum": "0.1.1",
         "@canvas-js/interfaces": "0.1.1",
-        "@canvas-js/okra-node": "0.1.1",
+        "@canvas-js/okra-node": "^0.1.1",
         "@chainsafe/libp2p-gossipsub": "^6.0.0",
         "@chainsafe/libp2p-noise": "^11.0.0",
+        "@hyperjump/json-schema": "^1.2.4",
         "@libp2p/bootstrap": "^6.0.0",
         "@libp2p/interface-connection": "^3.0.8",
         "@libp2p/interface-peer-id": "^2.0.1",
@@ -16756,6 +16757,48 @@
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "dev": true
+    },
+    "@hyperjump/json-pointer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-pointer/-/json-pointer-1.0.1.tgz",
+      "integrity": "sha512-vV2pSc7JCwbKEMzh8kr/ICZdO+UZbA3aZ7N8t7leDi9cduWKa9yoP5LS04LnsbErlPbUNHvWBFlbTaR/o/uf7A==",
+      "requires": {
+        "just-curry-it": "^5.3.0"
+      }
+    },
+    "@hyperjump/json-schema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-1.2.4.tgz",
+      "integrity": "sha512-KhljYrxKrqxrNCgsyt8rdgXgIIvlEx2SIsVlJe7QRPxiSkqVS9FiNBNLpo+2/J5K1qKPo7Z+QKO8smBmjS+Xbg==",
+      "requires": {
+        "@hyperjump/json-pointer": "^1.0.0",
+        "@hyperjump/pact": "^0.2.4",
+        "@hyperjump/uri": "^1.0.0",
+        "content-type": "^1.0.4",
+        "fastest-stable-stringify": "^2.0.2",
+        "undici": "^5.19.1",
+        "uuid": "^9.0.0"
+      }
+    },
+    "@hyperjump/pact": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@hyperjump/pact/-/pact-0.2.5.tgz",
+      "integrity": "sha512-93m7gLf40EI8svsKrdPc+KkLsngwX/2ld08xwc0PFioxJSxnfkx1BUHNJVjhG386UUYP6mNe+ZtmIiDXDJ4TQg==",
+      "requires": {
+        "just-curry-it": "^3.1.0"
+      },
+      "dependencies": {
+        "just-curry-it": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-3.2.1.tgz",
+          "integrity": "sha512-Q8206k8pTY7krW32cdmPsP+DqqLgWx/hYPSj9/+7SYqSqz7UuwPbfSe07lQtvuuaVyiSJveXk0E5RydOuWwsEg=="
+        }
+      }
+    },
+    "@hyperjump/uri": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@hyperjump/uri/-/uri-1.1.0.tgz",
+      "integrity": "sha512-xAgs2jKcMpYtoSa81XmuTIzDGCutLwzwkC7sYc54Fl+a75BfiHIIynRdBSJe31kSOgsRaNXM7sHpzdi8v51XhQ=="
     },
     "@improbable-eng/grpc-web": {
       "version": "0.14.1",
@@ -21414,6 +21457,11 @@
       "version": "1.0.16",
       "dev": true
     },
+    "fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
+    },
     "fastq": {
       "version": "1.15.0",
       "dev": true,
@@ -22474,6 +22522,11 @@
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
       }
+    },
+    "just-curry-it": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-5.3.0.tgz",
+      "integrity": "sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw=="
     },
     "k-bucket": {
       "version": "5.1.0",


### PR DESCRIPTION
This is a commit that was missing from: https://github.com/canvasxyz/canvas/pull/140

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
