### PR TITLE
Infinite scroll: Interleave posts that arrive out-of-order

### DIFF
--- a/examples/chat-next/.eslintrc.cjs
+++ b/examples/chat-next/.eslintrc.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:@next/next/recommended"],
+  plugins: ["@typescript-eslint"],
+  parser: "@typescript-eslint/parser",
+  ignorePatterns: [
+    "*.d.ts",
+    "*.cts",
+  ],
+  settings: {
+    "import/parsers": {
+      "@typescript-eslint/parser": [".ts", ".tsx"],
+    },
+  },
+  rules: {
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-empty-interface": "off",
+    "no-empty-pattern": "off",
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        "extendDefaults": true,
+        "types": { "{}": false },
+      },
+    ],
+  },
+};

--- a/examples/chat-next/components/Messages.tsx
+++ b/examples/chat-next/components/Messages.tsx
@@ -1,6 +1,6 @@
-import _ from "lodash"
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
 import { Virtuoso } from "react-virtuoso"
+import _ from "lodash"
 
 import { useEnsName } from "wagmi"
 import { Client, useRoute } from "@canvas-js/hooks"

--- a/examples/chat-next/package.json
+++ b/examples/chat-next/package.json
@@ -21,6 +21,7 @@
     "98.css": "^0.1.18",
     "ethers": "^5.7.1 <6",
     "http-status-codes": "^2.2.0",
+    "lodash": "^4.17.21",
     "next": "^13.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -29,6 +30,8 @@
     "wagmi": "^0.11.5"
   },
   "devDependencies": {
+    "@next/eslint-plugin-next": "^13.2.1",
+    "@types/lodash": "^4.14.191",
     "@types/use-sync-external-store": "^0.0.3"
   }
 }

--- a/examples/chat-webpack/src/Messages.tsx
+++ b/examples/chat-webpack/src/Messages.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo, useContext } from "react"
+import { Virtuoso } from "react-virtuoso"
 import _ from "lodash"
 
 import { useEnsName } from "wagmi"
