### PR TITLE
Add test data buttons, fix scrollback (chat-next)

### DIFF
--- a/examples/chat-next/components/Connect.tsx
+++ b/examples/chat-next/components/Connect.tsx
@@ -61,7 +61,6 @@ const Login: React.FC<{ setClient: (client: Client | null) => void }> = ({ setCl
 	const provider = useProvider<ethers.providers.JsonRpcProvider>()
 
 	const chainImplementation = useMemo(() => {
-		console.log("chain", chain)
 		return new EthereumChainImplementation(chain?.id.toString() ?? "1", provider)
 	}, [chain?.id, provider])
 

--- a/examples/chat-next/components/Connect.tsx
+++ b/examples/chat-next/components/Connect.tsx
@@ -49,7 +49,7 @@ export const Connect: React.FC<{ client: Client | null; setClient: (client: Clie
 				<ErrorMessage error={connectionError} />
 
 				<Login setClient={setClient} />
-				<GenerateData client={client} baseNumberOfMessages={50} />
+				{client && <GenerateData client={client} baseNumberOfMessages={50} />}
 			</div>
 		</div>
 	)

--- a/examples/chat-next/components/Connect.tsx
+++ b/examples/chat-next/components/Connect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react"
+import React, { useCallback, useState, useContext, useEffect, useMemo } from "react"
 
 import { ethers } from "ethers"
 import { useAccount, useConnect, useDisconnect, useSigner, useNetwork, useProvider } from "wagmi"
@@ -8,7 +8,10 @@ import { EthereumChainImplementation } from "@canvas-js/chain-ethereum"
 
 import { ErrorMessage } from "./ErrorMessage"
 
-export const Connect: React.FC<{ setClient: (client: Client | null) => void }> = ({ setClient }) => {
+export const Connect: React.FC<{ client: Client | null; setClient: (client: Client | null) => void }> = ({
+	client,
+	setClient,
+}) => {
 	const { connect, connectors, error: connectionError, isLoading: isConnectionLoading, pendingConnector } = useConnect()
 	const { disconnect } = useDisconnect()
 	const { address, isConnected } = useAccount()
@@ -43,10 +46,10 @@ export const Connect: React.FC<{ setClient: (client: Client | null) => void }> =
 						))}
 					</>
 				)}
-
 				<ErrorMessage error={connectionError} />
 
 				<Login setClient={setClient} />
+				<GenerateData client={client} baseNumberOfMessages={50} />
 			</div>
 		</div>
 	)
@@ -104,5 +107,35 @@ const Login: React.FC<{ setClient: (client: Client | null) => void }> = ({ setCl
 
 			<ErrorMessage error={error} />
 		</>
+	)
+}
+
+const GenerateData: React.FC<{ client: Client; baseNumberOfMessages: number }> = ({ client, baseNumberOfMessages }) => {
+	const [count, setCount] = useState(0)
+
+	const generateData = useCallback(
+		(n: number) => {
+			if (!client) return
+			const timestamp = +Date.now()
+			for (let i = 0; i < n; i++) {
+				const content = `#${count + i + 1}`
+				client.createPost({ content }, { timestamp: timestamp + i })
+			}
+			setCount(count + baseNumberOfMessages)
+		},
+		[client]
+	)
+
+	if (!client) return <></>
+
+	return (
+		<p>
+			<button disabled={!client} onClick={generateData.bind(this, baseNumberOfMessages)}>
+				Create {baseNumberOfMessages} messages
+			</button>{" "}
+			<button disabled={!client} onClick={generateData.bind(this, baseNumberOfMessages * 10)}>
+				Create {baseNumberOfMessages * 10} messages
+			</button>
+		</p>
 	)
 }

--- a/examples/chat-next/components/Messages.tsx
+++ b/examples/chat-next/components/Messages.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef } from "react"
+import _ from "lodash"
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
+import { Virtuoso } from "react-virtuoso"
 
 import { useEnsName } from "wagmi"
 import { Client, useRoute } from "@canvas-js/hooks"
