### PR TITLE
peer discovery tuning

### DIFF
--- a/examples/chat-advanced/package.json
+++ b/examples/chat-advanced/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@canvas-js/example-chat-advanced",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -13,9 +13,9 @@
     "dev": "concurrently --kill-others -n backend,frontend 'npm run dev:backend' 'npm run dev:frontend'"
   },
   "dependencies": {
-    "@canvas-js/chain-ethereum": "0.4.2",
-    "@canvas-js/cli": "0.4.2",
-    "@canvas-js/hooks": "0.4.2",
+    "@canvas-js/chain-ethereum": "0.4.3",
+    "@canvas-js/cli": "0.4.3",
+    "@canvas-js/hooks": "0.4.3",
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
     "@wagmi/chains": "^0.2.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,11 +31,11 @@
     },
     "examples/chat-advanced": {
       "name": "@canvas-js/example-chat-advanced",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
-        "@canvas-js/chain-ethereum": "0.4.2",
-        "@canvas-js/cli": "0.4.2",
-        "@canvas-js/hooks": "0.4.2",
+        "@canvas-js/chain-ethereum": "0.4.3",
+        "@canvas-js/cli": "0.4.3",
+        "@canvas-js/hooks": "0.4.3",
         "@types/react": "^18.0.35",
         "@types/react-dom": "^18.0.11",
         "@wagmi/chains": "^0.2.18",
@@ -58,146 +58,6 @@
         "ts-loader": "^9.4.2",
         "webpack-cli": "^5.0.1",
         "webpack-dev-server": "^4.13.3"
-      }
-    },
-    "examples/chat-advanced/node_modules/@canvas-js/chain-ethereum": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@canvas-js/chain-ethereum/-/chain-ethereum-0.4.2.tgz",
-      "integrity": "sha512-Y4w852+iRWJVOPW5ETisFbg4FkMGwFsxPEgwR6j/s0GtOC1Cs69+srfgqBJrnXvhd0pvzfaU1UDh8s8bgl/R0g==",
-      "dependencies": {
-        "@canvas-js/interfaces": "0.4.2",
-        "@ethersproject/wallet": "^5.7.0",
-        "ethers": "^5.7.2",
-        "safe-stable-stringify": "^2.4.3",
-        "siwe": "^2.1.3"
-      }
-    },
-    "examples/chat-advanced/node_modules/@canvas-js/cli": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@canvas-js/cli/-/cli-0.4.2.tgz",
-      "integrity": "sha512-NOPOOhjEnv0rD6aT9dzCWyAjJPA9qErPa1OzFiNeIgNVgpuQ3Ue5wGiFcjIr3KLXnsuTgzG8r0A2waq0MPA9Fg==",
-      "dependencies": {
-        "@canvas-js/chain-ethereum": "0.4.2",
-        "@canvas-js/core": "0.4.2",
-        "@canvas-js/interfaces": "0.4.2",
-        "@libp2p/interface-peer-id": "^2.0.1",
-        "@types/websocket": "^1.0.5",
-        "better-sqlite3": "^8.3.0",
-        "chalk": "^5.2.0",
-        "cors": "^2.8.5",
-        "ethers": "^5.7.2",
-        "express": "^4.18.2",
-        "express-winston": "^4.2.0",
-        "fp-ts": "^2.13.1",
-        "http-status-codes": "^2.2.0",
-        "io-ts": "^2.2.20",
-        "ipfs-only-hash": "^4.0.0",
-        "multiformats": "^11.0.2",
-        "p-queue": "^7.3.4",
-        "prom-client": "^14.2.0",
-        "prompts": "^2.4.2",
-        "stoppable": "^1.1.0",
-        "winston": "^3.8.2",
-        "ws": "^8.13.0",
-        "yargs": "^17.7.1"
-      },
-      "bin": {
-        "canvas": "dist/index.js"
-      }
-    },
-    "examples/chat-advanced/node_modules/@canvas-js/core": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@canvas-js/core/-/core-0.4.2.tgz",
-      "integrity": "sha512-8Q1AePIuJH9NHt85Zz+2PmY8qlWX6Meaxp7RGvznG023cy6QdS//Q9cWimLeE0M0jBD7axUKkC+8o6GPuV7l+w==",
-      "dependencies": {
-        "@canvas-js/chain-ethereum": "0.4.2",
-        "@canvas-js/interfaces": "0.4.2",
-        "@canvas-js/okra-browser": "^0.2.0",
-        "@canvas-js/okra-node": "^0.2.1",
-        "@chainsafe/libp2p-gossipsub": "^6.3.0",
-        "@chainsafe/libp2p-noise": "^11.0.4",
-        "@hyperjump/json-schema": "^1.4.4",
-        "@libp2p/bootstrap": "^6.0.3",
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-peer-id": "^2.0.1",
-        "@libp2p/interface-registrar": "^2.0.10",
-        "@libp2p/interfaces": "^3.3.1",
-        "@libp2p/kad-dht": "^8.0.10",
-        "@libp2p/logger": "^2.0.7",
-        "@libp2p/mplex": "^7.1.7",
-        "@libp2p/peer-id": "^2.0.3",
-        "@libp2p/peer-id-factory": "^2.0.3",
-        "@libp2p/prometheus-metrics": "^1.1.3",
-        "@libp2p/websockets": "^5.0.10",
-        "@multiformats/multiaddr": "^12.1.2",
-        "@noble/hashes": "^1.3.0",
-        "@types/better-sqlite3": "^7.6.4",
-        "@types/express": "^4.17.17",
-        "@types/k-bucket": "^5.0.1",
-        "@types/ws": "^8.5.4",
-        "aggregate-error": "^4.0.1",
-        "any-signal": "^4.1.1",
-        "better-sqlite3": "^8.3.0",
-        "chalk": "^5.2.0",
-        "ethers": "^5.7.2",
-        "express": "^4.18.2",
-        "fp-ts": "^2.13.1",
-        "http-status-codes": "^2.2.0",
-        "idb": "^7.1.1",
-        "io-ts": "^2.2.20",
-        "ipfs-only-hash": "^4.0.0",
-        "it-pipe": "^3.0.1",
-        "it-pushable": "^3.1.2",
-        "it-stream-types": "^2.0.1",
-        "k-bucket": "^5.1.0",
-        "libp2p": "^0.44.0",
-        "multiformats": "^11.0.2",
-        "p-queue": "^7.3.4",
-        "prom-client": "^14.2.0",
-        "protobufjs": "~7.2.2",
-        "quickjs-emscripten": "^0.22.0",
-        "safe-stable-stringify": "^2.4.3",
-        "uint8arraylist": "^2.4.3",
-        "uuid": "^9.0.0",
-        "ws": "^8.13.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "examples/chat-advanced/node_modules/@canvas-js/hooks": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@canvas-js/hooks/-/hooks-0.4.2.tgz",
-      "integrity": "sha512-Gd8LCcEXCVDi2dh3vRsqJ1E11Qsa3P98JWa8sqH5L32fa5RQSIDvm2CKqnGNACY+7ll9/d7jwJGh6P/lWDigzw==",
-      "dependencies": {
-        "@canvas-js/interfaces": "0.4.2",
-        "@libp2p/interfaces": "^3.3.1",
-        "use-debounce": "^9.0.4"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.0.35",
-        "react": "^18.2.0"
-      }
-    },
-    "examples/chat-advanced/node_modules/@canvas-js/interfaces": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@canvas-js/interfaces/-/interfaces-0.4.2.tgz",
-      "integrity": "sha512-+j7EqNNoKIvon9AJepfP7PyRtx/H7/D4Jl8S4wliM0VxH1pHYopWUbF4T6a2Ds/j9lc6YFa46ANcvevH7JT4SQ==",
-      "dependencies": {
-        "@libp2p/interfaces": "^3.3.1",
-        "@noble/hashes": "^1.3.0",
-        "safe-stable-stringify": "^2.4.3"
-      }
-    },
-    "examples/chat-advanced/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "examples/chat-browser": {
@@ -2244,99 +2104,6 @@
       "version": "2.0.1",
       "license": "MIT"
     },
