### PR TITLE
Interwallet cryptography classes (WIP)

### DIFF
--- a/interwallet/src/client/views/ChatSidebar.tsx
+++ b/interwallet/src/client/views/ChatSidebar.tsx
@@ -1,14 +1,14 @@
 import React, { useContext } from "react"
 import { useLiveQuery } from "dexie-react-hooks"
 
-import { PrivateUserRegistration, Room } from "../../shared/index.js"
+import { Room } from "../../shared/index.js"
 
 import { NewChatModal } from "./NewChatModal.js"
 import { RoomName } from "./RoomName.js"
 import { ChatContext } from "./ChatContext.js"
 
 export const ChatSidebar: React.FC<{}> = ({}) => {
-	const { db, selectedRoomId, setSelectedRoomId, user } = useContext(ChatContext)
+	const { db, selectedRoomId, setSelectedRoomId } = useContext(ChatContext)
 
 	const [showNewChatModal, setShowNewChatModal] = React.useState(false)
 
@@ -33,7 +33,6 @@ export const ChatSidebar: React.FC<{}> = ({}) => {
 						isSelected={!!selectedRoomId && room.id == selectedRoomId}
 						room={room}
 						selectRoom={() => setSelectedRoomId(room.id)}
-						user={user}
 					/>
 				))}
 			</div>
