### PR TITLE
fix infinite loop bug in notes app: use useEffect when creating ChainImplementation object

### DIFF
--- a/examples/notes/src/metamaskCrypto.ts
+++ b/examples/notes/src/metamaskCrypto.ts
@@ -1,6 +1,6 @@
 import { encrypt } from "@metamask/eth-sig-util"
 
-export async function metamaskGetPublicKey(account: string) {
+export async function metamaskGetPublicKey(account: string): Promise<Buffer> {
 	const keyB64 = (await (window as any).ethereum.request({
 		method: "eth_getEncryptionPublicKey",
 		params: [account],

--- a/examples/notes/src/useConnectOneStep.tsx
+++ b/examples/notes/src/useConnectOneStep.tsx
@@ -28,10 +28,9 @@ export const useConnectOneStep = ({
 	const { error: signerError, data: signer } = useSigner<ethers.providers.JsonRpcSigner>()
 	const { chain } = useNetwork()
 	const provider = useProvider<ethers.providers.JsonRpcProvider>()
+	const [chainImplementation, setChainImplementation] = useState<EthereumChainImplementation | null>(null)
 
 	// canvas login state
-	const chainImplementation = new EthereumChainImplementation(chain?.id ?? 1, window.location.host, provider)
-	// const signer = useCanvasSigner(ethersSigner!, ethers.providers.getNetwork(chain?.id!))
 	const { login, logout, isLoading, isPending, client } = useSession(chainImplementation, signer)
 
 	const logoutEverything = () => {
@@ -39,6 +38,12 @@ export const useConnectOneStep = ({
 		wagmiDisconnect()
 		setConnectionState("disconnected")
 	}
+
+	useEffect(() => {
+		if (chain) {
+			setChainImplementation(new EthereumChainImplementation(chain.id, window.location.host, provider))
+		}
+	}, [chain, window.location.host, provider])
 
 	useEffect(() => {
 		console.log(
@@ -80,8 +85,6 @@ export const useConnectOneStep = ({
 			}
 		}
 	}, [client, signer, isLoading, isPending])
-
-	useEffect(() => {}, [isLoading, isPending])
 
 	useEffect(() => {
 		// log out if wagmi is disconnected while logged in


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an infinite loop bug in the notes app - the `useConnectOneStep` hook was creating a chainimplementation object every time it was called, which then caused the `signer` object to update over and over, which eventually triggered an infinite loop... This should be wrapped in a `useEffect` call.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [x] Tested with notes (including login, create note, share note)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