-import { useRoute } from "@canvas-js/hooks"
-
+import { Client, useRoute } from "@canvas-js/hooks"
 import { AppContext } from "./AppContext"
 
 type Post = {
@@ -11,6 +11,106 @@ type Post = {
 	from_id: `0x${string}`
 	content: string
 	updated_at: number
+}
+
+export const MessagesInfiniteScroller: React.FC<{}> = ({}) => {
+	const [posts, setPosts] = useState<Post[]>([])
+	const [cursor, setCursor] = useState<string | number>("")
+
+	// Virtuoso uses firstItemIndex to maintain scroll position when
+	// items are added. It should always be set *relative to its
+	// original value* and cannot be negative, so we initialize it
+	// with a very large MAX_VALUE.
+	const MAX_VALUE = 999999999
+	const virtuoso = useRef(null)
+	const [firstItemIndex, setFirstItemIndex] = useState<number>(MAX_VALUE)
+
+	// Past posts are fetched declaratively, by updating `cursor`.
+	// Because of pagination, the route returns a window of posts ordered
+	// monotonically the same as displayed posts, but potentially overlapping
+	// or interleaved with them, so we use a Map to filter out duplicates.
+	const { data: pastPosts } = useRoute<Post>("/posts", { before: cursor }, { subscribe: false })
+
+	// Maintain a subscription to the most recent page of posts.
+	// We assume that posts are received in-order, an assumption which
+	// may be violated when generating data.
+	const { data: newPosts } = useRoute<Post>("/posts", { before: "" })
+
+	useEffect(() => {
+		if (!pastPosts || !newPosts) return
+
+		if (posts.length === 0) {
+			const filteredNewPosts = [...newPosts]
+			filteredNewPosts.reverse()
+			setPosts(filteredNewPosts)
+		} else {
+			const postsM = new Map(posts.map((f) => [f.id, f]))
+			const filteredPastPosts = pastPosts.filter((item) => !postsM.has(item.id))
+			const filteredNewPosts = newPosts.filter((item) => !postsM.has(item.id))
+			if (filteredPastPosts.length === 0 && filteredNewPosts.length === 0) return
+			setFirstItemIndex(firstItemIndex - filteredPastPosts.length)
+			filteredPastPosts.reverse()
+			filteredNewPosts.reverse()
+
+			// TODO: Interleave new posts according to updated_at, so if we
+			// receive new posts out-of-order (happens frequently on first insert)
+			// they won't persist out-of-order
+			setPosts([...filteredPastPosts, ...posts, ...filteredNewPosts])
+
+			// Scroll-to-bottom doesn't seem to work correctly, Virtuoso incorrectly
+			// caps the maximum scroll to `scroller.offsetHeight - scroller.scrollHeight`
+			// when there might be additional not-yet-rendered content at the bottom.
+			if (filteredPastPosts.length === 0) {
+				const scroller = document.querySelector("[data-virtuoso-scroller=true]") as HTMLElement
+				if (scroller === null) return
+				// Only scroll-to-bottom if we're already near the bottom
+				if (scroller.scrollTop + scroller.offsetHeight < scroller.scrollHeight - 40) return
+				setTimeout(() => {
+					scroller.scrollTop = 99999999
+					setTimeout(() => {
+						scroller.scrollTop = 99999999
+					}, 10)
+				}, 10)
+			}
+		}
+	}, [newPosts, pastPosts, posts])
+
+	const startReached = useCallback(
+		(index: number) => {
+			if (posts.length === 0) return
+
+			setTimeout(() => {
+				const earliestPost = posts[0]
+				const newCursor = earliestPost?.updated_at?.toString()
+				if (!earliestPost || cursor === earliestPost.updated_at) return // Nothing more
+				setCursor(earliestPost.updated_at)
+				console.log("cursor changed:", earliestPost.updated_at)
+			}, 500)
+		},
+		[posts, cursor]
+	)
+
+	const itemContent = useCallback((index: number, post: Post) => <Post key={post.id} {...post} />, [])
+	// const followOutput = useCallback((isAtBottom) => (isAtBottom ? "auto" : false), [])
+
+	return (
+		<ul className="tree-view">
+			{posts.length > 0 && (
+				<Virtuoso
+					atBottomThreshold={40}
+					ref={virtuoso}
+					firstItemIndex={firstItemIndex}
+					initialTopMostItemIndex={posts.length}
+					itemContent={itemContent}
+					data={posts}
+					startReached={startReached}
+					// followOutput={followOutput}
+					style={{ flex: "1 1 auto", overscrollBehavior: "contain" }}
+					increaseViewportBy={{ bottom: 40, top: 40 }}
+				/>
+			)}
+		</ul>
+	)
 }
 
 export const Messages: React.FC = ({}) => {
@@ -44,107 +144,23 @@ export const Messages: React.FC = ({}) => {
 		}
 	}, [isReady])
 