@@ -11,25 +13,81 @@ type Post = {
 }
 
 export const MessagesInfiniteScroller: React.FC<{}> = ({}) => {
-	const { data, error } = useRoute<Post>("/posts", {})
+	const [posts, setPosts] = useState<Post[]>([])
+	const [cursor, setCursor] = useState<string>("")
 
-	const scrollContainer = useRef<HTMLDivElement>(null)
-	useLayoutEffect(() => {
-		if (scrollContainer.current !== null) {
-			scrollContainer.current.scrollTop = scrollContainer.current.scrollHeight
+	// Virtuoso uses firstItemIndex to maintain scroll position when
+	// items are added. It should always be set *relative to its
+	// original value* and cannot be negative, so we initialize it
+	// with a very large MAX_VALUE.
+	const MAX_VALUE = 999999999
+	const virtuoso = useRef(null)
+	const [firstItemIndex, setFirstItemIndex] = useState<number>(MAX_VALUE)
+
+	// Posts are fetched declaratively, by updating `cursor`.
+	const { data: fetched, error } = useRoute<Post>("/posts", { before: cursor })
+
+	// Because of pagination, /posts returns a window of posts ordered
+	// the same as displayed posts, but potentially overlapping or
+	// interleaved, so we use a set comparision to filter out duplicates.
+	//
+	// New posts may enter *anywhere* in the window, but we only maintain
+	// a subscription to the latest (before = "") or (before = cursor)
+	useEffect(() => {
+		if (!fetched) return
+
+		if (posts.length === 0) {
+			const filtered = [...fetched]
+			filtered.reverse()
+			setPosts(filtered)
+		} else {
+			const postsM = new Map(posts.map((f) => [f.id, f]))
+			const filtered = fetched.filter((item) => !postsM.has(item.id))
+			if (filtered.length === 0) return
+			setFirstItemIndex(firstItemIndex - filtered.length)
+			filtered.reverse()
+			// TODO: Interleave new posts according to updated_at, so if we
+			// receive new posts out-of-order (happens frequenty on first insert)
+			// then they won't persist out-of-order
+			setPosts([...filtered, ...posts])
 		}
-	}, [data])
+	}, [fetched, posts])
+
+	const startReached = useCallback(
+		(event: React.UIEvent<HTMLElement>) => {
+			console.log("startReached")
+			if (posts.length === 0) return
+
+			setTimeout(() => {
+				const earliestPost = posts[0]
+				const newCursor = earliestPost?.updated_at?.toString()
+				if (!earliestPost || cursor === earliestPost.updated_at) return // Nothing more
+				setCursor(earliestPost.updated_at)
+				console.log("cursor changed:", earliestPost.updated_at)
+			}, 500)
+		},
+		[posts, cursor]
+	)
+
+	const itemContent = useCallback((index, post) => <Post key={post.id} {...post} />, [])
+	const followOutput = useCallback((isAtBottom) => (isAtBottom ? "smooth" : false), [])
 
 	return (
-		<div id="scroll-container" ref={scrollContainer}>
-			<ul className="tree-view">
-				{data &&
-					data.map((_, i, posts) => {
-						const post = posts[posts.length - i - 1]
-						return <Post key={post.id} {...post} />
-					})}
-			</ul>
-		</div>
+		<ul className="tree-view">
+			{posts.length > 0 && (
+				<Virtuoso
+					ref={virtuoso}
+					firstItemIndex={firstItemIndex}
+					initialTopMostItemIndex={posts.length}
+					itemContent={itemContent}
+					data={posts}
+					startReached={startReached}
+					followOutput={followOutput}
+					style={{ flex: "1 1 auto", overscrollBehavior: "contain" }}
+					increaseViewportBy={{ bottom: 0, top: 40 }}
+				/>
+			)}
+		</ul>
 	)
 }
 
@@ -42,7 +100,6 @@ export const Messages: React.FC<{ client: Client | null }> = ({ client }) => {
 			if (event.key === "Enter" && input !== null && client !== null) {
 				try {
 					const { hash } = await client.createPost({ content: input.value })
-					console.log("created post", hash)
 					input.value = ""
 					setTimeout(() => input.focus(), 0)
 				} catch (err) {

--- a/examples/chat-next/components/Messages.tsx
+++ b/examples/chat-next/components/Messages.tsx
@@ -10,6 +10,29 @@ type Post = {
 	updated_at: number
 }
 
+export const MessagesInfiniteScroller: React.FC<{}> = ({}) => {
+	const { data, error } = useRoute<Post>("/posts", {})
+
+	const scrollContainer = useRef<HTMLDivElement>(null)
+	useLayoutEffect(() => {
+		if (scrollContainer.current !== null) {
+			scrollContainer.current.scrollTop = scrollContainer.current.scrollHeight
+		}
+	}, [data])
+
+	return (
+		<div id="scroll-container" ref={scrollContainer}>
+			<ul className="tree-view">
+				{data &&
+					data.map((_, i, posts) => {
+						const post = posts[posts.length - i - 1]
+						return <Post key={post.id} {...post} />
+					})}
+			</ul>
+		</div>
+	)
+}
+
 export const Messages: React.FC<{ client: Client | null }> = ({ client }) => {
 	const inputRef = useRef<HTMLInputElement>(null)
 
@@ -40,30 +63,13 @@ export const Messages: React.FC<{ client: Client | null }> = ({ client }) => {
 		}
 	}, [isReady])
 
-	const { data, error } = useRoute<Post>("/posts", {})
-
-	const scrollContainer = useRef<HTMLDivElement>(null)
-	useLayoutEffect(() => {
-		if (scrollContainer.current !== null) {
-			scrollContainer.current.scrollTop = scrollContainer.current.scrollHeight
-		}
-	}, [data])
-
 	return (
 		<div id="messages" className="window">
 			<div className="title-bar">
 				<div className="title-bar-text">Messages</div>
 			</div>
 			<div className="window-body">
-				<div id="scroll-container" ref={scrollContainer}>
-					<ul className="tree-view">
-						{data &&
-							data.map((_, i, posts) => {
-								const post = posts[posts.length - i - 1]
-								return <Post key={post.id} {...post} />
-							})}
-					</ul>
-				</div>
+				<MessagesInfiniteScroller />
 				<input
 					type="text"
 					disabled={!isReady}

--- a/examples/chat-next/components/Messages.tsx
+++ b/examples/chat-next/components/Messages.tsx
@@ -14,7 +14,7 @@ type Post = {
 
 export const MessagesInfiniteScroller: React.FC<{}> = ({}) => {
 	const [posts, setPosts] = useState<Post[]>([])
-	const [cursor, setCursor] = useState<string>("")
+	const [cursor, setCursor] = useState<string | number>("")
 
 	// Virtuoso uses firstItemIndex to maintain scroll position when
 	// items are added. It should always be set *relative to its
@@ -60,7 +60,8 @@ export const MessagesInfiniteScroller: React.FC<{}> = ({}) => {
 			// caps the maximum scroll to `scroller.offsetHeight - scroller.scrollHeight`
 			// when there might be additional not-yet-rendered content at the bottom.
 			if (filteredPastPosts.length === 0) {
-				const scroller = document.querySelector("[data-virtuoso-scroller=true]")
+				const scroller = document.querySelector("[data-virtuoso-scroller=true]") as HTMLElement
+				if (scroller === null) return
 				// Only scroll-to-bottom if we're already near the bottom
 				if (scroller.scrollTop + scroller.offsetHeight < scroller.scrollHeight - 40) return
 				setTimeout(() => {
@@ -74,8 +75,7 @@ export const MessagesInfiniteScroller: React.FC<{}> = ({}) => {
 	}, [newPosts, pastPosts, posts])
 
 	const startReached = useCallback(
-		(event: React.UIEvent<HTMLElement>) => {
-			console.log("startReached")
+		(index: number) => {
 			if (posts.length === 0) return
 
 			setTimeout(() => {
@@ -89,7 +89,7 @@ export const MessagesInfiniteScroller: React.FC<{}> = ({}) => {
 		[posts, cursor]
 	)
 
-	const itemContent = useCallback((index, post) => <Post key={post.id} {...post} />, [])
+	const itemContent = useCallback((index: number, post: Post) => <Post key={post.id} {...post} />, [])
 	// const followOutput = useCallback((isAtBottom) => (isAtBottom ? "auto" : false), [])
 
 	return (

--- a/examples/chat-next/package.json
+++ b/examples/chat-next/package.json
@@ -24,6 +24,7 @@
     "next": "^13.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-virtuoso": "^4.1.0",
     "stoppable": "^1.1.0",
     "wagmi": "^0.11.5"
   },

--- a/examples/chat-next/pages/index.tsx
+++ b/examples/chat-next/pages/index.tsx
@@ -24,7 +24,7 @@ export default function Index() {
 			<Messages client={client} />
 			<div id="sidebar">
 				<Application />
-				<Connect setClient={setClient} />
+				<Connect client={client} setClient={setClient} />
 			</div>
 		</main>
 	)

--- a/examples/chat-next/spec.canvas.js
+++ b/examples/chat-next/spec.canvas.js
@@ -9,10 +9,11 @@ export const models = {
 }
 
 export const routes = {
-	"/posts": ({ offset = 0 }, { db }) =>
-		db.queryRaw(`SELECT id, from_id, content, updated_at FROM posts ORDER BY updated_at DESC LIMIT 50 OFFSET :offset`, {
-			offset,
-		}),
+	"/posts": ({ before = "" }, { db }) => {
+		return db.queryRaw(`SELECT * FROM posts WHERE updated_at < :before ORDER BY updated_at DESC LIMIT 50`, {
+			before,
+		})
+	},
 }
 
 export const actions = {

--- a/examples/chat-next/styles.css
+++ b/examples/chat-next/styles.css
@@ -49,17 +49,19 @@ main {
 	gap: 4px;
 }
 
-#scroll-container {
-	overflow-y: scroll;
+#messages ul.tree-view {
 	flex-grow: 1;
 	height: 0px;
+  padding: 2px;
 
 	display: flex;
 	flex-direction: column;
 }
 
-#scroll-container ul.tree-view {
-	flex-grow: 1;
+#messages ul.tree-view li {
+  margin: 0;
+  padding-top: 3px;
+  padding-left: 6px;
 }
 
 #sidebar {

--- a/examples/chat-webpack/package.json
+++ b/examples/chat-webpack/package.json
@@ -18,8 +18,10 @@
     "@types/react-dom": "^18.0.10",
     "@wagmi/chains": "^0.2.8",
     "98.css": "^0.1.18",
+    "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-virtuoso": "^4.1.0",
     "wagmi": "^0.11.5"
   },
   "devDependencies": {

--- a/examples/chat-webpack/spec.canvas.js
+++ b/examples/chat-webpack/spec.canvas.js
@@ -9,10 +9,11 @@ export const models = {
 }
 
 export const routes = {
-	"/posts": ({ offset = 0 }, { db }) =>
-		db.queryRaw(`SELECT id, from_id, content, updated_at FROM posts ORDER BY updated_at DESC LIMIT 50 OFFSET :offset`, {
-			offset,
-		}),
+	"/posts": ({ before = "" }, { db }) => {
+		return db.queryRaw(`SELECT * FROM posts WHERE updated_at < :before ORDER BY updated_at DESC LIMIT 50`, {
+			before,
+		})
+	},
 }
 
 export const actions = {

--- a/examples/chat-webpack/src/Connect.tsx
+++ b/examples/chat-webpack/src/Connect.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo } from "react"
+import React, { useCallback, useState, useContext, useEffect, useMemo } from "react"
 
 import { ethers } from "ethers"
 import { useAccount, useConnect, useDisconnect, useSigner, useNetwork, useProvider } from "wagmi"
@@ -47,6 +47,7 @@ export const Connect: React.FC = ({}) => {
 				<ErrorMessage error={connectionError} />
 
 				<Login />
+				<GenerateData baseNumberOfMessages={50} />
 			</div>
 		</div>
 	)
@@ -105,5 +106,36 @@ const Login: React.FC = ({}) => {
 
 			<ErrorMessage error={error} />
 		</>
+	)
+}
+
+const GenerateData: React.FC<{ baseNumberOfMessages: number }> = ({ baseNumberOfMessages }) => {
+	const { client } = useContext(AppContext)
+	const [count, setCount] = useState(0)
+
+	const generateData = useCallback(
+		(n: number) => {
+			if (!client) return
+			const timestamp = +Date.now()
+			for (let i = 0; i < n; i++) {
+				const content = `#${count + i + 1}`
+				client.createPost({ content }, { timestamp: timestamp + i })
+			}
+			setCount(count + baseNumberOfMessages)
+		},
+		[client]
+	)
+
+	if (!client) return <></>
+
+	return (
+		<p>
+			<button disabled={!client} onClick={generateData.bind(this, baseNumberOfMessages)}>
+				Create {baseNumberOfMessages} messages
+			</button>{" "}
+			<button disabled={!client} onClick={generateData.bind(this, baseNumberOfMessages * 10)}>
+				Create {baseNumberOfMessages * 10} messages
+			</button>
+		</p>
 	)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2591,6 +2591,36 @@
       "version": "13.1.6",
       "license": "MIT"
     },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.1.6.tgz",
+      "integrity": "sha512-F3/6Z8LH/pGlPzR1AcjPFxx35mPqjE5xZcf+IL+KgbW9tMkp7CYi1y7qKrEWU7W4AumxX/8OINnDQWLiwLasLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.1.6.tgz",
+      "integrity": "sha512-cMwQjnB8vrYkWyK/H0Rf2c2pKIH4RGjpKUDvbjVAit6SbwPDpmaijLio0LWFV3/tOnY6kvzbL62lndVA0mkYpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "13.1.6",
       "cpu": [
@@ -2600,6 +2630,156 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.1.6.tgz",
+      "integrity": "sha512-/uOky5PaZDoaU99ohjtNcDTJ6ks/gZ5ykTQDvNZDjIoCxFe3+t06bxsTPY6tAO6uEAw5f6vVFX5H5KLwhrkZCA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.1.6.tgz",
+      "integrity": "sha512-qaEALZeV7to6weSXk3Br80wtFQ7cFTpos/q+m9XVRFggu+8Ib895XhMWdJBzew6aaOcMvYR6KQ6JmHA2/eMzWw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.1.6.tgz",
+      "integrity": "sha512-OybkbC58A1wJ+JrJSOjGDvZzrVEQA4sprJejGqMwiZyLqhr9Eo8FXF0y6HL+m1CPCpPhXEHz/2xKoYsl16kNqw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.1.6.tgz",
+      "integrity": "sha512-yCH+yDr7/4FDuWv6+GiYrPI9kcTAO3y48UmaIbrKy8ZJpi7RehJe3vIBRUmLrLaNDH3rY1rwoHi471NvR5J5NQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.1.6.tgz",
+      "integrity": "sha512-ECagB8LGX25P9Mrmlc7Q/TQBb9rGScxHbv/kLqqIWs2fIXy6Y/EiBBiM72NTwuXUFCNrWR4sjUPSooVBJJ3ESQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.1.6.tgz",
+      "integrity": "sha512-GT5w2mruk90V/I5g6ScuueE7fqj/d8Bui2qxdw6lFxmuTgMeol5rnzAv4uAoVQgClOUO/MULilzlODg9Ib3Y4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.1.6.tgz",
+      "integrity": "sha512-keFD6KvwOPzmat4TCnlnuxJCQepPN+8j3Nw876FtULxo8005Y9Ghcl7ACcR8GoiKoddAq8gxNBrpjoxjQRHeAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.1.6.tgz",
+      "integrity": "sha512-OwertslIiGQluFvHyRDzBCIB07qJjqabAmINlXUYt7/sY7Q7QPE8xVi5beBxX/rxTGPIbtyIe3faBE6Z2KywhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.1.6.tgz",
+      "integrity": "sha512-g8zowiuP8FxUR9zslPmlju7qYbs2XBtTLVSxVikPtUDQedhcls39uKYLvOOd1JZg0ehyhopobRoH1q+MHlIN/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.1.6.tgz",
+      "integrity": "sha512-Ls2OL9hi3YlJKGNdKv8k3X/lLgc3VmLG3a/DeTkAd+lAituJp8ZHmRmm9f9SL84fT3CotlzcgbdaCDfFwFA6bA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -17482,8 +17662,80 @@
     "@next/env": {
       "version": "13.1.6"
     },
+    "@next/swc-android-arm-eabi": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.1.6.tgz",
+      "integrity": "sha512-F3/6Z8LH/pGlPzR1AcjPFxx35mPqjE5xZcf+IL+KgbW9tMkp7CYi1y7qKrEWU7W4AumxX/8OINnDQWLiwLasLQ==",
+      "optional": true
+    },
+    "@next/swc-android-arm64": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.1.6.tgz",
+      "integrity": "sha512-cMwQjnB8vrYkWyK/H0Rf2c2pKIH4RGjpKUDvbjVAit6SbwPDpmaijLio0LWFV3/tOnY6kvzbL62lndVA0mkYpw==",
+      "optional": true
+    },
     "@next/swc-darwin-arm64": {
       "version": "13.1.6",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.1.6.tgz",
+      "integrity": "sha512-/uOky5PaZDoaU99ohjtNcDTJ6ks/gZ5ykTQDvNZDjIoCxFe3+t06bxsTPY6tAO6uEAw5f6vVFX5H5KLwhrkZCA==",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.1.6.tgz",
+      "integrity": "sha512-qaEALZeV7to6weSXk3Br80wtFQ7cFTpos/q+m9XVRFggu+8Ib895XhMWdJBzew6aaOcMvYR6KQ6JmHA2/eMzWw==",
+      "optional": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.1.6.tgz",
+      "integrity": "sha512-OybkbC58A1wJ+JrJSOjGDvZzrVEQA4sprJejGqMwiZyLqhr9Eo8FXF0y6HL+m1CPCpPhXEHz/2xKoYsl16kNqw==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.1.6.tgz",
+      "integrity": "sha512-yCH+yDr7/4FDuWv6+GiYrPI9kcTAO3y48UmaIbrKy8ZJpi7RehJe3vIBRUmLrLaNDH3rY1rwoHi471NvR5J5NQ==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.1.6.tgz",
+      "integrity": "sha512-ECagB8LGX25P9Mrmlc7Q/TQBb9rGScxHbv/kLqqIWs2fIXy6Y/EiBBiM72NTwuXUFCNrWR4sjUPSooVBJJ3ESQ==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.1.6.tgz",
+      "integrity": "sha512-GT5w2mruk90V/I5g6ScuueE7fqj/d8Bui2qxdw6lFxmuTgMeol5rnzAv4uAoVQgClOUO/MULilzlODg9Ib3Y4Q==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.1.6.tgz",
+      "integrity": "sha512-keFD6KvwOPzmat4TCnlnuxJCQepPN+8j3Nw876FtULxo8005Y9Ghcl7ACcR8GoiKoddAq8gxNBrpjoxjQRHeAQ==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.1.6.tgz",
+      "integrity": "sha512-OwertslIiGQluFvHyRDzBCIB07qJjqabAmINlXUYt7/sY7Q7QPE8xVi5beBxX/rxTGPIbtyIe3faBE6Z2KywhQ==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.1.6.tgz",
+      "integrity": "sha512-g8zowiuP8FxUR9zslPmlju7qYbs2XBtTLVSxVikPtUDQedhcls39uKYLvOOd1JZg0ehyhopobRoH1q+MHlIN/w==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.1.6.tgz",
+      "integrity": "sha512-Ls2OL9hi3YlJKGNdKv8k3X/lLgc3VmLG3a/DeTkAd+lAituJp8ZHmRmm9f9SL84fT3CotlzcgbdaCDfFwFA6bA==",
       "optional": true
     },
     "@noble/ed25519": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "examples/chat-webpack",
         "examples/chat-next"
       ],
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
@@ -44,6 +47,7 @@
         "next": "^13.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-virtuoso": "^4.1.0",
         "stoppable": "^1.1.0",
         "wagmi": "^0.11.5"
       },
@@ -62,8 +66,10 @@
         "@types/react-dom": "^18.0.10",
         "@wagmi/chains": "^0.2.8",
         "98.css": "^0.1.18",
+        "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-virtuoso": "^4.1.0",
         "wagmi": "^0.11.5"
       },
       "devDependencies": {
@@ -10641,7 +10647,8 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -12922,6 +12929,18 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.1.0.tgz",
+      "integrity": "sha512-Vcq5WXn18PvPT55kdeGQ8BN3K95XyPe7hum8zG6Tx7g1CtUYVsQKN7fouMxBSy+XymEDB5ynGy8JWhuqyLLtPw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18",
+        "react-dom": ">=16 || >=17 || >= 18"
       }
     },
     "node_modules/read-pkg": {
@@ -16331,6 +16350,7 @@
         "next": "^13.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-virtuoso": "^4.1.0",
         "stoppable": "^1.1.0",
         "wagmi": "^0.11.5"
       }
@@ -16349,8 +16369,10 @@
         "concurrently": "^7.6.0",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.7.3",
+        "lodash": "*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-virtuoso": "^4.1.0",
         "style-loader": "^3.3.1",
         "ts-loader": "^9.4.2",
         "wagmi": "^0.11.5",
@@ -22950,7 +22972,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8"
@@ -24295,6 +24319,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-virtuoso": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.1.0.tgz",
+      "integrity": "sha512-Vcq5WXn18PvPT55kdeGQ8BN3K95XyPe7hum8zG6Tx7g1CtUYVsQKN7fouMxBSy+XymEDB5ynGy8JWhuqyLLtPw==",
+      "requires": {}
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "@typescript-eslint/parser": "^5.51.0",
     "eslint": "^8.33.0",
     "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
   }
 }

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -67,13 +67,9 @@ declare function useCanvas(): {
 
 ## `useRoute`
 
-You can use `useRoute` to fetch or subscribe to data from your application's routes.
+You can use `useRoute` to fetch/subscribe to data from your application's routes.
 
-The `Canvas` element internally establishes a WebSocket connection to the host. By default, the `useRoute` hook will use that websocket connection to subscribe to a given route, with any provided params.
-
-**Fetching routes with a subscription**
-
-For example, to subscribe to posts from a specific user:
+For example, to subscribe to the /posts route:
 
 ```tsx
 import { useRoute } from "@canvas-js/hooks"

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -88,6 +88,8 @@ The hook will re-render every time the resulting `data` changes (compared deep e
 
 Use this pattern when you want the host to push data to the client. **Don't** use this pattern if the parameter values (`{ user: "joel" }` in the example) change often. For subscriptions, routes are bound to concrete parameter values, so changing the parameters forces the hook to unsubscribe and re-subscribe.
 
+You can also provide a callback to the hook, which will be triggered whenever new data is returned from the hook. **If you do this, make sure to memoize your callback (i.e. wrap it in useCallback())!**
+
 **Fetching routes without a subscription**
 
 The `useRoute` hook can also fetch routes without subscribing to them. Pass a `{ subscribe: false }` options object as the third argument and the hook will use regulular HTTP GET requests, re-fetching the route data every time any of the parameter values passed to the hook change (and only then).

--- a/packages/hooks/src/useRoute.ts
+++ b/packages/hooks/src/useRoute.ts
@@ -81,7 +81,7 @@ export function useRoute<T extends Record<string, ModelValue> = Record<string, M
 				console.log("ws: failed to parse message", evt.data)
 			}
 		},
-		[callback]
+		[callback, params]
 	)
 
 	useEffect(() => {

--- a/packages/hooks/src/useSession.ts
+++ b/packages/hooks/src/useSession.ts
@@ -199,8 +199,6 @@ export function useSession<Signer, DelegatedSigner>(
 				block: options.unchecked ? null : await chainImplementation.getLatestBlock(),
 			})
 
-			console.log(action)
-
 			const res = await fetch(`${host}/actions`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },

--- a/packages/hooks/src/useSession.ts
+++ b/packages/hooks/src/useSession.ts
@@ -9,7 +9,14 @@ const second = 1000
 const minute = 60 * second
 const hour = 60 * minute
 
-export type Client = Record<string, (callArgs: Record<string, ActionArgument>) => Promise<{ hash: string }>>
+export type CallOptions = {
+	timestamp?: number
+}
+
+export type Client = Record<
+	string,
+	(callArgs: Record<string, ActionArgument>, callOptions?: CallOptions) => Promise<{ hash: string }>
+>
 
 /**
  * isLoading === true: waiting for application data from host, & checking localStorage for sessionObject
@@ -163,7 +170,11 @@ export function useSession<Signer, DelegatedSigner>(
 	}, [signer])
 
 	const dispatch = useCallback(
-		async (call: string, callArgs: Record<string, ActionArgument>): Promise<{ hash: string }> => {
+		async (
+			call: string,
+			callArgs: Record<string, ActionArgument>,
+			callOptions?: CallOptions
+		): Promise<{ hash: string }> => {
 			if (host === null) {
 				throw new Error("no host configured")
 			} else if (data === null) {
@@ -184,7 +195,7 @@ export function useSession<Signer, DelegatedSigner>(
 				callArgs,
 				chain,
 				chainId,
-				timestamp: Date.now(),
+				timestamp: callOptions?.timestamp ?? Date.now(),
 				block: options.unchecked ? null : await chainImplementation.getLatestBlock(),
 			})
 
@@ -217,7 +228,11 @@ export function useSession<Signer, DelegatedSigner>(
 	)
 
 	const client = useMemo<Client | null>(
-		() => data && Object.fromEntries(data.actions.map((action) => [action, (args) => dispatch(action, args)])),
+		() =>
+			data &&
+			Object.fromEntries(
+				data.actions.map((action) => [action, (args, callOptions?: CallOptions) => dispatch(action, args, callOptions)])
+			),
 		[data, dispatch]
 	)
 


### PR DESCRIPTION
- Add "Generate Data" buttons to chat apps
- Fix an issue with hooks not updating when params updated
- Fix an issue with example specs accidentally getting reverted
- Use `cursor = ""` for example specs, instead of `cursor = Infinity` which doesn't work with with new model param encoding
- Rewrite chat-next infinite scroller using React Virtuso, two useRoute() hooks, and declarative data pipelining
- Patch over an issue with Virtuoso sticky scrolling


## Description

<!--- Describe your changes in detail -->

## How has this been tested?

- [X] CI tests pass
- [X] Tested with chat-next (including login, all signers, and exchanging messages)
- [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

n/a

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
