### PR TITLE
sort messages in chat demo apps by updated_at and id

### DIFF
--- a/examples/chat-browser/spec.canvas.js
+++ b/examples/chat-browser/spec.canvas.js
@@ -1,26 +1,25 @@
-export const chains = ["eip155:1"];
+export const chains = ["eip155:1"]
 
 export const models = {
-  posts: {
-    id: "string",
-    content: "string",
-    from_id: "string",
-    updated_at: "datetime",
-    indexes: ["updated_at"],
-  },
-};
+	posts: {
+		id: "string",
+		content: "string",
+		from_id: "string",
+		updated_at: "datetime",
+		indexes: ["updated_at"],
+	},
+}
 
 export const routes = {
-  "/posts": ({ before = "" }, { db }) => {
-    return db.queryRaw(
-      `SELECT * FROM posts WHERE updated_at < :before ORDER BY updated_at DESC LIMIT 50`,
-      { before },
-    );
-  },
-};
+	"/posts": ({ before = "" }, { db }) => {
+		return db.queryRaw(`SELECT * FROM posts WHERE updated_at < :before ORDER BY updated_at DESC, id ASC LIMIT 50`, {
+			before,
+		})
+	},
+}
 
 export const actions = {
-  createPost({ content }, { db, hash, from }) {
-    db.posts.set(hash, { content, from_id: from });
-  },
-};
+	createPost({ content }, { db, hash, from }) {
+		db.posts.set(hash, { content, from_id: from })
+	},
+}

--- a/examples/chat-next/spec.canvas.js
+++ b/examples/chat-next/spec.canvas.js
@@ -1,26 +1,25 @@
-export const chains = ["eip155:1"];
+export const chains = ["eip155:1"]
 
 export const models = {
-  posts: {
-    id: "string",
-    content: "string",
-    from_id: "string",
-    updated_at: "datetime",
-    indexes: ["updated_at"],
-  },
-};
+	posts: {
+		id: "string",
+		content: "string",
+		from_id: "string",
+		updated_at: "datetime",
+		indexes: ["updated_at"],
+	},
+}
 
 export const routes = {
-  "/posts": ({ before = "" }, { db }) => {
-    return db.queryRaw(
-      `SELECT * FROM posts WHERE updated_at < :before ORDER BY updated_at DESC LIMIT 50`,
-      { before },
-    );
-  },
-};
+	"/posts": ({ before = "" }, { db }) => {
+		return db.queryRaw(`SELECT * FROM posts WHERE updated_at < :before ORDER BY updated_at DESC, id ASC LIMIT 50`, {
+			before,
+		})
+	},
+}
 
 export const actions = {
-  createPost({ content }, { db, hash, from }) {
-    db.posts.set(hash, { content, from_id: from });
-  },
-};
+	createPost({ content }, { db, hash, from }) {
+		db.posts.set(hash, { content, from_id: from })
+	},
+}

--- a/examples/chat-webpack/spec.canvas.js
+++ b/examples/chat-webpack/spec.canvas.js
@@ -1,26 +1,25 @@
-export const chains = ["eip155:1"];
+export const chains = ["eip155:1"]
 
 export const models = {
-  posts: {
-    id: "string",
-    content: "string",
-    from_id: "string",
-    updated_at: "datetime",
-    indexes: ["updated_at"],
-  },
-};
+	posts: {
+		id: "string",
+		content: "string",
+		from_id: "string",
+		updated_at: "datetime",
+		indexes: ["updated_at"],
+	},
+}
 
 export const routes = {
-  "/posts": ({ before = "" }, { db }) => {
-    return db.queryRaw(
-      `SELECT * FROM posts WHERE updated_at < :before ORDER BY updated_at DESC LIMIT 50`,
-      { before },
-    );
-  },
-};
+	"/posts": ({ before = "" }, { db }) => {
+		return db.queryRaw(`SELECT * FROM posts WHERE updated_at < :before ORDER BY updated_at DESC, id ASC LIMIT 50`, {
+			before,
+		})
+	},
+}
 
 export const actions = {
-  createPost({ content }, { db, hash, from }) {
-    db.posts.set(hash, { content, from_id: from });
-  },
-};
+	createPost({ content }, { db, hash, from }) {
+		db.posts.set(hash, { content, from_id: from })
+	},
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently, in the chat example apps, posts are sorted by the `updated_at` column. As a result, if two posts are sent that have the same `updated_at` value, there is no defined ordering. We want to consistently display these posts in the same order, so this PR modifies the Canvas specs in the chat example apps so that the `/posts` route also sorts posts by `id`.

This will wipe the past message history because the multihash of the contract will change, but that's ok

## How has this been tested?

- [x] CI tests pass
- [x] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Tested with notes (including login, create note, share note)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
