### PR TITLE
Better sync module syntax

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -18,12 +18,12 @@ import { multiaddr } from "@multiformats/multiaddr"
 import type { Action, Session } from "@canvas-js/interfaces"
 import { Core, CoreOptions } from "@canvas-js/core"
 import { getAPI, handleWebsocketConnection } from "@canvas-js/core/api"
-import { SessionExists, ActionExists } from "@canvas-js/core/utils"
 
 import { testnetBootstrapList } from "@canvas-js/core/bootstrap"
 import * as constants from "@canvas-js/core/constants"
 
 import { getChainImplementations, confirmOrExit, parseSpecArgument, installSpec, CANVAS_HOME } from "../utils.js"
+import { setupSyncModule } from "../syncModule.js"
 import { EthereumChainImplementation } from "@canvas-js/chain-ethereum"
 import { getReasonPhrase, StatusCodes } from "http-status-codes"
 import { P2PConfig } from "@canvas-js/core/components/libp2p"
@@ -262,73 +262,15 @@ export async function handler(args: Args) {
 		app.use(getAPI(core, { exposeMetrics: args.metrics, exposeP2P: args.p2p }))
 	}
 
-	let syncModuleTimer: ReturnType<typeof setTimeout>
+  let apiSyncTimer: { timer?: ReturnType<typeof setTimeout> }
 	if (args.syncModule) {
-		const { onPeerRecv, api } = await import(args.syncModule)
+		const { api, apiToPeerHandler, peerToApiHandler } = await import(args.syncModule)
 
-		if (!onPeerRecv) {
-			throw new Error("sync module must declare onPeerRecv to handle incoming actions")
-		}
-		if (!api || !api.onPoll) {
-			throw new Error("sync module must declare api.onPoll to handle incoming actions")
-		}
-		if (!api.endpoint) {
-			throw new Error("sync module must declare api.endpoint as url or function")
-		}
-		if (!api.frequency) {
-			throw new Error("sync module must declare api.frequency as msec")
-		}
+		if (!apiToPeerHandler) throw new Error("sync module must declare apiToPeerHandler")
+		if (!peerToApiHandler) throw new Error("sync module must declare peerToApiHandler")
+		if (!api) throw new Error("sync module must declare api url")
 
-		const getEndpoint = (cursor?: object) => {
-			return typeof api.endpoint === "string" ? api.endpoint : api.endpoint(cursor)
-		}
-
-		// loop:
-		console.log(chalk.green("[canvas-cli] syncModule polling:", getEndpoint()))
-		const apply = async (hash: string, action: Action, session: Session) => {
-			await core.apply(session).catch((err) => {
-				if (err instanceof SessionExists) {
-					console.log("Success: Already exists")
-				} else {
-					console.log(chalk.red(err.stack))
-				}
-			})
-			await core.apply(action).catch((err) => {
-				if (err instanceof ActionExists) {
-					console.log("Success: Already exists")
-				} else {
-					console.log(chalk.red(err.stack))
-				}
-			})
-		}
-		const sync = async () => {
-			const res = fetch(getEndpoint())
-				.then((res) => {
-					if (res.ok) {
-						const data = res
-							.json()
-							.then(async (data) => {
-								const result = await api.onPoll(data, apply)
-								if (result === false || result === null || result === undefined) {
-									console.log(chalk.green("[canvas-cli] syncModule: no new actions" + ` (${data.result?.length})`))
-								} else {
-									console.log(chalk.green("[canvas-cli] syncModule: synced new actions"))
-									// TODO: continue fetching data with cursor
-								}
-							})
-							.catch((err) => {
-								console.log(chalk.red("[canvas-cli] syncModule error:", err))
-							})
-					} else {
-						console.log(chalk.red("[canvas-cli] syncModule poll got error response"))
-					}
-				})
-				.catch((err) => {
-					console.log(chalk.red("[canvas-cli] fetch failed:", getEndpoint()))
-				})
-		}
-		sync()
-		syncModuleTimer = setInterval(sync, api.frequency)
+    apiSyncTimer = setupSyncModule(core, { api, apiToPeerHandler, peerToApiHandler })
 	}
 
 	const origin = `http://localhost:${args.port}`
@@ -379,7 +321,7 @@ export async function handler(args: Args) {
 				`\n${chalk.yellow("Received SIGINT, attempting to exit gracefully. ^C again to force quit.")}\n`
 			)
 
