### PR TITLE
core: add `export const chains = ["eip155:1", ...]` to specs

### DIFF
--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -25,7 +25,7 @@ export const builder = (yargs: Argv) =>
 		})
 		.option("chain-rpc", {
 			type: "array",
-			desc: "Provide an RPC endpoint for reading on-chain data (format: chain, chainId, URL)",
+			desc: "Provide an RPC endpoint for reading on-chain data (format: chain, URL)",
 		})
 		.option("unchecked", {
 			type: "boolean",

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -25,7 +25,10 @@ export async function handler(args: Args) {
 
 	try {
 		const vm = await VM.initialize({ app: uri, spec, chains: [], unchecked: true })
-		const { models, routes, actions, contractMetadata } = vm
+		const models = vm.getModels()
+		const routes = vm.getRoutes()
+		const actions = vm.getActions()
+		const contracts = vm.getContracts()
 		await vm.close()
 
 		console.log(`name: ${uri}\n`)
@@ -45,7 +48,7 @@ export async function handler(args: Args) {
 		console.log(actions.map((name) => `${name}({ ...args })\n`).join(""))
 
 		console.log(chalk.green("===== contracts ====="))
-		Object.entries(contractMetadata).forEach(([name, { chain, address, abi }]) => {
+		Object.entries(contracts).forEach(([name, { chain, address, abi }]) => {
 			console.log(`${name}: ${address} on ${chain}`)
 			abi.forEach((line) => console.log(`- ${line}`))
 		})

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -81,7 +81,7 @@ export const builder = (yargs: Argv) =>
 		})
 		.option("chain-rpc", {
 			type: "array",
-			desc: "Provide an RPC endpoint for reading on-chain data (format: chain, chainId, URL)",
+			desc: "Provide an RPC endpoint for reading on-chain data (format: chain, URL)",
 		})
 		.option("static", {
 			type: "string",

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -213,7 +213,7 @@ export async function handler(args: Args) {
 			}
 			console.log(`Serving API for ${core.app}:`)
 			console.log(`└ GET  ${apiURL}`)
-			for (const name of Object.keys(core.vm.routes)) {
+			for (const name of core.vm.getRoutes()) {
 				console.log(`└ GET  ${apiURL}/${name.slice(1)}`)
 			}
 			console.log(`└ POST ${apiURL}/actions`)

--- a/packages/core/src/components/modelStore/node/index.ts
+++ b/packages/core/src/components/modelStore/node/index.ts
@@ -36,8 +36,9 @@ class SqliteModelStore implements ModelStore {
 			this.database = new Database(databasePath)
 		}
 
-		initializeModelTables(vm.models, (sql) => this.database.exec(sql))
-		for (const [name, model] of Object.entries(vm.models)) {
+		const models = vm.getModels()
+		initializeModelTables(models, (sql) => this.database.exec(sql))
+		for (const [name, model] of Object.entries(models)) {
 			this.modelStatements[name] = mapEntries(getModelStatements(name, model), (_, sql) => this.database.prepare(sql))
 		}
 
@@ -116,7 +117,6 @@ class SqliteModelStore implements ModelStore {
 	}
 
 	public async getRoute(route: string, params: Record<string, string> = {}): Promise<Record<string, ModelValue>[]> {
-		assert(route in this.vm.routes, "invalid route name")
 		const filteredParams = mapEntries(params, (_, value) => (typeof value === "boolean" ? Number(value) : value))
 		return this.vm.executeRoute(route, filteredParams, (query: string | Query) => {
 			// TODO: Cache the prepared sql

--- a/packages/core/src/components/vm/exports.ts
+++ b/packages/core/src/components/vm/exports.ts
@@ -9,6 +9,7 @@ export type CustomActionDefinition = {
 }
 
 export type Exports = {
+	chains: string[]
 	actionHandles: Record<string, QuickJSHandle>
 	customAction: CustomActionDefinition | null
 	contractMetadata: Record<string, ContractMetadata>

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -27,6 +27,8 @@ export function parseIPFSURI(uri: string): CID {
 	}
 }
 
+export const getCustomActionSchemaName = (app: string, name: string) => `${app}?name=${name}`
+
 export const mapEntries = <K extends string, S, T>(object: Record<K, S>, map: (key: K, value: S) => T) =>
 	Object.fromEntries(Object.entries<S>(object).map(([key, value]) => [key, map(key as K, value)])) as Record<K, T>
 

--- a/packages/core/test/chains.test.ts
+++ b/packages/core/test/chains.test.ts
@@ -1,0 +1,89 @@
+import test from "ava"
+
+import { Core } from "@canvas-js/core"
+import { EthereumChainImplementation } from "@canvas-js/chain-ethereum"
+
+import { compileSpec, TestSigner } from "./utils.js"
+
+test("multiple chains export", async (t) => {
+	const { spec } = await compileSpec({
+		chains: ["eip155:1", "eip155:100"],
+		models: {},
+		actions: { foo: async ({}, {}) => {} },
+	})
+
+	const [mainnet, gnosis] = [new EthereumChainImplementation(1), new EthereumChainImplementation(0x64)]
+	const core = await Core.initialize({
+		chains: [mainnet, gnosis],
+		spec,
+		directory: null,
+		offline: true,
+	})
+
+	t.teardown(() => core.close())
+
+	const mainnetSigner = new TestSigner(core.app, mainnet)
+	const gnosisSigner = new TestSigner(core.app, gnosis)
+
+	await t.notThrowsAsync(async () => {
+		const action = await mainnetSigner.sign("foo", {})
+		await core.apply(action)
+	})
+
+	await t.notThrowsAsync(async () => {
+		const action = await gnosisSigner.sign("foo", {})
+		await core.apply(action)
+	})
+})
+
+test("missing chain declaration", async (t) => {
+	const { spec } = await compileSpec({
+		chains: ["eip155:1"],
+		models: {},
+		actions: { foo: async ({}, {}) => {} },
+	})
+
+	const [mainnet, gnosis] = [new EthereumChainImplementation(1), new EthereumChainImplementation(0x64)]
+	const core = await Core.initialize({
+		chains: [mainnet, gnosis],
+		spec,
+		directory: null,
+		offline: true,
+	})
+
+	t.teardown(() => core.close())
+
+	const mainnetSigner = new TestSigner(core.app, mainnet)
+	const gnosisSigner = new TestSigner(core.app, gnosis)
+
+	await t.notThrowsAsync(async () => {
+		const action = await mainnetSigner.sign("foo", {})
+		await core.apply(action)
+	})
+
+	await t.throwsAsync(
+		async () => {
+			const action = await gnosisSigner.sign("foo", {})
+			await core.apply(action)
+		},
+		{ message: "unsupported chain (eip155:100)" }
+	)
+})
+
+test("missing chain implementation", async (t) => {
+	const { app, spec } = await compileSpec({
+		chains: ["eip155:1", "eip155:100"],
+		models: {},
+		actions: { foo: async ({}, {}) => {} },
+	})
+
+	await t.throwsAsync(
+		Core.initialize({
+			chains: [new EthereumChainImplementation(1)],
+			spec,
+			directory: null,
+			offline: true,
+		}),
+		{ message: `${app} requires a chain implementation for eip155:100` }
+	)
+})

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -60,13 +60,14 @@ function compileActionHandlers<Models extends Record<string, Model>>(actions: Re
 }
 
 export async function compileSpec<Models extends Record<string, Model>>(exports: {
+	chains?: string[]
 	models: Models
 	actions: Record<string, ActionHandler<Models>>
 	routes?: Record<string, (params: Record<string, string>, db: RouteContext) => Query>
 	contracts?: Record<string, { chain: string; address: string; abi: string[] }>
 	sources?: Record<string, Record<string, ActionHandler<Models>>>
 }): Promise<{ app: string; cid: CID; spec: string }> {
-	const { models, actions, routes, contracts, sources } = exports
+	const { chains, models, actions, routes, contracts, sources } = exports
 
 	const actionEntries = compileActionHandlers(actions)
 
@@ -78,6 +79,7 @@ export async function compileSpec<Models extends Record<string, Model>>(exports:
 	})
 
 	const lines = [
+		`export const chains = ${JSON.stringify(chains ?? ["eip155:1"])};`,
 		`export const models = ${JSON.stringify(models, null, "\t")};`,
 		`export const actions = {\n${actionEntries.join(",\n")}};`,
 	]


### PR DESCRIPTION
## Description

This adds support for a `chains: string[]` export from specs, which they use to declare the exact list of CAIP-2 chain identifiers they want to support. If not present, it defaults to `[ "eip155:1" ]` (eth mainnet).

There are two ways that this is validated:

- `Core.initialize` will throw an error if it is not provided with a `ChainImplementation` for every chain in `chains`.
- `Core.apply` will throw an error if `action.payload.chain` / `session.payload.chain` is not one of the chains in `chains`, even if the Core has a chain implementation for it.

See the new test file in packages/core/test/chains.test.ts for examples of these checks.

<!--- Describe your changes in detail -->

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Tested with notes (including login, create note, share note)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

This adds support for a new optional export `chains: string[]`. Existing apps that have messages from a mix of chains will break.

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [x] Contract language
