### PR TITLE
scrappy first pass at an MST sync benchmark

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,8 @@
     "generate-rpc": "npm run generate-rpc-js && npm run generate-rpc-ts",
     "generate-rpc-js": "pbjs ./rpc/sync/index.proto -t static-module -w commonjs -o ./rpc/sync/index.cjs",
     "generate-rpc-ts": "pbjs -t static-module ./rpc/sync/index.proto | pbts -o ./rpc/sync/index.d.cts -",
-    "test": "ava"
+    "test": "ava",
+    "test-benchmark": "ENABLE_SYNC_BENCHMARK=1 ava --match 'test a really large sync'"
   },
   "dependencies": {
     "@canvas-js/chain-ethereum": "0.2.2",

--- a/packages/core/test/benchmark.test.ts
+++ b/packages/core/test/benchmark.test.ts
@@ -1,0 +1,107 @@
+import os from "node:os"
+import fs from "node:fs"
+import path from "node:path"
+import stream from "node:stream"
+import { v4 as uuidv4 } from "uuid"
+import { sha256 } from "@noble/hashes/sha256"
+
+import test from "ava"
+
+import { nanoid } from "nanoid"
+import toIterable from "stream-to-it"
+
+import type { Duplex } from "it-stream-types"
+import type { Uint8ArrayList } from "uint8arraylist"
+
+import type { Action, Message } from "@canvas-js/interfaces"
+
+import { openMessageStore } from "@canvas-js/core/components/messageStore"
+import { stringify } from "@canvas-js/core/utils"
+import { handleIncomingStream, sync } from "@canvas-js/core/sync"
+
+import { TestSigner, compileSpec } from "./utils.js"
+
+const { app, cid, appName } = await compileSpec({
+	name: "Test App",
+	models: {},
+	actions: { log: ({ message }, {}) => console.log(message) },
+})
+
+// creates an in-memory bi-directional connection
+function connect(): [
+	source: Duplex<Uint8ArrayList, Uint8ArrayList | Uint8Array>,
+	target: Duplex<Uint8ArrayList, Uint8ArrayList | Uint8Array>
+] {
+	const source = toIterable.duplex(new stream.PassThrough())
+	const target = toIterable.duplex(new stream.PassThrough())
+	return [
+		{ source: source.source, sink: target.sink },
+		{ source: target.source, sink: source.sink },
+	]
+}
+
+async function testSync(sourceMessages: Iterable<Message>, targetMessages: Iterable<Message>): Promise<Message[]> {
+	const sourceDirectory = path.resolve(os.tmpdir(), nanoid())
+	const targetDirectory = path.resolve(os.tmpdir(), nanoid())
+	fs.mkdirSync(sourceDirectory)
+	fs.mkdirSync(targetDirectory)
+
+	const sourceMessageStore = await openMessageStore(app, sourceDirectory)
+	const targetMessageStore = await openMessageStore(app, targetDirectory)
+	await sourceMessageStore.write(async (txn) => {
+		for (const message of sourceMessages) {
+			await txn.insertMessage(sha256(stringify(message)), message)
+		}
+	})
+	await targetMessageStore.write(async (txn) => {
+		for (const message of targetMessages) {
+			await txn.insertMessage(sha256(stringify(message)), message)
+		}
+	})
+
+	const delta: Message[] = []
+	try {
+		const [source, target] = connect()
+		await targetMessageStore.write(async (targetTxn) => {
+			await sourceMessageStore.read(async (sourceTxn) => {
+				await Promise.all([
+					handleIncomingStream(cid, source, sourceTxn),
+					sync(target, targetTxn, async (txn, hash, data, message) => void delta.push(message)),
+				])
+			})
+		})
+
+		return delta
+	} finally {
+		await sourceMessageStore.close()
+		await targetMessageStore.close()
+		fs.rmSync(sourceDirectory, { recursive: true })
+		fs.rmSync(targetDirectory, { recursive: true })
+	}
+}
+
+const signer = new TestSigner(app, appName)
+console.log(process.env.ENABLE_SYNC_BENCHMARK)
+if (process.env.ENABLE_SYNC_BENCHMARK) {
+	test("test a really large sync", async (t) => {
+		const sourceMessages: Action[] = []
+		for (var i = 0; i < 20; i++) {
+			sourceMessages.push(await signer.sign("log", { message: uuidv4() }))
+		}
+
+		const targetMessages: Action[] = []
+		for (var i = 0; i < 0; i++) {
+			targetMessages.push(await signer.sign("log", { message: uuidv4() }))
+		}
+
+		const startTime = new Date()
+		await testSync(sourceMessages, targetMessages)
+		const endTime = new Date()
+		// @ts-ignore
+		const timeDiffMs = endTime - startTime
+		const timeDiffS = timeDiffMs / 1000
+		console.log(timeDiffS)
+
+		t.pass()
+	})
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Does what it says on the tin. The code isn't DRY, it just randomly generates a load of signed messages and measures how long it takes to sync the MSTs.

We could measure how long it takes to sync two nodes (A and B) where each node has a different number of messages / overlapping sets of messages. Possible cases:
- A = empty set, B = empty set 
- A = empty set, B = n messages for varying values of n, to see how the MST sync time increases (linear? nlogn? quadratic?)
- A and B have overlapping sets of messages - does this affect how long sync takes?
- Does it make a difference how the messages are ordered?

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Tested with notes (including login, create note, share note)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
