### PR TITLE
add message pagination to API

### DIFF
--- a/packages/core/src/components/messageStore/browser/index.ts
+++ b/packages/core/src/components/messageStore/browser/index.ts
@@ -97,6 +97,10 @@ class IndexedDBMessageStore extends EventEmitter<MessageStoreEvents> implements 
 		}
 	}
 
+	public async countMessages(type?: "action" | "session" | "customAction" | undefined): Promise<number> {
+		throw Error("countMessages is not implemented in the browser")
+	}
+
 	public async read<T>(
 		callback: (txn: ReadOnlyTransaction) => T | Promise<T>,
 		options: { uri?: string } = {}

--- a/packages/core/src/components/messageStore/types.ts
+++ b/packages/core/src/components/messageStore/types.ts
@@ -25,10 +25,12 @@ export interface MessageStoreEvents {
 
 export interface MessageStore extends EventEmitter<MessageStoreEvents> {
 	getMessageStream(filter?: {
-		type?: Message["type"]
+		type?: Message["type"] | undefined
 		limit?: number
+		offset?: number
 		app?: string
 	}): AsyncIterable<[Uint8Array, Message]>
+	countMessages(type?: Message["type"]): Promise<number>
 
 	close(): Promise<void>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds pagination to the `/messages` daemon API.

Changes:
- Add a `offset` parameter to the `/messages` API endpoint. This only works in the node implementation. We only use this feature in canvas-hub (which calls canvas-hub-daemon, which is using node) so this doesn't break any new features.
- Implement limit/offset pagination in `SqliteMessageStore`
- Change the return type of the `/messages` endpoint to include pagination information

## How has this been tested?

- [x] CI tests pass
- [x] Tested with chat-next (including login, all signers, and exchanging messages)
- [x] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Tested with notes (including login, create note, share note)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [x] Daemon API
- [ ] Command line arguments
- [ ] Contract language
