### PR TITLE
change chat-next to a static export and serve with the --static flag

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,6 +13,7 @@ module.exports = {
     "*.cts",
     "**/dist/**/*.js",
     "**/lib/**/*.js",
+    "**/out/**/*.js",
   ],
   settings: {
     "import/parsers": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,4 @@ jobs:
         run: ./install.sh
 
       - name: Ensure Next.js example starts
-        run: npm run start --workspace=@canvas-js/example-chat-next & sleep 10 ; kill $!
+        run: npm run start --workspace=@canvas-js/example-chat-next & sleep 10 ; if [[ $( curl -s -o /dev/null -w "%{http_code}" http://localhost:8000 ) != "200" ]]; then exit 1; else kill $!; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,5 @@ jobs:
       - name: Install canvas CLI
         run: ./install.sh
 
-      - name: Ensure Webpack example starts
-        run: npm run start --workspace=@canvas-js/example-chat-webpack & sleep 10 ; kill $!
-
       - name: Ensure Next.js example starts
         run: npm run start --workspace=@canvas-js/example-chat-next & sleep 10 ; kill $!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,11 @@ jobs:
       - name: Build Webpack example
         run: npm run build --workspace=@canvas-js/example-chat-webpack
 
+      - name: Install canvas CLI
+        run: ./install.sh
+
+      - name: Ensure Webpack example starts
+        run: npm run start --workspace=@canvas-js/example-chat-webpack & sleep 10 ; kill $!
+
       - name: Ensure Next.js example starts
         run: npm run start --workspace=@canvas-js/example-chat-next & sleep 10 ; kill $!

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,13 @@
 .next/
 node_modules/
 
+
 packages/**/tsconfig.tsbuildinfo
 packages/**/lib/
 packages/**/dist/
+
+examples/**/out/
+examples/**/dist/
 
 *.canvas
 .vscode

--- a/examples/chat-next/components/Connect.tsx
+++ b/examples/chat-next/components/Connect.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useContext, useEffect, useMemo } from "react"
+import React, { useCallback, useState, useEffect, useMemo } from "react"
 
 import { ethers } from "ethers"
 import { useAccount, useConnect, useDisconnect, useSigner, useNetwork, useProvider } from "wagmi"
@@ -16,6 +16,9 @@ export const Connect: React.FC<{ client: Client | null; setClient: (client: Clie
 	const { disconnect } = useDisconnect()
 	const { address, isConnected } = useAccount()
 
+	const [isLoading, setIsLoading] = useState(true)
+	useEffect(() => setIsLoading(false), [])
+
 	return (
 		<div className="window">
 			<div className="title-bar">
@@ -32,18 +35,19 @@ export const Connect: React.FC<{ client: Client | null; setClient: (client: Clie
 				) : (
 					<>
 						<p>Connect to a provider:</p>
-						{connectors.map((connector) => (
-							<button
-								disabled={!connector.ready || isConnected}
-								key={connector.id}
-								onClick={() => connect({ connector })}
-								style={{ marginRight: 5 }}
-							>
-								{connector.name}
-								{!connector.ready && " (unavailable)"}
-								{isConnectionLoading && connector.id === pendingConnector?.id && " (connecting)"}
-							</button>
-						))}
+						{isLoading ||
+							connectors.map((connector) => (
+								<button
+									disabled={!connector.ready || isConnected}
+									key={connector.id}
+									onClick={() => connect({ connector })}
+									style={{ marginRight: 5 }}
+								>
+									{connector.name}
+									{!connector.ready && " (unavailable)"}
+									{isConnectionLoading && connector.id === pendingConnector?.id && " (connecting)"}
+								</button>
+							))}
 					</>
 				)}
 				<ErrorMessage error={connectionError} />

--- a/examples/chat-next/package.json
+++ b/examples/chat-next/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "NEXT_PUBLIC_HOST=/api next build && next export",
-    "start": "canvas run spec.canvas.js --install --unchecked --static dist --announce /dns4/canvas-chat-2.fly.dev/tcp/4044/ws",
+    "start": "canvas run spec.canvas.js --install --unchecked --static out --announce /dns4/canvas-chat-2.fly.dev/tcp/4044/ws",
     "dev:backend": "canvas run spec.canvas.js --unchecked --offline",
     "dev:frontend": "NEXT_PUBLIC_HOST='http://localhost:8000' next dev",
     "dev": "concurrently --kill-others -n backend,frontend 'npm run dev:backend' 'npm run dev:frontend'",

--- a/examples/chat-next/package.json
+++ b/examples/chat-next/package.json
@@ -5,9 +5,11 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "canvas-next",
-    "build": "next build",
-    "start": "NODE_ENV=production next build && canvas-next",
+    "build": "NEXT_PUBLIC_HOST=/api next build && next export",
+    "start": "canvas run spec.canvas.js --install --unchecked --static dist --announce /dns4/canvas-chat-2.fly.dev/tcp/4044/ws",
+    "dev:backend": "canvas run spec.canvas.js --unchecked --offline",
+    "dev:frontend": "NEXT_PUBLIC_HOST='http://localhost:8000' next dev",
+    "dev": "concurrently --kill-others -n backend,frontend 'npm run dev:backend' 'npm run dev:frontend'",
     "lint": "next lint"
   },
   "dependencies": {
@@ -15,7 +17,6 @@
     "@canvas-js/core": "0.1.3",
     "@canvas-js/hooks": "0.1.3",
     "@canvas-js/interfaces": "0.1.3",
-    "@canvas-js/next": "0.1.3",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
     "98.css": "^0.1.18",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.191",
-    "@types/use-sync-external-store": "^0.0.3"
+    "@types/use-sync-external-store": "^0.0.3",
+    "concurrently": "^7.6.0"
   }
 }

--- a/examples/chat-next/pages/_app.tsx
+++ b/examples/chat-next/pages/_app.tsx
@@ -1,17 +1,21 @@
 import React from "react"
 
-import type { AppProps } from "next/app"
+import { AppProps } from "next/app"
+
 import { WagmiConfig } from "wagmi"
 import { Canvas } from "@canvas-js/hooks"
 
-import { client } from "../utils/client"
+import { client } from "utils/client"
 
 import "98.css"
 import "styles.css"
 
-const host = "/app"
+export default function App({ Component, pageProps }: AppProps<{}>) {
+	const host = process.env.NEXT_PUBLIC_HOST
+	if (host === undefined) {
+		throw new Error("no host configured")
+	}
 
-export default function App({ Component, pageProps }: AppProps) {
 	return (
 		<React.StrictMode>
 			<WagmiConfig client={client}>

--- a/examples/chat-next/pages/index.tsx
+++ b/examples/chat-next/pages/index.tsx
@@ -1,16 +1,11 @@
 import React, { useState } from "react"
-import dynamic from "next/dynamic"
 import Head from "next/head"
 
+import { Connect } from "components/Connect"
+import { Messages } from "components/Messages"
+import { Application } from "components/Application"
+
 import { Client } from "@canvas-js/hooks"
-
-const Application = dynamic(() => import("components/Application").then(({ Application }) => Application), {
-	ssr: false,
-})
-
-const Connect = dynamic(() => import("components/Connect").then(({ Connect }) => Connect), { ssr: false })
-
-const Messages = dynamic(() => import("components/Messages").then(({ Messages }) => Messages), { ssr: false })
 
 export default function Index() {
 	const [client, setClient] = useState<Client | null>(null)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16312,7 +16312,7 @@
         "prom-client": "^14.1.1",
         "protobufjs": "~7.2.2",
         "protobufjs-cli": "~1.1.1",
-        "quickjs-emscripten": "*",
+        "quickjs-emscripten": "^0.22.0",
         "safe-stable-stringify": "^2.4.2",
         "stream-to-it": "^0.2.4",
         "timeout-abort-controller": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@canvas-js/core": "0.1.3",
         "@canvas-js/hooks": "0.1.3",
         "@canvas-js/interfaces": "0.1.3",
-        "@canvas-js/next": "0.1.3",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.10",
         "98.css": "^0.1.18",
@@ -54,7 +53,8 @@
       },
       "devDependencies": {
         "@types/lodash": "^4.14.191",
-        "@types/use-sync-external-store": "^0.0.3"
+        "@types/use-sync-external-store": "^0.0.3",
+        "concurrently": "^7.6.0"
       }
     },
     "examples/chat-webpack": {
@@ -7139,8 +7139,9 @@
     },
     "node_modules/concurrently": {
       "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.6.0.tgz",
+      "integrity": "sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
         "date-fns": "^2.29.1",
@@ -16333,12 +16334,12 @@
         "@canvas-js/core": "0.1.3",
         "@canvas-js/hooks": "0.1.3",
         "@canvas-js/interfaces": "0.1.3",
-        "@canvas-js/next": "0.1.3",
         "@types/lodash": "^4.14.191",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.10",
         "@types/use-sync-external-store": "^0.0.3",
         "98.css": "^0.1.18",
+        "concurrently": "*",
         "ethers": "^5.7.1 <6",
         "http-status-codes": "^2.2.0",
         "lodash": "^4.17.21",
@@ -20761,6 +20762,8 @@
     },
     "concurrently": {
       "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.6.0.tgz",
+      "integrity": "sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16339,7 +16339,7 @@
         "@types/react-dom": "^18.0.10",
         "@types/use-sync-external-store": "^0.0.3",
         "98.css": "^0.1.18",
-        "concurrently": "*",
+        "concurrently": "^7.6.0",
         "ethers": "^5.7.1 <6",
         "http-status-codes": "^2.2.0",
         "lodash": "^4.17.21",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This changes the `chat-next` example to not use `@canvas-js/next` and instead use `next export` to build a static bundle in the `out` directory that we then serve with `canvas run --static out` flag.

Also fixes some hydration issues that we were working around by using dynamic imports (which really we shouldn't have had to fall back on).

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

- [x] CI tests pass
- [x] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
