### PR TITLE
Add --syncModule option to CLI, updates Cosmos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18804,7 +18804,11 @@
       "name": "@canvas-js/cli",
       "version": "0.4.11",
       "dependencies": {
+        "@canvas-js/chain-cosmos": "0.4.11",
         "@canvas-js/chain-ethereum": "0.4.11",
+        "@canvas-js/chain-near": "0.4.11",
+        "@canvas-js/chain-solana": "0.4.11",
+        "@canvas-js/chain-substrate": "0.4.11",
         "@canvas-js/core": "0.4.11",
         "@canvas-js/interfaces": "0.4.11",
         "@libp2p/interface-peer-id": "^2.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,10 @@
   },
   "dependencies": {
     "@canvas-js/chain-ethereum": "0.4.11",
+    "@canvas-js/chain-cosmos": "0.4.11",
+    "@canvas-js/chain-near": "0.4.11",
+    "@canvas-js/chain-solana": "0.4.11",
+    "@canvas-js/chain-substrate": "0.4.11",
     "@canvas-js/core": "0.4.11",
     "@canvas-js/interfaces": "0.4.11",
     "@libp2p/interface-peer-id": "^2.0.1",

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -10,6 +10,11 @@ import { ethers } from "ethers"
 
 import type { ChainImplementation } from "@canvas-js/interfaces"
 import { EthereumChainImplementation } from "@canvas-js/chain-ethereum"
+import { CosmosChainImplementation } from "@canvas-js/chain-cosmos"
+import { SolanaChainImplementation } from "@canvas-js/chain-solana"
+import { SubstrateChainImplementation } from "@canvas-js/chain-substrate"
+// @ts-ignore
+import { NearChainImplementation } from "@canvas-js/chain-near"
 
 import * as constants from "@canvas-js/core/constants"
 import { assert } from "@canvas-js/core/utils"
@@ -92,13 +97,29 @@ export function getChainImplementations(args?: (string | number)[]): ChainImplem
 
 			const delimiterIndex = arg.indexOf("=")
 			if (delimiterIndex === -1) {
+				// chain provided without url
 				const [namespace, chainId] = parseChainId(arg)
 				if (namespace === "eip155") {
-					chains.push(new EthereumChainImplementation(parseInt(chainId), domain))
+					chains.push(new EthereumChainImplementation(chainId === "*" ? undefined : parseInt(chainId), domain))
+				} else if (namespace === "cosmos") {
+					const [namespace, chainId, bech32Prefix] = arg.split(":")
+					chains.push(
+						new CosmosChainImplementation(
+							chainId === "*" ? "cosmoshub-1" : chainId,
+							chainId === "*" ? "cosmos" : bech32Prefix
+						)
+					)
+				} else if (namespace === "solana") {
+					chains.push(new SolanaChainImplementation())
+				} else if (namespace === "substrate") {
+					chains.push(new SubstrateChainImplementation())
+				} else if (namespace === "near") {
+					chains.push(new NearChainImplementation())
 				} else {
-					throw new Error(`Unsupported chain ${arg}: only eip155 chains can be passed in the CLI`)
+					throw new Error(`Unsupported chain ${arg}`)
 				}
 			} else {
+				// chain provided with url
 				const chain = arg.slice(0, delimiterIndex)
 				const url = arg.slice(delimiterIndex + 1)
 				const [namespace, chainId] = parseChainId(chain)
@@ -106,7 +127,7 @@ export function getChainImplementations(args?: (string | number)[]): ChainImplem
 					const provider = new ethers.providers.JsonRpcProvider(url)
 					chains.push(new EthereumChainImplementation(parseInt(chainId), domain, provider))
 				} else {
-					throw new Error(`Unsupported chain ${arg}: only eip155 chains can be passed in the CLI`)
+					throw new Error(`Unsupported chain ${arg}: only eip155 chains can be passed in the CLI with RPCs`)
 				}
 			}
 		}