-    "node_modules/@chainsafe/libp2p-gossipsub": {
-      "version": "6.3.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@libp2p/crypto": "^1.0.3",
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-connection-manager": "^1.3.0",
-        "@libp2p/interface-keys": "^1.0.3",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-peer-store": "^1.2.2",
-        "@libp2p/interface-pubsub": "^3.0.0",
-        "@libp2p/interface-registrar": "^2.0.3",
-        "@libp2p/interfaces": "^3.2.0",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/peer-id": "^2.0.0",
-        "@libp2p/peer-record": "^5.0.0",
-        "@libp2p/pubsub": "^6.0.0",
-        "@libp2p/topology": "^4.0.0",
-        "@multiformats/multiaddr": "^12.0.0",
-        "abortable-iterator": "^4.0.2",
-        "denque": "^1.5.0",
-        "it-length-prefixed": "^8.0.2",
-        "it-pipe": "^2.0.4",
-        "it-pushable": "^3.1.0",
-        "multiformats": "^11.0.0",
-        "protobufjs": "^6.11.2",
-        "uint8arraylist": "^2.3.2",
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "npm": ">=8.7.0"
-      }
-    },
-    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/it-merge": {
-      "version": "2.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "it-pushable": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/it-pipe": {
-      "version": "2.0.5",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "it-merge": "^2.0.0",
-        "it-pushable": "^3.1.0",
-        "it-stream-types": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/it-stream-types": {
-      "version": "1.0.5",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/long": {
-      "version": "4.0.0",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/protobufjs": {
-      "version": "6.11.3",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
     "node_modules/@chainsafe/libp2p-noise": {
       "version": "11.0.4",
       "license": "Apache-2.0 OR MIT",
@@ -3656,20 +3423,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-connection-manager": {
-      "version": "1.5.0",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^12.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/interface-connection/node_modules/it-stream-types": {
       "version": "1.0.5",
       "license": "Apache-2.0 OR MIT",
@@ -4120,38 +3873,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/mplex": {
-      "version": "7.1.7",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-stream-muxer": "^3.0.0",
-        "@libp2p/interfaces": "^3.2.0",
-        "@libp2p/logger": "^2.0.0",
-        "abortable-iterator": "^4.0.2",
-        "any-signal": "^4.0.1",
-        "benchmark": "^2.1.4",
-        "it-batched-bytes": "^1.0.0",
-        "it-pushable": "^3.1.0",
-        "it-stream-types": "^1.0.4",
-        "rate-limiter-flexible": "^2.3.9",
-        "uint8arraylist": "^2.1.1",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/mplex/node_modules/it-stream-types": {
-      "version": "1.0.5",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/multistream-select": {
       "version": "3.1.5",
       "license": "Apache-2.0 OR MIT",
@@ -4330,57 +4051,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/pubsub": {
-      "version": "6.0.6",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/crypto": "^1.0.0",
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-pubsub": "^3.0.0",
-        "@libp2p/interface-registrar": "^2.0.0",
-        "@libp2p/interfaces": "^3.2.0",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/peer-collections": "^3.0.0",
-        "@libp2p/peer-id": "^2.0.0",
-        "@libp2p/topology": "^4.0.0",
-        "abortable-iterator": "^4.0.2",
-        "it-length-prefixed": "^9.0.0",
-        "it-pipe": "^3.0.0",
-        "it-pushable": "^3.0.0",
-        "multiformats": "^11.0.0",
-        "p-queue": "^7.2.0",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/pubsub/node_modules/it-length-prefixed": {
-      "version": "9.0.0",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "err-code": "^3.0.1",
-        "it-stream-types": "^1.0.5",
-        "uint8-varint": "^1.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/pubsub/node_modules/it-stream-types": {
-      "version": "1.0.5",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/record": {
       "version": "3.0.3",
       "license": "Apache-2.0 OR MIT",
@@ -4454,30 +4124,6 @@
     "node_modules/@libp2p/utils/node_modules/it-stream-types": {
       "version": "1.0.5",
       "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/websockets": {
-      "version": "5.0.10",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-transport": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.3",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/utils": "^3.0.2",
-        "@multiformats/mafmt": "^12.0.0",
-        "@multiformats/multiaddr": "^12.0.0",
-        "@multiformats/multiaddr-to-uri": "^9.0.2",
-        "abortable-iterator": "^4.0.2",
-        "it-ws": "^5.0.6",
-        "p-defer": "^4.0.0",
-        "p-timeout": "^6.0.0",
-        "wherearewe": "^2.0.1",
-        "ws": "^8.12.1"
-      },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -12371,27 +12017,6 @@
       "version": "1.0.9",
       "license": "ISC"
     },
-    "node_modules/it-batched-bytes": {
-      "version": "1.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "it-stream-types": "^1.0.4",
-        "p-defer": "^4.0.0",
-        "uint8arraylist": "^2.4.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-batched-bytes/node_modules/it-stream-types": {
-      "version": "1.0.5",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/it-drain": {
       "version": "3.0.1",
       "license": "Apache-2.0 OR MIT",
@@ -12652,29 +12277,6 @@
     },
     "node_modules/it-take": {
       "version": "3.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-ws": {
-      "version": "5.0.6",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "event-iterator": "^2.0.0",
-        "iso-url": "^1.1.2",
-        "it-stream-types": "^1.0.2",
-        "uint8arrays": "^4.0.2",
-        "ws": "^8.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-ws/node_modules/it-stream-types": {
-      "version": "1.0.5",
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -20867,9 +20469,9 @@
     "@canvas-js/example-chat-advanced": {
       "version": "file:examples/chat-advanced",
       "requires": {
-        "@canvas-js/chain-ethereum": "0.4.2",
-        "@canvas-js/cli": "0.4.2",
-        "@canvas-js/hooks": "0.4.2",
+        "@canvas-js/chain-ethereum": "0.4.3",
+        "@canvas-js/cli": "0.4.3",
+        "@canvas-js/hooks": "0.4.3",
         "@types/lodash": "^4.14.194",
         "@types/luxon": "^3.2.0",
         "@types/react": "^18.0.35",
@@ -20890,132 +20492,6 @@
         "wagmi": "^0.12.10",
         "webpack-cli": "^5.0.1",
         "webpack-dev-server": "^4.13.3"
-      },
-      "dependencies": {
-        "@canvas-js/chain-ethereum": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/@canvas-js/chain-ethereum/-/chain-ethereum-0.4.2.tgz",
-          "integrity": "sha512-Y4w852+iRWJVOPW5ETisFbg4FkMGwFsxPEgwR6j/s0GtOC1Cs69+srfgqBJrnXvhd0pvzfaU1UDh8s8bgl/R0g==",
-          "requires": {
-            "@canvas-js/interfaces": "0.4.2",
-            "@ethersproject/wallet": "^5.7.0",
-            "ethers": "^5.7.2",
-            "safe-stable-stringify": "^2.4.3",
-            "siwe": "^2.1.3"
-          }
-        },
-        "@canvas-js/cli": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/@canvas-js/cli/-/cli-0.4.2.tgz",
-          "integrity": "sha512-NOPOOhjEnv0rD6aT9dzCWyAjJPA9qErPa1OzFiNeIgNVgpuQ3Ue5wGiFcjIr3KLXnsuTgzG8r0A2waq0MPA9Fg==",
-          "requires": {
-            "@canvas-js/chain-ethereum": "0.4.2",
-            "@canvas-js/core": "0.4.2",
-            "@canvas-js/interfaces": "0.4.2",
-            "@libp2p/interface-peer-id": "^2.0.1",
-            "@types/websocket": "^1.0.5",
-            "better-sqlite3": "^8.3.0",
-            "chalk": "^5.2.0",
-            "cors": "^2.8.5",
-            "ethers": "^5.7.2",
-            "express": "^4.18.2",
-            "express-winston": "^4.2.0",
-            "fp-ts": "^2.13.1",
-            "http-status-codes": "^2.2.0",
-            "io-ts": "^2.2.20",
-            "ipfs-only-hash": "^4.0.0",
-            "multiformats": "^11.0.2",
-            "p-queue": "^7.3.4",
-            "prom-client": "^14.2.0",
-            "prompts": "^2.4.2",
-            "stoppable": "^1.1.0",
-            "winston": "^3.8.2",
-            "ws": "^8.13.0",
-            "yargs": "^17.7.1"
-          }
-        },
-        "@canvas-js/core": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/@canvas-js/core/-/core-0.4.2.tgz",
-          "integrity": "sha512-8Q1AePIuJH9NHt85Zz+2PmY8qlWX6Meaxp7RGvznG023cy6QdS//Q9cWimLeE0M0jBD7axUKkC+8o6GPuV7l+w==",
-          "requires": {
-            "@canvas-js/chain-ethereum": "0.4.2",
-            "@canvas-js/interfaces": "0.4.2",
-            "@canvas-js/okra-browser": "^0.2.0",
-            "@canvas-js/okra-node": "^0.2.1",
-            "@chainsafe/libp2p-gossipsub": "^6.3.0",
-            "@chainsafe/libp2p-noise": "^11.0.4",
-            "@hyperjump/json-schema": "^1.4.4",
-            "@libp2p/bootstrap": "^6.0.3",
-            "@libp2p/interface-connection": "^4.0.0",
-            "@libp2p/interface-peer-id": "^2.0.1",
-            "@libp2p/interface-registrar": "^2.0.10",
-            "@libp2p/interfaces": "^3.3.1",
-            "@libp2p/kad-dht": "^8.0.10",
-            "@libp2p/logger": "^2.0.7",
-            "@libp2p/mplex": "^7.1.7",
-            "@libp2p/peer-id": "^2.0.3",
-            "@libp2p/peer-id-factory": "^2.0.3",
-            "@libp2p/prometheus-metrics": "^1.1.3",
-            "@libp2p/websockets": "^5.0.10",
-            "@multiformats/multiaddr": "^12.1.2",
-            "@noble/hashes": "^1.3.0",
-            "@types/better-sqlite3": "^7.6.4",
-            "@types/express": "^4.17.17",
-            "@types/k-bucket": "^5.0.1",
-            "@types/ws": "^8.5.4",
-            "aggregate-error": "^4.0.1",
-            "any-signal": "^4.1.1",
-            "better-sqlite3": "^8.3.0",
-            "chalk": "^5.2.0",
-            "ethers": "^5.7.2",
-            "express": "^4.18.2",
-            "fp-ts": "^2.13.1",
-            "http-status-codes": "^2.2.0",
-            "idb": "^7.1.1",
-            "io-ts": "^2.2.20",
-            "ipfs-only-hash": "^4.0.0",
-            "it-pipe": "^3.0.1",
-            "it-pushable": "^3.1.2",
-            "it-stream-types": "^2.0.1",
-            "k-bucket": "^5.1.0",
-            "libp2p": "^0.44.0",
-            "multiformats": "^11.0.2",
-            "p-queue": "^7.3.4",
-            "prom-client": "^14.2.0",
-            "protobufjs": "~7.2.2",
-            "quickjs-emscripten": "^0.22.0",
-            "safe-stable-stringify": "^2.4.3",
-            "uint8arraylist": "^2.4.3",
-            "uuid": "^9.0.0",
-            "ws": "^8.13.0"
-          }
-        },
-        "@canvas-js/hooks": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/@canvas-js/hooks/-/hooks-0.4.2.tgz",
-          "integrity": "sha512-Gd8LCcEXCVDi2dh3vRsqJ1E11Qsa3P98JWa8sqH5L32fa5RQSIDvm2CKqnGNACY+7ll9/d7jwJGh6P/lWDigzw==",
-          "requires": {
-            "@canvas-js/interfaces": "0.4.2",
-            "@libp2p/interfaces": "^3.3.1",
-            "use-debounce": "^9.0.4"
-          }
-        },
-        "@canvas-js/interfaces": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/@canvas-js/interfaces/-/interfaces-0.4.2.tgz",
-          "integrity": "sha512-+j7EqNNoKIvon9AJepfP7PyRtx/H7/D4Jl8S4wliM0VxH1pHYopWUbF4T6a2Ds/j9lc6YFa46ANcvevH7JT4SQ==",
-          "requires": {
-            "@libp2p/interfaces": "^3.3.1",
-            "@noble/hashes": "^1.3.0",
-            "safe-stable-stringify": "^2.4.3"
-          }
-        },
-        "chalk": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
-        }
       }
     },
     "@canvas-js/example-chat-browser": {
@@ -21178,75 +20654,6 @@
     },
     "@chainsafe/is-ip": {
       "version": "2.0.1"
-    },
-    "@chainsafe/libp2p-gossipsub": {
-      "version": "6.3.0",
-      "requires": {
-        "@libp2p/crypto": "^1.0.3",
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-connection-manager": "^1.3.0",
-        "@libp2p/interface-keys": "^1.0.3",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-peer-store": "^1.2.2",
-        "@libp2p/interface-pubsub": "^3.0.0",
-        "@libp2p/interface-registrar": "^2.0.3",
-        "@libp2p/interfaces": "^3.2.0",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/peer-id": "^2.0.0",
-        "@libp2p/peer-record": "^5.0.0",
-        "@libp2p/pubsub": "^6.0.0",
-        "@libp2p/topology": "^4.0.0",
-        "@multiformats/multiaddr": "^12.0.0",
-        "abortable-iterator": "^4.0.2",
-        "denque": "^1.5.0",
-        "it-length-prefixed": "^8.0.2",
-        "it-pipe": "^2.0.4",
-        "it-pushable": "^3.1.0",
-        "multiformats": "^11.0.0",
-        "protobufjs": "^6.11.2",
-        "uint8arraylist": "^2.3.2",
-        "uint8arrays": "^4.0.2"
-      },
-      "dependencies": {
-        "it-merge": {
-          "version": "2.0.1",
-          "requires": {
-            "it-pushable": "^3.1.0"
-          }
-        },
-        "it-pipe": {
-          "version": "2.0.5",
-          "requires": {
-            "it-merge": "^2.0.0",
-            "it-pushable": "^3.1.0",
-            "it-stream-types": "^1.0.3"
-          }
-        },
-        "it-stream-types": {
-          "version": "1.0.5"
-        },
-        "long": {
-          "version": "4.0.0"
-        },
-        "protobufjs": {
-          "version": "6.11.3",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.1",
-            "@types/node": ">=13.7.0",
-            "long": "^4.0.0"
-          }
-        }
-      }
     },
     "@chainsafe/libp2p-noise": {
       "version": "11.0.4",
@@ -22033,15 +21440,6 @@
         }
       }
     },