-			clearInterval(syncModuleTimer)
+			if (apiSyncTimer) clearInterval(apiSyncTimer.timer)
 
 			console.log("[canvas-cli] Stopping API server...")
 			await new Promise<void>((resolve, reject) => server.stop((err) => (err ? reject(err) : resolve())))

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -262,7 +262,7 @@ export async function handler(args: Args) {
 		app.use(getAPI(core, { exposeMetrics: args.metrics, exposeP2P: args.p2p }))
 	}
 
-  let apiSyncTimer: { timer?: ReturnType<typeof setTimeout> }
+	let apiSyncTimer: { timer?: ReturnType<typeof setTimeout> }
 	if (args.syncModule) {
 		const { api, apiToPeerHandler, peerToApiHandler } = await import(args.syncModule)
 
@@ -270,7 +270,7 @@ export async function handler(args: Args) {
 		if (!peerToApiHandler) throw new Error("sync module must declare peerToApiHandler")
 		if (!api) throw new Error("sync module must declare api url")
 
-    apiSyncTimer = setupSyncModule(core, { api, apiToPeerHandler, peerToApiHandler })
+		apiSyncTimer = setupSyncModule(core, { api, apiToPeerHandler, peerToApiHandler })
 	}
 
 	const origin = `http://localhost:${args.port}`
@@ -321,7 +321,7 @@ export async function handler(args: Args) {
 				`\n${chalk.yellow("Received SIGINT, attempting to exit gracefully. ^C again to force quit.")}\n`
 			)
 
-			if (apiSyncTimer) clearInterval(apiSyncTimer.timer)
+			if (apiSyncTimer) clearTimeout(apiSyncTimer.timer)
 
 			console.log("[canvas-cli] Stopping API server...")
 			await new Promise<void>((resolve, reject) => server.stop((err) => (err ? reject(err) : resolve())))

--- a/packages/cli/src/syncModule.ts
+++ b/packages/cli/src/syncModule.ts
@@ -21,6 +21,11 @@ export type SyncModuleExports = {
 
 let wrapper: { timer?: ReturnType<typeof setTimeout> } = {}
 
+const getTimestamp = () => {
+	const d = new Date()
+	return `${d.getHours()}:${d.getMinutes().toString().padStart(2, "0")}:${d.getSeconds().toString().padStart(2, "0")}`
+}
+
 export const setupSyncModule = (core: Core, { api, apiToPeerHandler, peerToApiHandler }: SyncModuleExports) => {
 	const API_SYNC_DELAY = 5000
 
@@ -53,10 +58,12 @@ export const setupSyncModule = (core: Core, { api, apiToPeerHandler, peerToApiHa
 					.then(async (data) => {
 						const result = await apiToPeerHandler(data, apply)
 						if (!result?.next) {
-							console.log(chalk.green("[canvas-cli] api-sync success: no new actions"))
+							console.log(chalk.green(`[canvas-cli] [${getTimestamp()}] api-sync success: no new actions`))
 							wrapper.timer = setTimeout(sync, API_SYNC_DELAY)
 						} else {
-							console.log(chalk.green(`[canvas-cli] api-sync success: ${result.applied} new actions`))
+							console.log(
+								chalk.green(`[canvas-cli] [${getTimestamp()}] api-sync success: ${result.applied} new actions`)
+							)
 							sync(result.next)
 						}
 					})
@@ -66,7 +73,7 @@ export const setupSyncModule = (core: Core, { api, apiToPeerHandler, peerToApiHa
 					})
 			})
 			.catch((err) => {
-				console.log(chalk.red("[canvas-cli] api-sync fetch failed:", api))
+				console.log(chalk.red("[canvas-cli] api-sync fetch failed:", api, err))
 				wrapper.timer = setTimeout(sync, API_SYNC_DELAY)
 			})
 

--- a/packages/cli/src/syncModule.ts
+++ b/packages/cli/src/syncModule.ts
@@ -1,0 +1,74 @@
+import chalk from "chalk"
+import type { Core } from "@canvas-js/core"
+import { SessionExists, ActionExists } from "@canvas-js/core/utils"
+import type { Action, Session } from "@canvas-js/interfaces"
+
+// Types for returned JSON from the API
+type AnyJson =  boolean | number | string | null | JsonArray | JsonMap;
+interface JsonMap {  [key: string]: AnyJson; }
+interface JsonArray extends Array<AnyJson> {}
+
+// Types for defining sync module structure
+export type SyncModuleCursor = { next?: "string" }
+export type SyncModuleApply = (hash: string, action: Action, session: Session) => void
+export type SyncModuleExports = {
+  api: string,
+  apiToPeerHandler: (response: AnyJson, apply: SyncModuleApply) => Promise<SyncModuleCursor>
+  peerToApiHandler: (action: Action, session: Session) => Promise<void>
+}
+
+let wrapper: { timer?: ReturnType<typeof setTimeout> } = {}
+
+export const setupSyncModule = (core: Core, { api, apiToPeerHandler, peerToApiHandler }: SyncModuleExports) => {
+  const API_SYNC_DELAY = 5000
+
+	const apply = async (hash: string, action: Action, session: Session) => {
+		await core.apply(session).catch((err: any) => {
+			if (err instanceof SessionExists) {
+				console.log("Success: Already exists")
+			} else {
+				console.log(chalk.red(err.stack))
+			}
+		})
+		await core.apply(action).catch((err: any) => {
+			if (err instanceof ActionExists) {
+				console.log("Success: Already exists")
+			} else {
+				console.log(chalk.red(err.stack))
+			}
+		})
+	}
+
+	const sync = () => fetch(api)
+		.then((res) => {
+			if (!res.ok) {
+				console.log(chalk.red("[canvas-cli] api-sync poll got error response"))
+        return
+      }
+			res
+				.json()
+				.then(async (data) => {
+					const result = await apiToPeerHandler(data, apply)
+					if (!result?.next) {
+						console.log(chalk.green("[canvas-cli] api-sync: no new actions" + ` (${data.result?.length})`))
+					} else {
+						console.log(chalk.green("[canvas-cli] api-sync: synced new actions"))
+						// TODO: continue fetching data with cursor
+					}
+		      setTimeout(sync, API_SYNC_DELAY)
+				})
+				.catch((err) => {
+					console.log(chalk.red("[canvas-cli] api-sync error:", err))
+		      setTimeout(sync, API_SYNC_DELAY)
+				})
+		})
+		.catch((err) => {
+      console.log(chalk.red("[canvas-cli] fetch failed:", api))
+		  setTimeout(sync, API_SYNC_DELAY)
+    })
+
+	console.log(chalk.green("[canvas-cli] api-sync polling:", api))
+	sync()
+
+  return wrapper
+}

--- a/packages/cli/src/syncModule.ts
+++ b/packages/cli/src/syncModule.ts
@@ -4,23 +4,25 @@ import { SessionExists, ActionExists } from "@canvas-js/core/utils"
 import type { Action, Session } from "@canvas-js/interfaces"
 
 // Types for returned JSON from the API
-type AnyJson =  boolean | number | string | null | JsonArray | JsonMap;
-interface JsonMap {  [key: string]: AnyJson; }
+type AnyJson = boolean | number | string | null | JsonArray | JsonMap
+interface JsonMap {
+	[key: string]: AnyJson
+}
 interface JsonArray extends Array<AnyJson> {}
 
 // Types for defining sync module structure
-export type SyncModuleCursor = { next?: "string", applied?: number }
+export type SyncModuleCursor = { next?: "string"; applied?: number }
 export type SyncModuleApply = (hash: string, action: Action, session: Session) => void
 export type SyncModuleExports = {
-  api: string,
-  apiToPeerHandler: (response: AnyJson, apply: SyncModuleApply) => Promise<SyncModuleCursor>
-  peerToApiHandler: ({ action, session }: { action: Action, session: Session }) => Promise<void>
+	api: string
+	apiToPeerHandler: (response: AnyJson, apply: SyncModuleApply) => Promise<SyncModuleCursor>
+	peerToApiHandler: ({ action, session }: { action: Action; session: Session }) => Promise<void>
 }
 
 let wrapper: { timer?: ReturnType<typeof setTimeout> } = {}
 
 export const setupSyncModule = (core: Core, { api, apiToPeerHandler, peerToApiHandler }: SyncModuleExports) => {
-  const API_SYNC_DELAY = 5000
+	const API_SYNC_DELAY = 5000
 
 	const apply = async (hash: string, action: Action, session: Session) => {
 		await core.apply(session).catch((err: any) => {
@@ -39,36 +41,37 @@ export const setupSyncModule = (core: Core, { api, apiToPeerHandler, peerToApiHa
 		})
 	}
 
-	const sync = (apiUrl = api) => fetch(apiUrl)
-		.then((res) => {
-			if (!res.ok) {
-				console.log(chalk.red("[canvas-cli] api-sync poll got error response"))
-        return
-      }
-			res
-				.json()
-				.then(async (data) => {
-					const result = await apiToPeerHandler(data, apply)
-					if (!result?.next) {
-						console.log(chalk.green("[canvas-cli] api-sync success: no new actions"))
-		        setTimeout(sync, API_SYNC_DELAY)
-					} else {
-						console.log(chalk.green(`[canvas-cli] api-sync success: ${result.applied} new actions`))
-            sync(result.next)
-					}
-				})
-				.catch((err) => {
-					console.log(chalk.red("[canvas-cli] api-sync error:", err))
-		      setTimeout(sync, API_SYNC_DELAY)
-				})
-		})
-		.catch((err) => {
-      console.log(chalk.red("[canvas-cli] api-sync fetch failed:", api))
-		  setTimeout(sync, API_SYNC_DELAY)
-    })
+	const sync = (apiUrl = api) =>
+		fetch(apiUrl)
+			.then((res) => {
+				if (!res.ok) {
+					console.log(chalk.red("[canvas-cli] api-sync poll got error response"))
+					return
+				}
+				res
+					.json()
+					.then(async (data) => {
+						const result = await apiToPeerHandler(data, apply)
+						if (!result?.next) {
+							console.log(chalk.green("[canvas-cli] api-sync success: no new actions"))
+							wrapper.timer = setTimeout(sync, API_SYNC_DELAY)
+						} else {
+							console.log(chalk.green(`[canvas-cli] api-sync success: ${result.applied} new actions`))
+							sync(result.next)
+						}
+					})
+					.catch((err) => {
+						console.log(chalk.red("[canvas-cli] api-sync error:", err))
+						wrapper.timer = setTimeout(sync, API_SYNC_DELAY)
+					})
+			})
+			.catch((err) => {
+				console.log(chalk.red("[canvas-cli] api-sync fetch failed:", api))
+				wrapper.timer = setTimeout(sync, API_SYNC_DELAY)
+			})
 
 	console.log(chalk.green("[canvas-cli] api-sync starting:", api))
 	sync()
 
-  return wrapper
+	return wrapper
 }

--- a/packages/core/src/components/messageStore/node/SqliteMessageStore.ts
+++ b/packages/core/src/components/messageStore/node/SqliteMessageStore.ts
@@ -10,7 +10,7 @@ import type { Message, Session } from "@canvas-js/interfaces"
 
 import { getMessageKey } from "@canvas-js/core/sync"
 import { MESSAGE_DATABASE_FILENAME, MST_DIRECTORY_NAME } from "@canvas-js/core/constants"
-import { mapEntries, toHex, assert, ActionExists, SessionExists } from "@canvas-js/core/utils"
+import { mapEntries, toHex, assert, AlreadyExists } from "@canvas-js/core/utils"
 
 import type { MessageStore, MessageStoreEvents, ReadOnlyTransaction, ReadWriteTransaction } from "../types.js"
 
@@ -227,7 +227,7 @@ export class SqliteMessageStore extends EventEmitter<MessageStoreEvents> impleme
 							txn.set(key, id)
 						} catch (error: any) {
 							if (error.code === "SQLITE_CONSTRAINT_PRIMARYKEY") {
-								throw message.type === "session" ? new SessionExists() : new ActionExists()
+								throw new AlreadyExists()
 							}
 						}
 					},

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -160,5 +160,4 @@ export function getErrorMessage(err: unknown): string {
 	}
 }
 
-export class ActionExists extends Error {}
-export class SessionExists extends Error {}
+export class AlreadyExists extends Error {}


### PR DESCRIPTION
Module now expects `{ api, apiToPeerHandler, peerToApiHandler }`.

Exports types for syncModule, improves logging, replaces ActionExists/SessionExists with one AlreadyExists exception.

Uses setTimeout to request more pages from the API (should be replaced with AbortController, because it's a little flaky now).

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

- [X] CI tests pass
- [ ] Tested with chat-next (including login, all signers, and exchanging messages)
- [ ] Tested with chat-webpack (including login, all signers, and exchanging messages)
- [ ] Tested with notes (including login, create note, share note)
- [ ] Other:

syncModule doesn't really have tests yet.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Hooks
- [ ] Daemon API
- [ ] Command line arguments
- [ ] Contract language