-	const [cursor, setCursor] = useState("")
-	const [pages, setPages] = useState<Record<string, Post[]>>({})
-	const [messages, setMessages] = useState<Post[]>([])
-	const [latest, setLatest] = useState<Post[]>([]) // only used to trigger the LayoutEffect to scroll to bottom
-	const [trailing, setTrailing] = useState<Post[]>([]) // messages no longer in latest, but not in scrollback
-
-	// Subscribe to both the latest posts, and scrollback
-	const callbackLatest = useCallback(
-		(data: Post[] | null, error: Error | null) => {
-			if (!data) return
-			const hashes = new Set(data.map((d) => d.id))
-			setLatest(data)
-			setTrailing(latest.filter((d) => !hashes.has(d.id)).concat(trailing))
-		},
-		[trailing, setTrailing]
-	)
-	const callbackPrev = useCallback(
-		(data: Post[] | null, error: Error | null) => {
-			if (!data || cursor === "") return
-			setPages({ ...pages, [cursor]: data })
-		},
-		[cursor]
-	)
-
-	const { data: curr, error } = useRoute<Post>("/posts", { before: "" }, undefined, callbackLatest)
-	const { data: prev } = useRoute<Post>("/posts", { before: cursor }, undefined, callbackPrev)
-	useEffect(() => {
-		const scrollback = Object.keys(pages).reduce((acc: Post[], page) => acc.concat(pages[page]), [])
-		setMessages(latest.concat(trailing).concat(scrollback))
-	}, [latest, pages])
-
-	// Load more on scroll
-	const handleScroll = useMemo(
-		() =>
-			_.throttle((event: React.UIEvent<HTMLElement>) => {
-				if ((event?.target as HTMLElement)?.scrollTop > 50) return
-				if (messages.length > 0)
-					setTimeout(() => {
-						const earliestPost = messages[messages.length - 1]?.updated_at?.toString()
-						if (cursor === earliestPost) return // Nothing more to load
-						setCursor(earliestPost)
-					})
-			}, 750),
-		[messages, cursor]
-	)
-
-	// Jump to bottom on load, and when the current page updates, but not when messages updates
-	const scrollContainer = useRef<HTMLDivElement>(null)
-	useLayoutEffect(() => {
-		if (!curr?.length || !messages?.length) return
-		setTimeout(() => {
-			if (scrollContainer.current !== null) {
-				scrollContainer.current.scrollTop = scrollContainer.current.scrollHeight
-			}
-		})
-	}, [latest, curr?.length !== 0 && prev?.length !== 0 && messages.length !== 0])
-
 	return (
 		<div id="messages" className="window">
 			<div className="title-bar">
 				<div className="title-bar-text">Messages</div>
 			</div>
-			{error ? (
-				<div className="window-body">
-					<ul className="tree-view">
-						<li>{error.toString()}</li>
-					</ul>
-				</div>
-			) : (
-				<div className="window-body">
-					<div id="scroll-container" ref={scrollContainer} onScroll={handleScroll}>
-						<ul className="tree-view">
-							<Posts posts={messages} />
-						</ul>
-					</div>
-					<input
-						type="text"
-						disabled={!isReady}
-						ref={inputRef}
-						onKeyDown={handleKeyDown}
-						placeholder={isReady ? "" : "Start a session to chat"}
-					/>
-				</div>
-			)}
+			<div className="window-body">
+				<MessagesInfiniteScroller />
+				<input
+					type="text"
+					disabled={!isReady}
+					ref={inputRef}
+					onKeyDown={handleKeyDown}
+					placeholder={isReady ? "" : "Start a session to chat"}
+				/>
+			</div>
 		</div>
 	)
-}
-
-const Posts: React.FC<{ posts: null | Post[] }> = (props) => {
-	if (props.posts === null) {
-		return null
-	} else {
-		return (
-			<>
-				{props.posts.map((_, i, posts) => {
-					const post = posts[posts.length - i - 1]
-					return <Post key={post.id} {...post} />
-				})}
-			</>
-		)
-	}
 }
 
 const Post: React.FC<Post> = ({ from_id, content, updated_at }) => {

--- a/examples/chat-webpack/src/Messages.tsx
+++ b/examples/chat-webpack/src/Messages.tsx
@@ -52,10 +52,39 @@ export const MessagesInfiniteScroller: React.FC<{}> = ({}) => {
 			filteredPastPosts.reverse()
 			filteredNewPosts.reverse()
 
-			// TODO: Interleave new posts according to updated_at, so if we
-			// receive new posts out-of-order (happens frequently on first insert)
+			// Interleave new posts according to updated_at, so if we
+			// receive new posts out-of-order (happens frequently on batch insert)
 			// they won't persist out-of-order
-			setPosts([...filteredPastPosts, ...posts, ...filteredNewPosts])
+			let result
+			if (
+				// check if all posts are ordered
+				(filteredPastPosts.length === 0 && posts.length === 0) ||
+				(posts.length === 0 && filteredNewPosts.length === 0)
+			) {
+				result = [...filteredPastPosts, ...posts, ...filteredNewPosts]
+			} else {
+				// check if past + present posts are ordered
+				if (
+					filteredPastPosts.length === 0 ||
+					posts.length === 0 ||
+					filteredPastPosts[filteredPastPosts.length - 1].updated_at < posts[0].updated_at
+				) {
+					result = [...filteredPastPosts, ...posts]
+				} else {
+					result = _.sortedUniqBy(_.sortBy([...filteredPastPosts, ...posts], "updated_at"), "updated_at")
+				}
+				// check if present + new posts are ordered
+				if (
+					result.length === 0 ||
+					filteredNewPosts.length === 0 ||
+					result[result.length - 1].updated_at < filteredNewPosts[0].updated_at
+				) {
+					result = [...result, ...filteredNewPosts]
+				} else {
+					result = _.sortedUniqBy(_.sortBy([...result, ...filteredNewPosts], "updated_at"), "updated_at")
+				}
+			}
+			setPosts(result)
 
 			// Scroll-to-bottom doesn't seem to work correctly, Virtuoso incorrectly
 			// caps the maximum scroll to `scroller.offsetHeight - scroller.scrollHeight`

--- a/examples/chat-webpack/src/styles.css
+++ b/examples/chat-webpack/src/styles.css
@@ -36,17 +36,19 @@ body {
 	gap: 4px;
 }
 
-#scroll-container {
-	overflow-y: scroll;
+#messages ul.tree-view {
 	flex-grow: 1;
 	height: 0px;
+  padding: 2px;
 
 	display: flex;
 	flex-direction: column;
 }
 
-#scroll-container ul.tree-view {
-	flex-grow: 1;
+#messages ul.tree-view li {
+  margin: 0;
+  padding-top: 3px;
+  padding-left: 6px;
 }
 
 #sidebar {
