### PR TITLE
upgrade quickjs, add bigint support to contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12835,8 +12835,9 @@
       }
     },
     "node_modules/quickjs-emscripten": {
-      "version": "0.21.1",
-      "license": "MIT"
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten/-/quickjs-emscripten-0.22.0.tgz",
+      "integrity": "sha512-v73d6VqmXQvBWkorM/5W3bL1kRGhBwhKq3IIMnYp/FN5TSwjWrGBl/eBMone9o4/0DFioxQ23AGIQKG9Hx9Qtg=="
     },
     "node_modules/rabin-wasm": {
       "version": "0.1.5",
@@ -15730,7 +15731,7 @@
         "p-queue": "^7.3.0",
         "prom-client": "^14.1.1",
         "protobufjs": "~7.2.2",
-        "quickjs-emscripten": "^0.21.1",
+        "quickjs-emscripten": "^0.22.0",
         "safe-stable-stringify": "^2.4.2",
         "timeout-abort-controller": "^3.0.0",
         "uint8arraylist": "^2.4.3",
@@ -16310,7 +16311,7 @@
         "prom-client": "^14.1.1",
         "protobufjs": "~7.2.2",
         "protobufjs-cli": "~1.1.1",
-        "quickjs-emscripten": "^0.21.1",
+        "quickjs-emscripten": "*",
         "safe-stable-stringify": "^2.4.2",
         "stream-to-it": "^0.2.4",
         "timeout-abort-controller": "^3.0.0",
@@ -24238,7 +24239,9 @@
       "version": "4.0.1"
     },
     "quickjs-emscripten": {
-      "version": "0.21.1"
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten/-/quickjs-emscripten-0.22.0.tgz",
+      "integrity": "sha512-v73d6VqmXQvBWkorM/5W3bL1kRGhBwhKq3IIMnYp/FN5TSwjWrGBl/eBMone9o4/0DFioxQ23AGIQKG9Hx9Qtg=="
     },
     "rabin-wasm": {
       "version": "0.1.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "p-queue": "^7.3.0",
     "prom-client": "^14.1.1",
     "protobufjs": "~7.2.2",
-    "quickjs-emscripten": "^0.21.1",
+    "quickjs-emscripten": "^0.22.0",
     "safe-stable-stringify": "^2.4.2",
     "timeout-abort-controller": "^3.0.0",
     "uint8arraylist": "^2.4.3",

--- a/packages/core/src/vm/vm.ts
+++ b/packages/core/src/vm/vm.ts
@@ -578,11 +578,9 @@ export class VM {
 		} else if (typeof value === "number") {
 			return this.context.newNumber(value)
 		} else if (typeof value === "bigint") {
-			// TODO: support real bigints
-			// return newBigInt(this.context, value)
-			return this.context.newNumber(Number(value))
+			return this.context.newBigInt(value)
 		} else if (ethers.BigNumber.isBigNumber(value)) {
-			return this.context.newNumber(value.toNumber())
+			return this.context.newBigInt(value.toBigInt())
 		} else {
 			console.error(value)
 			throw new Error("Unsupported value type in contract function result")

--- a/packages/core/test/contracts.test.ts
+++ b/packages/core/test/contracts.test.ts
@@ -24,7 +24,7 @@ test("contracts (milady balanceOf)", async (t) => {
 		actions: {
 			async verify({}, { contracts, from }) {
 				const [balance] = await contracts.milady.balanceOf(from)
-				if (balance === 0) {
+				if (balance === 0n) {
 					throw new Error("balance is zero!")
 				}
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

quickjs-emscripten finally added support for native BigInts. ethers has its own class `ethers.BigNumber` that it returns from contract calls (although that's getting replace with native BigInts in v6), and previously we were just forcibly converting this to `number` values. This upgrades quickjs and returns native bigints inside the VM for `ethers.BigNumber` and external `bigint` values.

<!--- Describe your changes in detail -->

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