-    "@libp2p/interface-connection-manager": {
-      "version": "1.5.0",
-      "requires": {
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^12.0.0"
-      }
-    },
     "@libp2p/interface-content-routing": {
       "version": "2.0.2",
       "requires": {
@@ -22351,30 +21749,6 @@
         "multiformats": "^11.0.0"
       }
     },
-    "@libp2p/mplex": {
-      "version": "7.1.7",
-      "requires": {
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-stream-muxer": "^3.0.0",
-        "@libp2p/interfaces": "^3.2.0",
-        "@libp2p/logger": "^2.0.0",
-        "abortable-iterator": "^4.0.2",
-        "any-signal": "^4.0.1",
-        "benchmark": "^2.1.4",
-        "it-batched-bytes": "^1.0.0",
-        "it-pushable": "^3.1.0",
-        "it-stream-types": "^1.0.4",
-        "rate-limiter-flexible": "^2.3.9",
-        "uint8arraylist": "^2.1.1",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
-      },
-      "dependencies": {
-        "it-stream-types": {
-          "version": "1.0.5"
-        }
-      }
-    },
     "@libp2p/multistream-select": {
       "version": "3.1.5",
       "requires": {
@@ -22499,44 +21873,6 @@
         }
       }
     },
-    "@libp2p/pubsub": {
-      "version": "6.0.6",
-      "requires": {
-        "@libp2p/crypto": "^1.0.0",
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-pubsub": "^3.0.0",
-        "@libp2p/interface-registrar": "^2.0.0",
-        "@libp2p/interfaces": "^3.2.0",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/peer-collections": "^3.0.0",
-        "@libp2p/peer-id": "^2.0.0",
-        "@libp2p/topology": "^4.0.0",
-        "abortable-iterator": "^4.0.2",
-        "it-length-prefixed": "^9.0.0",
-        "it-pipe": "^3.0.0",
-        "it-pushable": "^3.0.0",
-        "multiformats": "^11.0.0",
-        "p-queue": "^7.2.0",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^4.0.2"
-      },
-      "dependencies": {
-        "it-length-prefixed": {
-          "version": "9.0.0",
-          "requires": {
-            "err-code": "^3.0.1",
-            "it-stream-types": "^1.0.5",
-            "uint8-varint": "^1.0.1",
-            "uint8arraylist": "^2.0.0",
-            "uint8arrays": "^4.0.2"
-          }
-        },
-        "it-stream-types": {
-          "version": "1.0.5"
-        }
-      }
-    },
     "@libp2p/record": {
       "version": "3.0.3",
       "requires": {
@@ -22587,25 +21923,6 @@
         "it-stream-types": {
           "version": "1.0.5"
         }
-      }
-    },
-    "@libp2p/websockets": {
-      "version": "5.0.10",
-      "requires": {
-        "@libp2p/interface-connection": "^4.0.0",
-        "@libp2p/interface-transport": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.3",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/utils": "^3.0.2",
-        "@multiformats/mafmt": "^12.0.0",
-        "@multiformats/multiaddr": "^12.0.0",
-        "@multiformats/multiaddr-to-uri": "^9.0.2",
-        "abortable-iterator": "^4.0.2",
-        "it-ws": "^5.0.6",
-        "p-defer": "^4.0.0",
-        "p-timeout": "^6.0.0",
-        "wherearewe": "^2.0.1",
-        "ws": "^8.12.1"
       }
     },
     "@lit-labs/ssr-dom-shim": {
@@ -27835,19 +27152,6 @@
     "it-batch": {
       "version": "1.0.9"
     },
-    "it-batched-bytes": {
-      "version": "1.0.1",
-      "requires": {
-        "it-stream-types": "^1.0.4",
-        "p-defer": "^4.0.0",
-        "uint8arraylist": "^2.4.1"
-      },
-      "dependencies": {
-        "it-stream-types": {
-          "version": "1.0.5"
-        }
-      }
-    },
     "it-drain": {
       "version": "3.0.1"
     },
@@ -27998,21 +27302,6 @@
     },
     "it-take": {
       "version": "3.0.1"
-    },
-    "it-ws": {
-      "version": "5.0.6",
-      "requires": {
-        "event-iterator": "^2.0.0",
-        "iso-url": "^1.1.2",
-        "it-stream-types": "^1.0.2",
-        "uint8arrays": "^4.0.2",
-        "ws": "^8.4.0"
-      },
-      "dependencies": {
-        "it-stream-types": {
-          "version": "1.0.5"
-        }
-      }
     },
     "jayson": {
       "version": "3.7.0",

--- a/packages/core/src/components/libp2p/browser/options.ts
+++ b/packages/core/src/components/libp2p/browser/options.ts
@@ -54,8 +54,7 @@ export async function getLibp2pOptions(peerId: PeerId, config: P2PConfig): Promi
 
 		dht: kadDHT({
 			protocolPrefix: "/canvas",
-			// clientMode: true,
-			clientMode: false,
+			clientMode: true,
 			providers: { provideValidity: 20 * minute, cleanupInterval: 5 * minute },
 		}),
 

--- a/packages/core/src/components/libp2p/browser/options.ts
+++ b/packages/core/src/components/libp2p/browser/options.ts
@@ -48,6 +48,7 @@ export async function getLibp2pOptions(peerId: PeerId, config: P2PConfig): Promi
 		streamMuxers: [mplex()],
 		peerDiscovery: [bootstrap({ list: bootstrapList })],
 
+		// switch to the canvas protocol prefix in the next minor version
 		// identify: {
 		// 	protocolPrefix: "canvas",
 		// },

--- a/packages/core/src/components/libp2p/browser/options.ts
+++ b/packages/core/src/components/libp2p/browser/options.ts
@@ -48,6 +48,10 @@ export async function getLibp2pOptions(peerId: PeerId, config: P2PConfig): Promi
 		streamMuxers: [mplex()],
 		peerDiscovery: [bootstrap({ list: bootstrapList })],
 
+		// identify: {
+		// 	protocolPrefix: "canvas",
+		// },
+
 		dht: kadDHT({
 			protocolPrefix: "/canvas",
 			clientMode: true,

--- a/packages/core/src/components/libp2p/browser/options.ts
+++ b/packages/core/src/components/libp2p/browser/options.ts
@@ -54,7 +54,8 @@ export async function getLibp2pOptions(peerId: PeerId, config: P2PConfig): Promi
 
 		dht: kadDHT({
 			protocolPrefix: "/canvas",
-			clientMode: true,
+			// clientMode: true,
+			clientMode: false,
 			providers: { provideValidity: 20 * minute, cleanupInterval: 5 * minute },
 		}),
 

--- a/packages/core/src/components/libp2p/node/options.ts
+++ b/packages/core/src/components/libp2p/node/options.ts
@@ -78,6 +78,7 @@ export async function getLibp2pOptions(peerId: PeerId, config: P2PConfig): Promi
 
 		metrics: prometheusMetrics({ registry: register }),
 
+		// switch to the canvas protocol prefix in the next minor version
 		// identify: {
 		// 	protocolPrefix: "canvas",
 		// },

--- a/packages/core/src/components/libp2p/node/options.ts
+++ b/packages/core/src/components/libp2p/node/options.ts
@@ -50,8 +50,6 @@ export async function getLibp2pOptions(peerId: PeerId, config: P2PConfig): Promi
 		)
 	}
 
-	const discoverRelays = config.announce ? 0 : bootstrapList.length
-
 	const announce = config.announce ?? []
 	for (const address of announce) {
 		console.log(chalk.gray(`[canvas-core] [p2p] Announcing on ${address}`))
@@ -73,7 +71,7 @@ export async function getLibp2pOptions(peerId: PeerId, config: P2PConfig): Promi
 			maxParallelDialsPerPeer: DIAL_CONCURRENCY_PER_PEER,
 		},
 
-		transports: [webSockets(), circuitRelayTransport({ discoverRelays })],
+		transports: [webSockets(), circuitRelayTransport({ discoverRelays: announce.length === 0 ? 1 : 0 })],
 		connectionEncryption: [noise()],
 		streamMuxers: [mplex()],
 		peerDiscovery: [bootstrap({ list: bootstrapList })],
@@ -86,8 +84,7 @@ export async function getLibp2pOptions(peerId: PeerId, config: P2PConfig): Promi
 
 		dht: kadDHT({
 			protocolPrefix: "/canvas",
-			// clientMode: announce.length === 0,
-			clientMode: false,
+			clientMode: announce.length === 0,
 			providers: { provideValidity: 20 * minute, cleanupInterval: 5 * minute },
 		}),
 

--- a/packages/core/src/components/libp2p/node/options.ts
+++ b/packages/core/src/components/libp2p/node/options.ts
@@ -80,6 +80,16 @@ export async function getLibp2pOptions(peerId: PeerId, config: P2PConfig): Promi
 
 		metrics: prometheusMetrics({ registry: register }),
 
+		// identify: {
+		// 	protocolPrefix: "canvas",
+		// },
+
+		dht: kadDHT({
+			protocolPrefix: "/canvas",
+			clientMode: announce.length === 0,
+			providers: { provideValidity: 20 * minute, cleanupInterval: 5 * minute },
+		}),
+
 		pubsub: gossipsub({
 			emitSelf: false,
 			fallbackToFloodsub: false,
@@ -87,12 +97,6 @@ export async function getLibp2pOptions(peerId: PeerId, config: P2PConfig): Promi
 			globalSignaturePolicy: "StrictSign",
 			msgIdFn: (msg) => sha256(msg.data),
 			msgIdToStrFn: (id) => hex(id),
-		}),
-
-		dht: kadDHT({
-			protocolPrefix: "/canvas",
-			clientMode: announce.length === 0,
-			providers: { provideValidity: 20 * minute, cleanupInterval: 5 * minute },
 		}),
 
 		ping: {

--- a/packages/core/src/components/libp2p/node/options.ts
+++ b/packages/core/src/components/libp2p/node/options.ts
@@ -86,7 +86,8 @@ export async function getLibp2pOptions(peerId: PeerId, config: P2PConfig): Promi
 
 		dht: kadDHT({
 			protocolPrefix: "/canvas",
-			clientMode: announce.length === 0,
+			// clientMode: announce.length === 0,
+			clientMode: false,
 			providers: { provideValidity: 20 * minute, cleanupInterval: 5 * minute },
 		}),
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -28,7 +28,6 @@ import { Source } from "./source.js"
 import { actionType, messageType } from "./codecs.js"
 import { toHex, signalInvalidType, stringify, parseIPFSURI, assert, getCustomActionSchemaName } from "./utils.js"
 import * as constants from "./constants.js"
-import { startPingService } from "./services/ping.js"
 
 export interface CoreConfig extends CoreOptions, P2PConfig {
 	// pass `null` to run in memory (NodeJS only)
@@ -91,8 +90,6 @@ export class Core extends EventEmitter<CoreEvents> implements CoreAPI {
 		if (libp2p !== null && core.sources !== null) {
 			await libp2p.start()
 			await Promise.all(Object.values(core.sources).map((source) => source.start()))
-
-			// startPingService({ libp2p, signal: core.controller.signal, verbose })
 		}
 
 		return core

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -92,7 +92,7 @@ export class Core extends EventEmitter<CoreEvents> implements CoreAPI {
 			await libp2p.start()
 			await Promise.all(Object.values(core.sources).map((source) => source.start()))
 
-			startPingService({ libp2p, signal: core.controller.signal, verbose })
+			// startPingService({ libp2p, signal: core.controller.signal, verbose })
 		}
 
 		return core

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -28,6 +28,7 @@ import { Source } from "./source.js"
 import { actionType, messageType } from "./codecs.js"
 import { toHex, signalInvalidType, stringify, parseIPFSURI, assert, getCustomActionSchemaName } from "./utils.js"
 import * as constants from "./constants.js"
+import { startPingService } from "./services/ping.js"
 
 export interface CoreConfig extends CoreOptions, P2PConfig {
 	// pass `null` to run in memory (NodeJS only)
@@ -90,6 +91,8 @@ export class Core extends EventEmitter<CoreEvents> implements CoreAPI {
 		if (libp2p !== null && core.sources !== null) {
 			await libp2p.start()
 			await Promise.all(Object.values(core.sources).map((source) => source.start()))
+
+			startPingService({ libp2p, signal: core.controller.signal, verbose })
 		}
 
 		return core

--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -66,6 +66,15 @@ export class Source extends EventEmitter<SourceEvents> {
 			console.log(chalk.gray(this.prefix, `Subscribed to GossipSub topic`))
 		}
 
+		this.libp2p.addEventListener("peer:discovery", async ({ detail: { id } }) => {
+			const protocols = await this.libp2p.peerStore.protoBook.get(id)
+			if (protocols.includes(this.uri)) {
+				console.log(chalk.gray(this.prefix, `Discovered application peer ${id}`))
+
+				this.handlePeerDiscovery(id)
+			}
+		})
+
 		this.libp2p.peerStore.addEventListener("change:protocols", ({ detail: { peerId, oldProtocols, protocols } }) => {
 			if (this.libp2p.peerId.equals(peerId)) {
 				return
@@ -244,11 +253,11 @@ export class Source extends EventEmitter<SourceEvents> {
 		this.pendingSyncPeers.set(id, {})
 		try {
 			await this.syncQueue.add(() => this.sync(peerId))
-			this.syncHistroy.set(id, performance.now())
 		} catch (err) {
 			logErrorMessage(this.prefix, "Sync failed", err)
 		} finally {
 			this.pendingSyncPeers.delete(id)
+			this.syncHistroy.set(id, performance.now())
 		}
 	}
 

--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -66,15 +66,6 @@ export class Source extends EventEmitter<SourceEvents> {
 			console.log(chalk.gray(this.prefix, `Subscribed to GossipSub topic`))
 		}
 
-		this.libp2p.addEventListener("peer:discovery", async ({ detail: { id } }) => {
-			const protocols = await this.libp2p.peerStore.protoBook.get(id)
-			if (protocols.includes(this.uri)) {
-				console.log(chalk.gray(this.prefix, `Discovered application peer ${id}`))
-
-				this.handlePeerDiscovery(id)
-			}
-		})
-
 		this.libp2p.peerStore.addEventListener("change:protocols", ({ detail: { peerId, oldProtocols, protocols } }) => {
 			if (this.libp2p.peerId.equals(peerId)) {
 				return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fixes a bug in setting `discoverRelays` if an empty `announce` array is provided
- add peers to the sync history map even if the sync failed

<!--- Describe your changes in detail -->

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Tested with notes (including login, create note, share note)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