@@ -54,7 +56,7 @@ body {
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
-	width: 420px;
+	flex-grow: 0;
 }
 
 span.address {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "98.css": "^0.1.18",
         "ethers": "^5.7.1 <6",
         "http-status-codes": "^2.2.0",
+        "lodash": "^4.17.21",
         "next": "^13.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -52,6 +53,8 @@
         "wagmi": "^0.11.5"
       },
       "devDependencies": {
+        "@next/eslint-plugin-next": "^13.2.1",
+        "@types/lodash": "^4.14.191",
         "@types/use-sync-external-store": "^0.0.3"
       }
     },
@@ -2597,6 +2600,35 @@
       "version": "13.1.6",
       "license": "MIT"
     },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.2.1.tgz",
+      "integrity": "sha512-r0i5rcO6SMAZtqiGarUVMr3k256X0R0j6pEkKg4PxqUW+hG0qgMxRVAJsuoRG5OBFkCOlSfWZJ0mP9fQdCcyNg==",
+      "dev": true,
+      "dependencies": {
+        "glob": "7.1.7"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@next/swc-android-arm-eabi": {
       "version": "13.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.1.6.tgz",
@@ -4163,8 +4195,9 @@
     },
     "node_modules/@types/lodash": {
       "version": "4.14.191",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -16341,12 +16374,15 @@
         "@canvas-js/hooks": "0.1.1",
         "@canvas-js/interfaces": "0.1.1",
         "@canvas-js/next": "0.1.1",
+        "@next/eslint-plugin-next": "^13.2.1",
+        "@types/lodash": "^4.14.191",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.10",
         "@types/use-sync-external-store": "^0.0.3",
         "98.css": "^0.1.18",
         "ethers": "^5.7.1 <6",
         "http-status-codes": "^2.2.0",
+        "lodash": "^4.17.21",
         "next": "^13.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -16369,7 +16405,7 @@
         "concurrently": "^7.6.0",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.7.3",
-        "lodash": "*",
+        "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-virtuoso": "^4.1.0",
@@ -17684,6 +17720,31 @@
     "@next/env": {
       "version": "13.1.6"
     },
+    "@next/eslint-plugin-next": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.2.1.tgz",
+      "integrity": "sha512-r0i5rcO6SMAZtqiGarUVMr3k256X0R0j6pEkKg4PxqUW+hG0qgMxRVAJsuoRG5OBFkCOlSfWZJ0mP9fQdCcyNg==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.7"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
     "@next/swc-android-arm-eabi": {
       "version": "13.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.1.6.tgz",
@@ -18719,6 +18780,8 @@
     },
     "@types/lodash": {
       "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
       "dev": true
     },
     "@types/long": {


### PR DESCRIPTION
Ports infinite scroll to chat-webpack, interleaves posts that arrive out-of-order correctly

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

- [X] CI tests pass
- [X] Tested with chat-next (including login, all signers, and exchanging messages)
- [X] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

n/a

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