@@ -55,7 +54,6 @@ const ChatSidebarRoom = ({
 }: {
 	isSelected: boolean
 	room: Room
-	user: PrivateUserRegistration
 	selectRoom: () => void
 }) => {
 	if (isSelected) {

--- a/interwallet/src/client/views/ChatSidebar.tsx
+++ b/interwallet/src/client/views/ChatSidebar.tsx
@@ -7,7 +7,7 @@ import { NewChatModal } from "./NewChatModal.js"
 import { RoomName } from "./RoomName.js"
 import { ChatContext } from "./ChatContext.js"
 
-export const ChatSidebar = () => {
+export const ChatSidebar: React.FC<{}> = ({}) => {
 	const { db, selectedRoomId, setSelectedRoomId, user } = useContext(ChatContext)
 
 	const [showNewChatModal, setShowNewChatModal] = React.useState(false)

--- a/interwallet/src/server/manager.ts
+++ b/interwallet/src/server/manager.ts
@@ -16,7 +16,6 @@ import {
 	USER_REGISTRY_TOPIC,
 	assert,
 	validateEvent,
-	validateRoomRegistration,
 	validateUserRegistration,
 } from "../shared/index.js"
 
@@ -25,6 +24,7 @@ import { applyRoomRegistration, applyUserRegistration, getRooms } from "./db.js"
 import { dataDirectory } from "./config.js"
 import { PING_DELAY, PING_INTERVAL, PING_TIMEOUT } from "./constants.js"
 import { anySignal } from "any-signal"
+import { SignedRoomRegistration } from "../shared/SignedRoomRegistration.js"
 
 export class RoomManager {
 	public static async initialize(peerId: PeerId): Promise<RoomManager> {
@@ -104,7 +104,10 @@ export class RoomManager {
 	}
 
 	private applyRoomRegistryEntry = async (key: Uint8Array, value: Uint8Array) => {
-		const room = await validateRoomRegistration(key, value)
+		const signedRoom = SignedRoomRegistration.decode(value)
+		await signedRoom.validate(key)
+
+		const room = signedRoom.getRoomDbEntry()
 
 		this.log(
 			"registering room %s with members %o",

--- a/interwallet/src/shared/EncryptedEvent.ts
+++ b/interwallet/src/shared/EncryptedEvent.ts
@@ -38,7 +38,7 @@ export class EncryptedEvent {
 		const sender = room.members.find((member) => member.address === senderAddress)
 		assert(sender !== undefined, "sender is not a member of the room")
 
-		// validate all of the key bundles
+		// TODO: validate all of the key bundles
 
 		for (const eachRecipient of this.recipients) {
 			if (eachRecipient === undefined) {

--- a/interwallet/src/shared/EncryptedEvent.ts
+++ b/interwallet/src/shared/EncryptedEvent.ts
@@ -1,0 +1,66 @@
+import { bytesToHex, getAddress } from "viem"
+
+import * as Messages from "./messages.js"
+import { Room } from "./types"
+import { assert } from "."
+
+type EncryptedPayload = {
+	publicKey: Uint8Array
+	ciphertext: Uint8Array
+	nonce: Uint8Array
+}
+
+export class EncryptedEvent {
+	readonly roomId: Uint8Array
+	readonly senderAddress: Uint8Array
+	readonly senderPublicKey: Uint8Array
+	readonly recipients: EncryptedPayload[]
+
+	constructor(
+		roomId: Uint8Array,
+		senderAddress: Uint8Array,
+		senderPublicKey: Uint8Array,
+		recipients: EncryptedPayload[]
+	) {
+		this.roomId = roomId
+		this.senderAddress = senderAddress
+		this.senderPublicKey = senderPublicKey
+		this.recipients = recipients
+	}
+
+	async validate(room: Room) {
+		const senderAddress = getAddress(bytesToHex(this.senderAddress))
+		const sender = room.members.find((member) => member.address === senderAddress)
+		assert(sender !== undefined, "sender is not a member of the room")
+
+		// validate all of the key bundles
+
+		for (const eachRecipient of this.recipients) {
+			if (eachRecipient === undefined) {
+				continue
+			}
+			const recipientPublicKey = bytesToHex(eachRecipient.publicKey)
+			const recipient = room.members.find((member) => member.keyBundle.encryptionPublicKey === recipientPublicKey)
+			assert(recipient !== undefined, "recipient is not a member of the room")
+		}
+	}
+
+	static decode(value: Uint8Array): EncryptedEvent {
+		const decodedEvent = Messages.EncryptedEvent.decode(value)
+
+		return new EncryptedEvent(
+			decodedEvent.roomId,
+			decodedEvent.senderAddress,
+			decodedEvent.senderPublicKey,
+			decodedEvent.recipients
+		)
+	}
+	static encode(event: EncryptedEvent): Uint8Array {
+		return Messages.EncryptedEvent.encode({
+			roomId: event.roomId,
+			senderAddress: event.senderAddress,
+			senderPublicKey: event.senderPublicKey,
+			recipients: event.recipients,
+		})
+	}
+}

--- a/interwallet/src/shared/PublicUserRegistration.ts
+++ b/interwallet/src/shared/PublicUserRegistration.ts
@@ -1,0 +1,69 @@
+import { bytesToHex, hexToBytes, recoverTypedDataAddress } from "viem"
+import * as Messages from "./messages.js"
+import { KeyBundle } from "./types"
+import { assert } from "./utils.js"
+import { equals } from "uint8arrays"
+
+function constructTypedKeyBundle(keyBundle: KeyBundle) {
+	const types = {
+		EIP712Domain: [{ name: "name", type: "string" }],
+		KeyBundle: [
+			{ name: "signingPublicKey", type: "bytes" },
+			{ name: "encryptionPublicKey", type: "bytes" },
+		],
+	} as const
+
+	// these return types match what's expected by `eth-sig-util`
+	return {
+		types,
+		primaryType: "KeyBundle" as const,
+		domain: { name: "InterwalletChat" } as const,
+		message: keyBundle,
+	}
+}
+
+export class PublicUserRegistration {
+	readonly address: `0x${string}`
+	readonly keyBundle: KeyBundle
+	readonly keyBundleSignature: `0x${string}`
+
+	constructor(address: `0x${string}`, keyBundle: KeyBundle, keyBundleSignature: `0x${string}`) {
+		this.address = address
+		this.keyBundle = keyBundle
+		this.keyBundleSignature = keyBundleSignature
+	}
+
+	async validate() {
+		const typedKeyBundle = constructTypedKeyBundle(this.keyBundle)
+
+		const address = await recoverTypedDataAddress({
+			...typedKeyBundle,
+			signature: this.keyBundleSignature,
+		})
+
+		assert(equals(hexToBytes(address), hexToBytes(this.address)), "invalid signature")
+	}
+
+	static decode(value: Uint8Array): PublicUserRegistration {
+		const { address, keyBundle, signature } = Messages.SignedUserRegistration.decode(value)
+		return new PublicUserRegistration(
+			bytesToHex(address),
+			{
+				encryptionPublicKey: bytesToHex(keyBundle!.encryptionPublicKey),
+				signingPublicKey: bytesToHex(keyBundle!.signingPublicKey),
+			},
+			bytesToHex(signature)
+		)
+	}
+
+	static encode({ address, keyBundle, keyBundleSignature }: PublicUserRegistration): Uint8Array {
+		return Messages.SignedUserRegistration.encode({
+			address: hexToBytes(address),
+			keyBundle: {
+				encryptionPublicKey: hexToBytes(keyBundle.encryptionPublicKey),
+				signingPublicKey: hexToBytes(keyBundle.signingPublicKey),
+			},
+			signature: hexToBytes(keyBundleSignature),
+		})
+	}
+}

--- a/interwallet/src/shared/PublicUserRegistration.ts
+++ b/interwallet/src/shared/PublicUserRegistration.ts
@@ -4,7 +4,7 @@ import { KeyBundle } from "./types"
 import { assert } from "./utils.js"
 import { equals } from "uint8arrays"
 
-function constructTypedKeyBundle(keyBundle: KeyBundle) {
+export function constructTypedKeyBundle(keyBundle: KeyBundle) {
 	const types = {
 		EIP712Domain: [{ name: "name", type: "string" }],
 		KeyBundle: [

--- a/interwallet/src/shared/RoomRegistration.ts
+++ b/interwallet/src/shared/RoomRegistration.ts
@@ -1,0 +1,72 @@
+import { bytesToHex, hexToBytes } from "viem/utils"
+import * as Messages from "./messages.js"
+import { blake3 } from "@noble/hashes/blake3"
+import { assert } from "./utils.js"
+import { PublicUserRegistration } from "./PublicUserRegistration.js"
+import { base58btc } from "multiformats/bases/base58"
+
+export const getRoomId = (key: Uint8Array) => base58btc.baseEncode(key)
+
+export class RoomRegistration {
+	readonly id: string
+	readonly creatorAddress: `0x${string}`
+	readonly members: PublicUserRegistration[]
+
+	constructor(creatorAddress: `0x${string}`, members: PublicUserRegistration[]) {
+		this.creatorAddress = creatorAddress
+		this.members = members
+
+		const hash = blake3.create({ dkLen: 16 })
+		for (const member of this.members) {
+			assert(member.address, "missing member.address")
+			hash.update(hexToBytes(member.address))
+		}
+
+		this.id = getRoomId(hash.digest())
+	}
+
+	getCreator(): PublicUserRegistration | null {
+		let creator: PublicUserRegistration | null = null
+		for (const member of this.members) {
+			if (member.address == this.creatorAddress) {
+				creator = member
+			}
+		}
+		return creator
+	}
+
+	async validate() {
+		for (const member of this.members) {
+			await member.validate()
+		}
+
+		const creator = this.getCreator()
+		assert(creator !== null, "room creator must be a member of the room")
+
+		// TODO: validate the creator's address against its key bundle
+	}
+
+	static decode(value: Uint8Array): RoomRegistration {
+		const { creator, members } = Messages.RoomRegistration.decode(value)
+		return new RoomRegistration(
+			bytesToHex(creator),
+			members.map((member) => PublicUserRegistration.decode(Messages.SignedUserRegistration.encode(member)))
+		)
+	}
+
+	static encode({ creatorAddress, members }: RoomRegistration): Uint8Array {
+		return Messages.RoomRegistration.encode({
+			creator: hexToBytes(creatorAddress),
+			members: members.map((member) => {
+				return {
+					address: hexToBytes(member.address),
+					keyBundle: {
+						encryptionPublicKey: hexToBytes(member.keyBundle.encryptionPublicKey),
+						signingPublicKey: hexToBytes(member.keyBundle.signingPublicKey),
+					},
+					signature: hexToBytes(member.keyBundleSignature),
+				}
+			}),
+		})
+	}
+}

--- a/interwallet/src/shared/SignedEncryptedEvent.ts
+++ b/interwallet/src/shared/SignedEncryptedEvent.ts
@@ -1,0 +1,42 @@
+import { assert } from "."
+import { getRoomId } from "./RoomRegistration.js"
+import * as Messages from "./messages.js"
+import { Room } from "./types"
+import nacl from "tweetnacl"
+import { EncryptedEvent } from "./EncryptedEvent"
+
+export class SignedEncryptedEvent {
+	readonly signature: Uint8Array
+	readonly encryptedEvent: EncryptedEvent
+
+	constructor(signature: Uint8Array, encryptedEvent: EncryptedEvent) {
+		this.signature = signature
+		this.encryptedEvent = encryptedEvent
+	}
+
+	async validate(key: Uint8Array, room: Room) {
+		assert(getRoomId(this.encryptedEvent.roomId) === room.id, "event is for a different room")
+
+		const signedData = Messages.EncryptedEvent.encode(this.encryptedEvent)
+
+		await this.encryptedEvent.validate(room)
+
+		assert(
+			nacl.sign.detached.verify(signedData, this.signature, this.encryptedEvent.senderPublicKey),
+			"invalid event signature"
+		)
+	}
+
+	static decode(value: Uint8Array): SignedEncryptedEvent {
+		const { signature, data: signedData } = Messages.SignedData.decode(value)
+		const encryptedEvent = EncryptedEvent.decode(signedData)
+		return new SignedEncryptedEvent(signature, encryptedEvent)
+	}
+
+	static encode(event: SignedEncryptedEvent): Uint8Array {
+		return Messages.SignedData.encode({
+			signature: event.signature,
+			data: Messages.EncryptedEvent.encode(event.encryptedEvent),
+		})
+	}
+}

--- a/interwallet/src/shared/SignedRoomRegistration.ts
+++ b/interwallet/src/shared/SignedRoomRegistration.ts
@@ -1,0 +1,63 @@
+import nacl from "tweetnacl"
+import { hexToBytes } from "viem"
+
+import * as Messages from "./messages.js"
+import { RoomRegistration, getRoomId } from "./RoomRegistration"
+import { assert } from "./utils"
+import { PrivateUserRegistration } from "./types.js"
+
+export class SignedRoomRegistration {
+	public readonly roomRegistration: RoomRegistration
+	public readonly signature: Uint8Array
+
+	constructor(roomRegistration: RoomRegistration, signature: Uint8Array) {
+		this.roomRegistration = roomRegistration
+		this.signature = signature
+	}
+
+	getRoomDbEntry() {
+		return {
+			id: this.roomRegistration.id,
+			creator: this.roomRegistration.creatorAddress,
+			members: this.roomRegistration.members,
+		}
+	}
+
+	async validate(key: Uint8Array) {
+		await this.roomRegistration.validate()
+		const creator = this.roomRegistration.getCreator()
+		assert(creator !== null, "room creator must be a member of the room")
+
+		const signedData = RoomRegistration.encode(this.roomRegistration)
+		assert(
+			nacl.sign.detached.verify(signedData, this.signature, hexToBytes(creator.keyBundle.signingPublicKey)),
+			"invalid room registration signature"
+		)
+
+		assert(getRoomId(key) == this.roomRegistration.id, "invalid room registration id")
+	}
+
+	static decode(value: Uint8Array): SignedRoomRegistration {
+		const { signature, data: signedData } = Messages.SignedData.decode(value)
+		const roomRegistration = RoomRegistration.decode(signedData)
+		return new SignedRoomRegistration(roomRegistration, signature)
+	}
+
+	static sign(roomRegistration: RoomRegistration, user: PrivateUserRegistration): SignedRoomRegistration {
+		assert(roomRegistration.creatorAddress === user.address, "room creator must be the current user")
+		assert(
+			roomRegistration.members.find(({ address }) => address === user.address),
+			"members did not include the current user"
+		)
+
+		const signature = nacl.sign.detached(RoomRegistration.encode(roomRegistration), hexToBytes(user.signingPrivateKey))
+		return new SignedRoomRegistration(roomRegistration, signature)
+	}
+
+	static encode({ signature, roomRegistration }: SignedRoomRegistration): Uint8Array {
+		return Messages.SignedData.encode({
+			signature,
+			data: RoomRegistration.encode(roomRegistration),
+		})
+	}
+}

--- a/interwallet/src/shared/cryptography.ts
+++ b/interwallet/src/shared/cryptography.ts
@@ -3,6 +3,7 @@ import nacl from "tweetnacl"
 import { WalletClient } from "viem"
 import { getAddress, bytesToHex, hexToBytes, keccak256 } from "viem/utils"
 
+import { constructTypedKeyBundle } from "./PublicUserRegistration.js"
 import { type KeyBundle, type PrivateUserRegistration } from "./types.js"
 
 const buildMagicString = (pin: string) => `[Password: ${pin}]
@@ -12,24 +13,6 @@ Generate a new messaging key?
 Signing this message will allow the application to read & write messages from your address.
 
 Only do this when setting up your messaging client or mobile application.`
-
-function constructTypedKeyBundle(keyBundle: KeyBundle) {
-	const types = {
-		EIP712Domain: [{ name: "name", type: "string" }],
-		KeyBundle: [
-			{ name: "signingPublicKey", type: "bytes" },
-			{ name: "encryptionPublicKey", type: "bytes" },
-		],
-	} as const
-
-	// these return types match what's expected by `eth-sig-util`
-	return {
-		types,
-		primaryType: "KeyBundle" as const,
-		domain: { name: "InterwalletChat" } as const,
-		message: keyBundle,
-	}
-}
 
 class DerivedSecrets {
 	readonly encryptionKeyPair: nacl.BoxKeyPair

--- a/interwallet/src/shared/types.ts
+++ b/interwallet/src/shared/types.ts
@@ -11,24 +11,21 @@ export type KeyBundle = {
 	encryptionPublicKey: `0x${string}`
 }
 
-// export type RoomRegistration = {
-// 	creator: `0x${string}`
-// 	members: PublicUserRegistration[]
-// }
-
-export type Room = {
-	id: string
-	creator: `0x${string}`
-	members: PublicUserRegistration[]
-}
-
-export interface PublicUserRegistration {
+// this corresponds to the fields exposed by the PublicRoomRegistration class,
+// but is only used for defining database schemas
+type PublicRoomRegistration = {
 	address: `0x${string}`
 	keyBundle: KeyBundle
 	keyBundleSignature: `0x${string}`
 }
 
-export interface PrivateUserRegistration extends PublicUserRegistration {
+export type Room = {
+	id: string
+	creator: `0x${string}`
+	members: PublicRoomRegistration[]
+}
+
+export interface PrivateUserRegistration extends PublicRoomRegistration {
 	encryptionPrivateKey: `0x${string}`
 	signingPrivateKey: `0x${string}`
 }

--- a/interwallet/src/shared/types.ts
+++ b/interwallet/src/shared/types.ts
@@ -15,14 +15,16 @@ export type KeyBundle = {
 	encryptionPublicKey: `0x${string}`
 }
 
-export type RoomRegistration = {
-	creator: `0x${string}`
-	members: PublicUserRegistration[]
-}
+// export type RoomRegistration = {
+// 	creator: `0x${string}`
+// 	members: PublicUserRegistration[]
+// }
 
 export type Room = {
 	id: string
-} & RoomRegistration
+	creator: `0x${string}`
+	members: PublicUserRegistration[]
+}
 
 export interface PublicUserRegistration {
 	address: `0x${string}`
@@ -48,9 +50,4 @@ export const serializePublicUserRegistration = (user: PublicUserRegistration): M
 		signingPublicKey: hexToBytes(user.keyBundle.signingPublicKey),
 		encryptionPublicKey: hexToBytes(user.keyBundle.encryptionPublicKey),
 	},
-})
-
-export const serializeRoomRegistration = ({ creator, members }: RoomRegistration): Messages.RoomRegistration => ({
-	creator: hexToBytes(creator),
-	members: members.map(serializePublicUserRegistration),
 })

--- a/interwallet/src/shared/types.ts
+++ b/interwallet/src/shared/types.ts
@@ -1,7 +1,3 @@
-import { hexToBytes } from "viem"
-
-import * as Messages from "./messages.js"
-
 export type EventMap = {
 	message: { content: string; timestamp: number; sender: string }
 }
@@ -36,18 +32,3 @@ export interface PrivateUserRegistration extends PublicUserRegistration {
 	encryptionPrivateKey: `0x${string}`
 	signingPrivateKey: `0x${string}`
 }
-
-export const getPublicUserRegistration = ({
-	encryptionPrivateKey,
-	signingPrivateKey,
-	...user
-}: PrivateUserRegistration): PublicUserRegistration => user
-
-export const serializePublicUserRegistration = (user: PublicUserRegistration): Messages.SignedUserRegistration => ({
-	address: hexToBytes(user.address),
-	signature: hexToBytes(user.keyBundleSignature),
-	keyBundle: {
-		signingPublicKey: hexToBytes(user.keyBundle.signingPublicKey),
-		encryptionPublicKey: hexToBytes(user.keyBundle.encryptionPublicKey),
-	},
-})


### PR DESCRIPTION
This PR is an attempt to simplify the external interface of the encryption, signing and serialization code.

The motivation here was that I wanted to clean up the code so that we could swap out the encryption primitives with something like libsignal or Wire's Proteus library (https://github.com/wireapp/wire-web-core/tree/main/packages/proteus). I was reading through the Proteus source code and noticed how much cleaner it was than our own and got some ideas...

Almost all of the cryptography code (with the exception of the code for deriving the key bundle) has been moved into classes, where each class has the following methods (there may be others):
- `encode` - takes the class data and converts it to Uint8array. This basically maps onto the functions exposed by protobuf. If the data has the correct type this should always succeed.
- `decode` - takes a Uint8array and converts it into the class data. If the data has the correct type this should always succeed.
- `validate` - checks the integrity/correctness of the data, e.g. signatures, invariants like "room creator must be member of the room", "events must be for the room they have been sent to". This function can take additional arguments. Every object should recursively call the `validate` function for every object contained within it. If validation fails, this will throw an exception.

I'm not sure about the names of the classes, I have mostly copied the names of the existing types (like PublicUserRegistration), I am still working on this bit...

In addition, the message encryption code has been moved to `EncryptedEvent`, which is nested inside `SignedEncryptedEvent` - I think it should be possible to create some sort of generic encryption/decryption class here.

TODO:
- [x] Make sure names of the new classes don't clash with existing types
- [ ] Figure out how this corresponds to the other work we are doing with the Store