### PR TITLE
add models to app response

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -181,6 +181,7 @@ export class Core extends EventEmitter<CoreEvents> implements CoreAPI {
 			actions: this.vm.getActions(),
 			routes: this.vm.getRoutes(),
 			chains: this.vm.getChains(),
+			models: this.vm.getModels(),
 			peers,
 			merkleRoots: this.messageStore.getMerkleRoots(),
 		}

--- a/packages/interfaces/src/core.ts
+++ b/packages/interfaces/src/core.ts
@@ -30,6 +30,7 @@ export type ApplicationData = {
 	uri: string
 	peerId: string | null
 	actions: string[]
+	models: Record<string, Record<string, string>>
 	routes: string[]
 	chains: string[]
 	peers: { id: string; protocols?: string[]; addresses?: string[] }[]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We need this for canvas-hub so that it knows which model names to query to generate the `ModelTables`

## How has this been tested?

- [x] CI tests pass
- [x] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Tested with notes (including login, create note, share note)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