--- a/packages/core/src/components/vm/exports.ts
+++ b/packages/core/src/components/vm/exports.ts
@@ -9,7 +9,7 @@ export type CustomActionDefinition = {
 }
 
 export type Exports = {
-	chains: string[]
+	signers: string[]
 	actionHandles: Record<string, QuickJSHandle>
 	customAction: CustomActionDefinition | null
 	contractMetadata: Record<string, ContractMetadata>

--- a/packages/core/src/components/vm/validate.ts
+++ b/packages/core/src/components/vm/validate.ts
@@ -220,7 +220,7 @@ export function validateCanvasSpec(
 			for (const [source, sourceHandle] of Object.entries(
 				sourcesHandle.consume((handle) => unwrapObject(context, handle))
 			)) {
-				assertLogError(ipfsURIPattern.test(source), `Source '${source}' is invalid: the keys must be ipfs:// URIs`)
+				// assertLogError(ipfsURIPattern.test(source), `Source '${source}' is invalid: the keys must be ipfs:// URIs`)
 				assertLogError(context.typeof(sourceHandle) === "object", `sources["${source}"] must be an object`)
 				exports.sourceHandles[source] = sourceHandle.consume((handle) => unwrapObject(context, handle))
 				for (const [name, handle] of Object.entries(exports.sourceHandles[source])) {

--- a/packages/core/src/components/vm/validate.ts
+++ b/packages/core/src/components/vm/validate.ts
@@ -45,7 +45,7 @@ export function validateCanvasSpec(
 	}
 
 	const exports: Exports = {
-		chains: [],
+		signers: [],
 		models: {},
 		contractMetadata: {},
 		routeHandles: {},
@@ -61,10 +61,10 @@ export function validateCanvasSpec(
 
 	// validate chains
 	if (chainsHandle === undefined) {
-		exports.chains.push("eip155:1") // ethereum mainnet
+		exports.signers.push("eip155:1") // ethereum mainnet
 	} else {
 		for (const chainHandle of chainsHandle.consume((handle) => unwrapArray(context, handle))) {
-			exports.chains.push(chainHandle.consume(context.getString))
+			exports.signers.push(chainHandle.consume(context.getString))
 		}
 	}
 

--- a/packages/core/src/components/vm/vm.ts
+++ b/packages/core/src/components/vm/vm.ts
@@ -88,7 +88,7 @@ export class VM {
 			}
 
 			// ensure we don't have extra chain implementations
-			for (const chainImplementation of chains) {
+			for (const impl of chains) {
 				if (
 					exports.signers.find((signerCaip) => {
 						const signerCaipSubstring = signerCaip.slice(0, signerCaip.length - 1)
@@ -97,7 +97,7 @@ export class VM {
 				) {
 					continue
 				} else {
-					throw new Error(`${app} contract didn't declare a signer for ${chainImplementation.chain}`)
+					throw new Error(`${app} contract didn't declare a signer for ${impl.chain}`)
 				}
 			}
 

--- a/packages/core/src/components/vm/vm.ts
+++ b/packages/core/src/components/vm/vm.ts
@@ -73,7 +73,13 @@ export class VM {
 
 			// validate the presence of the declared chains
 			for (const chain of exports.chains) {
-				if (chains.find((impl) => impl.chain === chain)) {
+				if (
+					chains.find(
+						(impl) =>
+							// accept exact matches, or fuzzy matches where the contract requests "chain:*"
+							impl.chain === chain || (chain.endsWith("*") && impl.chain.startsWith(chain.slice(0, chain.length - 1)))
+					)
+				) {
 					continue
 				} else {
 					throw new Error(`${app} requires a chain implementation for ${chain}`)
@@ -322,7 +328,7 @@ export class VM {
 	}
 
 	public getChains(): string[] {
-		return this.exports.chains
+		return this.chains.map((c) => c.chain)
 	}
 
 	public getModels(): Record<string, Model> {

--- a/packages/core/src/components/vm/vm.ts
+++ b/packages/core/src/components/vm/vm.ts
@@ -72,7 +72,7 @@ export class VM {
 			}
 
 			// validate the presence of the declared chains
-			for (const chain of exports.chains) {
+			for (const chain of exports.signers) {
 				if (
 					chains.find(
 						(impl) =>
@@ -327,8 +327,8 @@ export class VM {
 		this.runtime.dispose()
 	}
 
-	public getChains(): string[] {
-		return this.chains.map((c) => c.chain)
+	public getSigners(): string[] {
+		return this.exports.signers
 	}
 
 	public getModels(): Record<string, Model> {

--- a/packages/core/src/components/vm/vm.ts
+++ b/packages/core/src/components/vm/vm.ts
@@ -342,6 +342,14 @@ export class VM {
 		this.runtime.dispose()
 	}
 
+	public hasSigner(signerCaip: string): boolean {
+		const matchingSigner = this.exports.signers.find(
+			(signer) =>
+				signerCaip === signer || (signer.endsWith("*") && signerCaip.startsWith(signer.slice(0, signer.length - 1)))
+		)
+		return matchingSigner !== undefined
+	}
+
 	public getSigners(): string[] {
 		return this.exports.signers
 	}

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -230,7 +230,7 @@ export class Core extends EventEmitter<CoreEvents> implements CoreAPI {
 			cid: this.cid.toString(),
 			actions: this.vm.getActions(),
 			routes: this.vm.getRoutes(),
-			chains: this.vm.getChains(),
+			signers: this.vm.getSigners(),
 			models: this.vm.getModels(),
 			peers,
 			merkleRoots: this.messageStore.getMerkleRoots(),
@@ -354,7 +354,7 @@ export class Core extends EventEmitter<CoreEvents> implements CoreAPI {
 		const fromAddress = action.payload.from
 
 		assert(app === this.app || this.vm.sources.has(app), `action signed for wrong application (${app})`)
-		assert(this.vm.getChains().includes(chain), `unsupported chain (${chain})`)
+		assert(this.vm.getSigners().includes(chain), `unsupported action signer (${chain})`)
 
 		// TODO: verify that actions signed for a previous app were valid within that app
 
@@ -387,7 +387,7 @@ export class Core extends EventEmitter<CoreEvents> implements CoreAPI {
 		const { app, sessionIssued, block, chain } = session.payload
 
 		assert(app === this.app || this.vm.sources.has(app), `session signed for wrong application (${app})`)
-		assert(this.vm.getChains().includes(chain), `unsupported chain (${chain})`)
+		assert(this.vm.getSigners().includes(chain), `unsupported session signer (${chain})`)
 
 		// check the timestamp bounds
 		assert(sessionIssued > BOUNDS_CHECK_LOWER_LIMIT, "session issued too far in the past")

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -354,7 +354,7 @@ export class Core extends EventEmitter<CoreEvents> implements CoreAPI {
 		const fromAddress = action.payload.from
 
 		assert(app === this.app || this.vm.sources.has(app), `action signed for wrong application (${app})`)
-		assert(this.vm.getSigners().includes(chain), `unsupported action signer (${chain})`)
+		assert(this.vm.hasSigner(chain), `unsupported action signer (${chain})`)
 
 		// TODO: verify that actions signed for a previous app were valid within that app
 
@@ -387,7 +387,7 @@ export class Core extends EventEmitter<CoreEvents> implements CoreAPI {
 		const { app, sessionIssued, block, chain } = session.payload
 
 		assert(app === this.app || this.vm.sources.has(app), `session signed for wrong application (${app})`)
-		assert(this.vm.getSigners().includes(chain), `unsupported session signer (${chain})`)
+		assert(this.vm.hasSigner(chain), `unsupported session signer (${chain})`)
 
 		// check the timestamp bounds
 		assert(sessionIssued > BOUNDS_CHECK_LOWER_LIMIT, "session issued too far in the past")

--- a/packages/core/test/chains.test.ts
+++ b/packages/core/test/chains.test.ts
@@ -44,29 +44,16 @@ test("missing signer declaration for provided chain implementation", async (t) =
 	})
 
 	const [mainnet, gnosis] = [new EthereumChainImplementation(1), new EthereumChainImplementation(0x64)]
-	const core = await Core.initialize({
-		chains: [mainnet, gnosis],
-		spec,
-		directory: null,
-		offline: true,
-	})
-
-	t.teardown(() => core.close())
-
-	const mainnetSigner = new TestSigner(core.app, mainnet)
-	const gnosisSigner = new TestSigner(core.app, gnosis)
-
-	await t.notThrowsAsync(async () => {
-		const action = await mainnetSigner.sign("foo", {})
-		await core.apply(action)
-	})
-
 	await t.throwsAsync(
 		async () => {
-			const action = await gnosisSigner.sign("foo", {})
-			await core.apply(action)
+			const core = await Core.initialize({
+				chains: [mainnet, gnosis],
+				spec,
+				directory: null,
+				offline: true,
+			})
 		},
-		{ message: "unsupported action signer (eip155:100)" }
+		{ message: "ipfs://QmPrP7ZVTKSkoNtpfr24XH1UNqSugEDNSqY9BGV7hE8SF9 contract didn't declare a signer for eip155:100" }
 	)
 })
 

--- a/packages/core/test/chains.test.ts
+++ b/packages/core/test/chains.test.ts
@@ -36,7 +36,7 @@ test("multiple chains export", async (t) => {
 	})
 })
 
-test("missing chain declaration", async (t) => {
+test("missing signer declaration for provided chain implementation", async (t) => {
 	const { spec } = await compileSpec({
 		chains: ["eip155:1"],
 		models: {},
@@ -66,7 +66,7 @@ test("missing chain declaration", async (t) => {
 			const action = await gnosisSigner.sign("foo", {})
 			await core.apply(action)
 		},
-		{ message: "unsupported chain (eip155:100)" }
+		{ message: "unsupported action signer (eip155:100)" }
 	)
 })
 

--- a/packages/core/test/validate.test.ts
+++ b/packages/core/test/validate.test.ts
@@ -325,17 +325,17 @@ const VALIDATION_TEST_FIXTURES: {
     `,
 		expectedResult: success,
 	},
-	{
-		name: "reject source with invalid name",
-		app: `
-      export const models = {};
-      export const actions = {};
-      export const sources = {
-        "something.py": {}
-      }
-    `,
-		expectedResult: errors(["Source 'something.py' is invalid: the keys must be ipfs:// URIs"]),
-	},
+	// {
+	// 	name: "reject source with invalid name",
+	// 	app: `
+	//     export const models = {};
+	//     export const actions = {};
+	//     export const sources = {
+	//       "something.py": {}
+	//     }
+	//   `,
+	// 	expectedResult: errors(["Source 'something.py' is invalid: the keys must be ipfs:// URIs"]),
+	// },
 	{
 		name: "reject a valid source with invalid values",
 		app: `

--- a/packages/hooks/src/useSession.ts
+++ b/packages/hooks/src/useSession.ts
@@ -130,7 +130,7 @@ export function useSession<Signer, DelegatedSigner>(
 			}
 
 			const { chain } = chainImplementation
-			if (!data.chains.includes(chain)) {
+			if (!data.signers.includes(chain)) {
 				throw new InvalidChainError(`Invalid chain: ${chain}`)
 			}
 

--- a/packages/interfaces/src/core.ts
+++ b/packages/interfaces/src/core.ts
@@ -32,7 +32,7 @@ export type ApplicationData = {
 	actions: string[]
 	models: Record<string, Record<string, string>>
 	routes: string[]
-	chains: string[]
+	signers: string[]
 	peers: { id: string; protocols?: string[]; addresses?: string[] }[]
 	merkleRoots: Record<string, string>
 }


### PR DESCRIPTION
- Allows CLI runners to provide an ESM module containing logic for syncing a Canvas node to an API.
- Changes `export chains` in contracts to `export signers`. Accepts CAIP-2 wildcards, e.g. `eip155:*`.
- Relaxes requirement that sources are IPFS URLs. This allows apps to use custom strings as sources...

## How has this been tested?

No tests yet. Developed against https://github.com/hicommonwealth/commonwealth/pull/3600

- [x] CI tests pass
- [x] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Tested with notes (including login, create note, share note)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

- Breaking changes to contract language (`export chains` is now `export signers`)
- APIs internal to hooks/core (no changes required for external apps using hooks)

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [x] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [x] Contract language
