### PR TITLE
Bob/can 162 consolidate tables in nodejs messageStore

### DIFF
--- a/packages/core/src/components/messageStore/node/index.ts
+++ b/packages/core/src/components/messageStore/node/index.ts
@@ -19,7 +19,7 @@ export * from "../types.js"
 type MessageRecord = {
 	hash: Buffer
 	type: string
-	payload: string
+	message: string
 }
 
 type SessionHashRecord = {
@@ -136,7 +136,7 @@ class SqliteMessageStore extends EventEmitter<MessageStoreEvents> implements Mes
 		if (record === undefined || record.type !== "session") {
 			return [null, null]
 		} else {
-			return [toHex(record.hash), JSON.parse(record.payload) as Session]
+			return [toHex(record.hash), JSON.parse(record.message) as Session]
 		}
 	}
 
@@ -147,7 +147,7 @@ class SqliteMessageStore extends EventEmitter<MessageStoreEvents> implements Mes
 		if (record === undefined) {
 			return null
 		} else {
-			return JSON.parse(record.payload) as Message
+			return JSON.parse(record.message) as Message
 		}
 	}
 
@@ -184,7 +184,7 @@ class SqliteMessageStore extends EventEmitter<MessageStoreEvents> implements Mes
 		}
 
 		for (const record of iter as Iterable<MessageRecord>) {
-			yield [record.hash, JSON.parse(record.payload) as Message]
+			yield [record.hash, JSON.parse(record.message) as Message]
 		}
 	}
 
@@ -220,7 +220,7 @@ class SqliteMessageStore extends EventEmitter<MessageStoreEvents> implements Mes
 			this.statements.insertMessage.run({
 				hash: id,
 				type: message.type,
-				payload: JSON.stringify(message),
+				message: JSON.stringify(message),
 			})
 
 			if (message.type === "session") {
@@ -261,11 +261,11 @@ class SqliteMessageStore extends EventEmitter<MessageStoreEvents> implements Mes
 	}
 
 	// This table stores messages (actions, sessions, customActions)
-	// The `payload` field is a JSON blob
+	// The `message` field is a JSON blob
 	private static createMessagesTable = `CREATE TABLE IF NOT EXISTS messages (
 		hash      BLOB PRIMARY KEY,
 		type      TEXT NOT NULL,
-		payload   BLOB NOT NULL
+		message   BLOB NOT NULL
 	)`
 
 	private static createSessionHashTable = `CREATE TABLE IF NOT EXISTS session_hash (
@@ -276,7 +276,7 @@ class SqliteMessageStore extends EventEmitter<MessageStoreEvents> implements Mes
 	private static statements = {
 		insertSessionHash: `INSERT INTO session_hash (session_address, hash) VALUES (:session_address, :hash)`,
 		getSessionHashBySessionAddress: `SELECT * FROM session_hash WHERE session_address = :session_address`,
-		insertMessage: `INSERT INTO messages (hash, type, payload) VALUES (:hash, :type, :payload)`,
+		insertMessage: `INSERT INTO messages (hash, type, message) VALUES (:hash, :type, :message)`,
 		getMessageByHash: `SELECT * FROM messages WHERE hash = :hash`,
 		getMessages: `SELECT * FROM messages`,
 		getMessagesByType: `SELECT * FROM messages WHERE type = :type`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR replaces the `actions`, `sessions` and `customActions` in the node messageStore implementation (`SqliteMessageStore`) with two tables:
- `messages` - this has an id, hash and message column - `message` stores a JSON serialized copy of the `Action` or `Session` or `CustomAction` object. 
- `session_address` - this has a `session_address` and `hash` column. this is used to look up sessions by their session address. we can look up the hash from this table, then look up the session object itself in the `messages` table

This PR also modifies the message store to ignore the `app` filter when `getMessageStream` is called. TODO: remove this from the function signature

## How has this been tested?

- [x] CI tests pass
- [x] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Tested with notes (including login, create note, share note)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
