### PR TITLE
Bob/canvas notes changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
 - [ ] CI tests pass
 - [ ] Tested with chat-next (including login, all signers, and exchanging messages)
 - [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
+- [ ] Tested with notes (including login, create note, share note)
 - [ ] Other:
 
 <!--- Please describe in detail how you tested your changes. -->

--- a/examples/notes/fly.toml
+++ b/examples/notes/fly.toml
@@ -36,8 +36,8 @@ processes = []
   protocol = "tcp"
   script_checks = []
   [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
+    hard_limit = 100
+    soft_limit = 100
     type = "connections"
 
   [[services.http_checks]]

--- a/examples/notes/public/index.html
+++ b/examples/notes/public/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 	<head>
 		<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta charset="utf-8" />
-		<title>Canvas Example App</title>
+		<title>Canvas Notes</title>
 		<script defer type="module" src="index.js"></script>
 	</head>
 	<body>

--- a/examples/notes/spec.canvas.js
+++ b/examples/notes/spec.canvas.js
@@ -94,8 +94,3 @@ export const actions = {
 		db.users.del(from)
 	},
 }
-
-// TODO: implement encryption
-// TODO: could we make encrypted_notes, encrypted_keys and users separate contracts?
-// encrypted_notes -> encrypted_keys, users
-// encrypted_keys -> users

--- a/examples/notes/spec.canvas.js
+++ b/examples/notes/spec.canvas.js
@@ -94,3 +94,8 @@ export const actions = {
 		db.users.del(from)
 	},
 }
+
+// TODO: implement encryption
+// TODO: could we make encrypted_notes, encrypted_keys and users separate contracts?
+// encrypted_notes -> encrypted_keys, users
+// encrypted_keys -> users

--- a/packages/hooks/src/useWebsocket.ts
+++ b/packages/hooks/src/useWebsocket.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useEffect, useRef } from "react"
 
 import { ApplicationData } from "./CanvasContext.js"
 
@@ -83,17 +83,21 @@ const setupWebsocket = (
 }
 
 export function useWebsocket(config: WebSocketConfig): WebSocket | null {
-	const [ws, setWS] = useState<WebSocket | null>(null)
+	const wsRef = useRef<WebSocket | null>(null)
 
 	useEffect(() => {
 		// Set up a websocket, and re-connect whenever connection fails
 		const reconnect = (delay: number) => {
 			const newDelay = delay < 10000 ? delay + 1000 : delay
-			setTimeout(() => setWS(setupWebsocket(config, reconnect, newDelay)), delay)
+			setTimeout(() => {
+				wsRef.current = setupWebsocket(config, reconnect, newDelay)
+			}, delay)
 		}
 
-		setWS(setupWebsocket(config, reconnect, 0))
+		if (wsRef.current == null) {
+			wsRef.current = setupWebsocket(config, () => {}, 0)
+		}
 	}, [])
 
-	return ws
+	return wsRef.current
 }


### PR DESCRIPTION
Some changes I made after pushing canvas-notes to production

## Description

Changes:
- Increase concurrency limit on the fly deployment
- Change title to be "Canvas Notes"
- Fix the bug where we get two WS connections - I think the cause of this is that React initially renders components twice, so the useEffect hook in `useWebsocket` is being called twice. We can use useRef (whose value persists between these two renders) to make sure that the actual WS connection is only created once.

## How has this been tested?

- [x] CI tests pass
- [x] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

This includes one change to the `useWebsocket` hook (it was creating two WS connections for retrieving route data, when we only need one) but it shouldn't change the behaviour of existing apps.

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
