### PR TITLE
Generic action signatures for inline contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1928,7 +1928,8 @@
     },
     "node_modules/@ipld/schema": {
       "version": "4.2.3",
-      "license": "(Apache-2.0 AND MIT)",
+      "resolved": "https://registry.npmjs.org/@ipld/schema/-/schema-4.2.3.tgz",
+      "integrity": "sha512-duCFnoZ9hQHVbD7fAfXPtSno+ujJ3dsMsM8wYHUIV/NSTxWyKlvnWxHNp4I+3K8xwdQX2qcXp6Bc0G61YMXbAA==",
       "dependencies": {
         "get-stdin": "^9.0.0",
         "yargs": "^17.7.2"
@@ -12345,14 +12346,15 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "5.0.1",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.2.tgz",
+      "integrity": "sha512-2ustYUX1R2rL/Br5B/FMhi8d5/QzvkJ912rBYxskcpu0myTHzSZfTr1LAS2Sm7jxRUObRrSBFoyzwAhL49aVSg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
@@ -17505,6 +17507,7 @@
         "@chainsafe/libp2p-gossipsub": "^10.1.0",
         "@chainsafe/libp2p-noise": "^13.0.1",
         "@ipld/dag-cbor": "^9.0.6",
+        "@ipld/schema": "^4.2.3",
         "@libp2p/bootstrap": "^9.0.8",
         "@libp2p/interface": "^0.1.3",
         "@libp2p/interface-internal": "^0.1.6",
@@ -17544,7 +17547,7 @@
         "@canvas-js/okra-node": "^0.5.6",
         "@types/node": "^20.8.5",
         "dotenv": "^16.3.1",
-        "nanoid": "^5.0.1",
+        "nanoid": "^5.0.2",
         "stream-to-it": "^0.2.4"
       },
       "engines": {

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -1,31 +1,31 @@
-import type { Argv } from "yargs"
+// import type { Argv } from "yargs"
 
-import * as json from "@ipld/dag-json"
+// import * as json from "@ipld/dag-json"
 
-import { Canvas } from "@canvas-js/core"
+// import { Canvas } from "@canvas-js/core"
 
-import { getContractLocation } from "../utils.js"
+// import { getContractLocation } from "../utils.js"
 
-export const command = "export <path>"
-export const desc = "Export the messages in a topic as dag-json to stdout"
-export const builder = (yargs: Argv) =>
-	yargs.positional("path", {
-		describe: "Path to application directory",
-		type: "string",
-		demandOption: true,
-	})
+// export const command = "export <path>"
+// export const desc = "Export the messages in a topic as dag-json to stdout"
+// export const builder = (yargs: Argv) =>
+// 	yargs.positional("path", {
+// 		describe: "Path to application directory",
+// 		type: "string",
+// 		demandOption: true,
+// 	})
 
-type Args = ReturnType<typeof builder> extends Argv<infer T> ? T : never
+// type Args = ReturnType<typeof builder> extends Argv<infer T> ? T : never
 
-export async function handler(args: Args) {
-	const { contract, location } = getContractLocation(args)
-	if (location === null) {
-		throw new Error("Expected path to application directory, found path to contract file")
-	}
+// export async function handler(args: Args) {
+// 	const { topic, contract, location } = getContractLocation(args)
+// 	if (location === null) {
+// 		throw new Error("Expected path to application directory, found path to contract file")
+// 	}
 
-	const app = await Canvas.initialize({ contract, location, offline: true })
-	for await (const [id, signature, message] of app.getMessageStream()) {
-		process.stdout.write(json.format([id, signature, message]))
-		process.stdout.write("\n")
-	}
-}
+// 	const app = await Canvas.initialize({ topic: "", contract, location, offline: true })
+// 	for await (const [id, signature, message] of app.getMessageStream()) {
+// 		process.stdout.write(json.format([id, signature, message]))
+// 		process.stdout.write("\n")
+// 	}
+// }

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -3,8 +3,8 @@ import type { CommandModule } from "yargs"
 import * as init from "./init.js"
 import * as info from "./info.js"
 import * as run from "./run.js"
-import * as exportData from "./export.js"
+// import * as exportData from "./export.js"
 // import * as importData from "./import.js"
 
 // export const commands = [init, info, run, exportData, importData] as CommandModule[]
-export const commands = [init, info, run, exportData] as unknown as CommandModule[]
+export const commands = [init, info, run] as unknown as CommandModule[]

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -1,6 +1,3 @@
-import path from "node:path"
-import fs from "node:fs"
-
 import type { Argv } from "yargs"
 
 import chalk from "chalk"
@@ -23,7 +20,7 @@ type Args = ReturnType<typeof builder> extends Argv<infer T> ? T : never
 export async function handler(args: Args) {
 	const { contract, location, uri } = getContractLocation(args)
 	try {
-		const app = await Canvas.initialize({ contract, location, offline: true })
+		const app = await Canvas.initialize({ topic: "fdjskal", contract, location, offline: true })
 		console.log(`name: ${uri}\n`)
 		console.log(chalk.green("===== models ====="))
 		console.log(`${JSON.stringify(app.db.models, null, "  ")}\n`)

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -160,6 +160,7 @@ export async function handler(args: Args) {
 	// }
 
 	const app = await Canvas.initialize({
+		topic: "jjkljkl",
 		location,
 		contract,
 		listen,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "@chainsafe/libp2p-gossipsub": "^10.1.0",
     "@chainsafe/libp2p-noise": "^13.0.1",
     "@ipld/dag-cbor": "^9.0.6",
+    "@ipld/schema": "^4.2.3",
     "@libp2p/bootstrap": "^9.0.8",
     "@libp2p/interface": "^0.1.3",
     "@libp2p/interface-internal": "^0.1.6",
@@ -79,7 +80,7 @@
     "@canvas-js/okra-node": "^0.5.6",
     "@types/node": "^20.8.5",
     "dotenv": "^16.3.1",
-    "nanoid": "^5.0.1",
+    "nanoid": "^5.0.2",
     "stream-to-it": "^0.2.4"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,2 @@
 export * from "./Canvas.js"
-export type { ActionImplementation, ActionContext, ModelAPI } from "./runtime/index.js"
+export * from "./runtime/types.js"

--- a/packages/core/src/runtime/FunctionRuntime.ts
+++ b/packages/core/src/runtime/FunctionRuntime.ts
@@ -1,5 +1,4 @@
-import type { Action, SessionSigner } from "@canvas-js/interfaces"
-import type { JSValue } from "@canvas-js/vm"
+import type { Action, CBORValue, SessionSigner } from "@canvas-js/interfaces"
 import { AbstractModelDB, ModelValue, validateModelValue } from "@canvas-js/modeldb"
 
 import target from "#target"
@@ -23,7 +22,7 @@ export class FunctionRuntime extends AbstractRuntime {
 				...AbstractRuntime.sessionsModel,
 				...AbstractRuntime.effectsModel,
 			})
-			return new FunctionRuntime(signers, contract.topic, db, contract.actions, indexHistory)
+			return new FunctionRuntime(signers, db, contract.actions, indexHistory)
 		} else {
 			const db = await target.openDB(location, "models", {
 				...contract.models,
@@ -31,15 +30,14 @@ export class FunctionRuntime extends AbstractRuntime {
 				...AbstractRuntime.versionsModel,
 			})
 
-			return new FunctionRuntime(signers, contract.topic, db, contract.actions, indexHistory)
+			return new FunctionRuntime(signers, db, contract.actions, indexHistory)
 		}
 	}
 
 	constructor(
 		public readonly signers: SessionSigner[],
-		public readonly topic: string,
 		public readonly db: AbstractModelDB,
-		public readonly actions: Record<string, ActionImplementation>,
+		public readonly actions: Record<string, ActionImplementation<CBORValue, CBORValue>>,
 		indexHistory: boolean
 	) {
 		super(indexHistory)
@@ -53,7 +51,7 @@ export class FunctionRuntime extends AbstractRuntime {
 		modelEntries: Record<string, Record<string, ModelValue | null>>,
 		id: string,
 		action: Action
-	): Promise<JSValue | void> {
+	): Promise<CBORValue | void> {
 		const { chain, address, name, args, blockhash, timestamp } = action
 		assert(this.actions[name] !== undefined, `invalid action name: ${name}`)
 
@@ -86,6 +84,7 @@ export class FunctionRuntime extends AbstractRuntime {
 			}
 		})
 
-		return await this.actions[name](api, args, { id, chain, address, blockhash, timestamp })
+		const result = await this.actions[name](api, args, { id, chain, address, blockhash, timestamp })
+		return result as CBORValue | void
 	}
 }

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -8,7 +8,7 @@ import { FunctionRuntime } from "./FunctionRuntime.js"
 export { AbstractRuntime as Runtime } from "./AbstractRuntime.js"
 export * from "./types.js"
 
-export async function initRuntime(
+export async function createRuntime(
 	location: string | null,
 	signers: SessionSigner[],
 	contract: string | InlineContract,

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -1,25 +1,25 @@
 import type { ModelsInit, ModelValue } from "@canvas-js/modeldb"
-import type { JSValue } from "@canvas-js/vm"
 
 import type { Awaitable } from "../utils.js"
 
-export type InlineContract = {
-	topic: string
+// /** This is type-level type; only used by generics, never values */
+// export type TSignature = { args: any; result: unknown }
+
+// /** This is type-level type; only used by generics, never values */
+// export type TActions = Record<string, TSignature>
+
+export type InlineContract<
+	Actions extends Record<string, ActionImplementation> = Record<string, ActionImplementation>
+> = {
 	models: ModelsInit
-	actions: Record<string, ActionImplementation>
+	actions: Actions
 }
 
-export type ActionImplementation = (
+export type ActionImplementation<Args = any, Result = any> = (
 	db: Record<string, ModelAPI>,
-	args: JSValue,
+	args: Args,
 	context: ActionContext
-) => Awaitable<void | JSValue>
-
-export type GenericActionImplementation = (
-	db: Record<string, ModelAPI>,
-	args: any,
-	context: ActionContext
-) => Awaitable<void | JSValue>
+) => Awaitable<Result>
 
 export type ModelAPI = {
 	get: (key: string) => Promise<ModelValue | null>

--- a/packages/core/src/targets/browser/index.ts
+++ b/packages/core/src/targets/browser/index.ts
@@ -39,5 +39,5 @@ export default {
 	openGossipLog: <Payload, Result>(location: string | null, init: GossipLogInit<Payload, Result>) =>
 		GossipLog.open(`${location}/topics/${init.topic}`, init),
 
-	createLibp2p: (config, peerId) => createLibp2p(getLibp2pOptions(config, peerId)),
+	createLibp2p: (peerId, options) => createLibp2p(getLibp2pOptions(peerId, options)),
 } satisfies PlatformTarget

--- a/packages/core/src/targets/browser/libp2p.ts
+++ b/packages/core/src/targets/browser/libp2p.ts
@@ -24,14 +24,24 @@ import {
 	MIN_CONNECTIONS,
 	PING_TIMEOUT,
 } from "../../constants.js"
-import { CanvasConfig } from "../../Canvas.js"
 
 import type { ServiceMap } from "../interface.js"
 
-export function getLibp2pOptions(config: CanvasConfig, peerId: PeerId): Libp2pOptions<ServiceMap> {
-	const announce = config.announce ?? []
-	const listen = config.listen ?? ["/webrtc"]
-	const bootstrapList = config.bootstrapList ?? []
+export function getLibp2pOptions(
+	peerId: PeerId,
+	options: {
+		offline?: boolean
+		start?: boolean
+		listen?: string[]
+		announce?: string[]
+		bootstrapList?: string[]
+		minConnections?: number
+		maxConnections?: number
+	}
+): Libp2pOptions<ServiceMap> {
+	const announce = options.announce ?? []
+	const listen = options.listen ?? ["/webrtc"]
+	const bootstrapList = options.bootstrapList ?? []
 
 	for (const address of announce) {
 		console.log(chalk.gray(`[canvas-core] Announcing on ${address}`))
@@ -60,8 +70,8 @@ export function getLibp2pOptions(config: CanvasConfig, peerId: PeerId): Libp2pOp
 
 		connectionGater: { denyDialMultiaddr },
 		connectionManager: {
-			minConnections: config.minConnections ?? MIN_CONNECTIONS,
-			maxConnections: config.maxConnections ?? MAX_CONNECTIONS,
+			minConnections: options.minConnections ?? MIN_CONNECTIONS,
+			maxConnections: options.maxConnections ?? MAX_CONNECTIONS,
 			autoDialConcurrency: DIAL_CONCURRENCY,
 			maxParallelDialsPerPeer: DIAL_CONCURRENCY_PER_PEER,
 		},

--- a/packages/core/src/targets/interface.ts
+++ b/packages/core/src/targets/interface.ts
@@ -9,12 +9,21 @@ import type { DiscoveryService } from "@canvas-js/discovery"
 import type { AbstractModelDB, ModelsInit } from "@canvas-js/modeldb"
 import type { AbstractGossipLog, GossipLogInit } from "@canvas-js/gossiplog"
 
-import type { CanvasConfig } from "../Canvas.js"
-
 export interface PlatformTarget {
 	getPeerId: (location: string | null) => Promise<PeerId>
 
-	createLibp2p: (config: CanvasConfig, peerId: PeerId) => Promise<Libp2p<ServiceMap>>
+	createLibp2p: (
+		peerId: PeerId,
+		options: {
+			offline?: boolean
+			start?: boolean
+			listen?: string[]
+			announce?: string[]
+			bootstrapList?: string[]
+			minConnections?: number
+			maxConnections?: number
+		}
+	) => Promise<Libp2p<ServiceMap>>
 
 	openDB: (
 		location: string | null,

--- a/packages/core/src/targets/node/index.ts
+++ b/packages/core/src/targets/node/index.ts
@@ -58,5 +58,5 @@ export default {
 		}
 	},
 
-	createLibp2p: (config, peerId) => createLibp2p(getLibp2pOptions(config, peerId)),
+	createLibp2p: (peerId, options) => createLibp2p(getLibp2pOptions(peerId, options)),
 } satisfies PlatformTarget

--- a/packages/core/src/targets/node/libp2p.ts
+++ b/packages/core/src/targets/node/libp2p.ts
@@ -28,14 +28,24 @@ import {
 	MIN_CONNECTIONS,
 	PING_TIMEOUT,
 } from "../../constants.js"
-import type { CanvasConfig } from "../../Canvas.js"
 
 import type { ServiceMap } from "../interface.js"
 
-export function getLibp2pOptions(config: CanvasConfig, peerId: PeerId): Libp2pOptions<ServiceMap> {
-	const announce = config.announce ?? []
-	const listen = config.listen ?? []
-	const bootstrapList = config.bootstrapList ?? []
+export function getLibp2pOptions(
+	peerId: PeerId,
+	options: {
+		offline?: boolean
+		start?: boolean
+		listen?: string[]
+		announce?: string[]
+		bootstrapList?: string[]
+		minConnections?: number
+		maxConnections?: number
+	}
+): Libp2pOptions<ServiceMap> {
+	const announce = options.announce ?? []
+	const listen = options.listen ?? []
+	const bootstrapList = options.bootstrapList ?? []
 
 	for (const address of announce) {
 		console.log(chalk.gray(`[canvas-core] Announcing on ${address}`))
@@ -72,8 +82,8 @@ export function getLibp2pOptions(config: CanvasConfig, peerId: PeerId): Libp2pOp
 
 		connectionGater: { denyDialMultiaddr },
 		connectionManager: {
-			minConnections: config.minConnections ?? MIN_CONNECTIONS,
-			maxConnections: config.maxConnections ?? MAX_CONNECTIONS,
+			minConnections: options.minConnections ?? MIN_CONNECTIONS,
+			maxConnections: options.maxConnections ?? MAX_CONNECTIONS,
 			autoDialConcurrency: DIAL_CONCURRENCY,
 			maxParallelDialsPerPeer: DIAL_CONCURRENCY_PER_PEER,
 		},

--- a/packages/interfaces/src/action.ts
+++ b/packages/interfaces/src/action.ts
@@ -1,8 +1,6 @@
 import type { JSONValue } from "./values.js"
 
-type CBORValue = JSONValue<null | boolean | number | string | Uint8Array>
-
-export type ActionArguments = CBORValue
+export type CBORValue = JSONValue<null | boolean | number | string | Uint8Array>
 
 export type Action = {
 	type: "action"
@@ -13,7 +11,7 @@ export type Action = {
 	address: string
 
 	name: string
-	args: ActionArguments
+	args: CBORValue
 
 	blockhash: string | null
 	timestamp: number

--- a/packages/interfaces/src/session.ts
+++ b/packages/interfaces/src/session.ts
@@ -7,13 +7,16 @@ export type SessionData = IPLDValue
 export type Session<Data = SessionData> = {
 	type: "session"
 
-	/** CAIP-2 prefix, e.g. "eip155:1" */
+	/** CAIP-2 prefix, e.g. "eip155:1" for mainnet Ethereum */
 	chain: string
 	/** CAIP-2 address (without the prefix, e.g. "0xb94d27...") */
 	address: string
 
+	/** ephemeral session key used to sign subsequent actions */
 	publicKeyType: SignatureType
 	publicKey: Uint8Array
+
+	/** chain-specific session payload, e.g. a SIWE message & signature */
 	data: Data
 
 	blockhash: string | null

--- a/packages/interfaces/src/signer.ts
+++ b/packages/interfaces/src/signer.ts
@@ -10,13 +10,15 @@ type Awaitable<T> = T | Promise<T>
 
 export interface SessionSigner {
 	match: (chain: string) => boolean
+
 	sign: (message: Message<Action | Session>) => Awaitable<Signature>
-
-	/** Verify that `session.data` authorizes `session.publicKey` to take actions on behalf of the user */
-	verifySession: (session: Session) => Awaitable<void>
-
 	getSession: (topic: string, options?: { chain?: string; timestamp?: number }) => Awaitable<Session>
-	clear: () => Awaitable<void>
+
+	/**
+	 * Verify that `session.data` authorizes `session.publicKey`
+	 * to take actions on behalf of the user `${sesion.chain}:${session.address}`
+	 */
+	verifySession: (session: Session) => Awaitable<void>
 }
 
 export interface SessionStore {

--- a/packages/interfaces/test/signers.test.ts
+++ b/packages/interfaces/test/signers.test.ts
@@ -1,6 +1,6 @@
 import test from "ava"
 
-import { Action, ActionArguments, Message, Session, SessionSigner as Signer } from "@canvas-js/interfaces"
+import { Message, Session, SessionSigner as Signer } from "@canvas-js/interfaces"
 import { verifySignature } from "@canvas-js/signed-cid"
 
 import { SIWESigner } from "@canvas-js/chain-ethereum"

--- a/packages/mudevm-sync/src/index.ts
+++ b/packages/mudevm-sync/src/index.ts
@@ -6,7 +6,7 @@ import { ethers } from "ethers"
 import { Canvas, ActionImplementation } from "@canvas-js/core"
 import { SIWESigner } from "@canvas-js/chain-ethereum"
 import { typeOf, JSObject, JSValue } from "@canvas-js/vm"
-import { ModelsInit, PropertyType } from "@canvas-js/modeldb"
+import { ModelsInit } from "@canvas-js/modeldb"
 
 import type { MUDCoreUserConfig } from "@latticexyz/config"
 import type { ExpandMUDUserConfig } from "@latticexyz/store/ts/register/typeExtensions"
@@ -145,8 +145,8 @@ export function useCanvas<
 			// create application
 			const topic = `world.contract-${props.world.worldContract.address.toLowerCase()}`
 			const app = await Canvas.initialize({
+				topic,
 				contract: {
-					topic,
 					models: modelsInit,
 					actions: actionsSpec,
 				},

--- a/packages/templates/src/index.ts
+++ b/packages/templates/src/index.ts
@@ -1,6 +1,6 @@
-import type { TemplateInlineContract } from "@canvas-js/core"
+import type { InlineContract } from "@canvas-js/core"
 
-export const PublicChat: TemplateInlineContract = {
+export const PublicChat = {
 	models: {
 		messages: {
 			id: "primary",
@@ -11,14 +11,14 @@ export const PublicChat: TemplateInlineContract = {
 		},
 	},
 	actions: {
-		sendMessage: (db, { message }, { address, timestamp, id }) => {
+		sendMessage: (db, { message }: { message: string }, { address, timestamp, id }) => {
 			if (!message || !message.trim()) throw new Error()
 			db.messages.set({ id, message, address, timestamp })
 		},
 	},
-}
+} satisfies InlineContract
 
-export const ChannelChat: TemplateInlineContract = {
+export const ChannelChat = {
 	models: {
 		channels: {
 			name: "primary",
@@ -58,4 +58,4 @@ export const ChannelChat: TemplateInlineContract = {
 			db.messages.set({ id, message, address, channel, timestamp })
 		},
 	},
-}
+} satisfies InlineContract


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds some light generic types to the `Canvas` class so that `app.actions` infers signatures from inline contracts.

## How has this been tested?

- [x] CI tests pass
- [x] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Contract language
- [x] Core interface
- [ ] CLI arguments
- [ ] Data storage formats
