### PR TITLE
add boolean model db type, including to tests

### DIFF
--- a/packages/core/src/runtime/ContractRuntime.ts
+++ b/packages/core/src/runtime/ContractRuntime.ts
@@ -193,6 +193,9 @@ export class ContractRuntime extends AbstractRuntime {
 				return this.vm.context.getString(handle)
 			} else if (property.type === "bytes") {
 				return this.vm.getUint8Array(handle)
+			} else if (property.type === "boolean") {
+				const value = this.vm.context.getNumber(handle)
+				return value === 1
 			} else {
 				signalInvalidType(property.type)
 			}

--- a/packages/modeldb/src/config.ts
+++ b/packages/modeldb/src/config.ts
@@ -46,7 +46,7 @@ export function parseConfig(init: ModelsInit): Config {
 	return { relations, models }
 }
 
-export const primitivePropertyPattern = /^(integer|float|string|bytes)(\??)$/
+export const primitivePropertyPattern = /^(integer|float|string|bytes|boolean)(\??)$/
 export const referencePropertyPattern = /^@([a-z0-9.-]+)(\??)$/
 export const relationPropertyPattern = /^@([a-z0-9.-]+)\[\]$/
 

--- a/packages/modeldb/src/query.ts
+++ b/packages/modeldb/src/query.ts
@@ -128,11 +128,37 @@ const byteOrder: Order = {
 	},
 }
 
+const booleanOrder: Order = {
+	equals: (a, b) => {
+		if (a === null && b === null) {
+			return true
+		} else if (typeof a === "boolean" && typeof b === "boolean") {
+			return a === b
+		} else {
+			return false
+		}
+	},
+	lessThan: (a, b) => {
+		if (a === null && b === null) {
+			return false
+		} else if (a === null) {
+			return true
+		} else if (b === null) {
+			return false
+		} else if (typeof a === "boolean" && typeof b === "boolean") {
+			return a === false && b === true
+		} else {
+			return false
+		}
+	},
+}
+
 export const primitiveTypeOrders: Record<PrimitiveType, Order> = {
 	integer: numberOrder,
 	float: numberOrder,
 	string: stringOrder,
 	bytes: byteOrder,
+	boolean: booleanOrder,
 }
 
 export const referenceOrder = stringOrder

--- a/packages/modeldb/src/sqlite/api.ts
+++ b/packages/modeldb/src/sqlite/api.ts
@@ -33,6 +33,7 @@ const primitiveColumnTypes = {
 	float: "FLOAT",
 	string: "TEXT",
 	bytes: "BLOB",
+	boolean: "INTEGER",
 } satisfies Record<PrimitiveType, string>
 
 function getPropertyColumnType(property: Property): string {
@@ -316,8 +317,8 @@ export class ModelAPI {
 
 	private getWhereExpression(
 		where: WhereCondition = {},
-	): [where: string | null, params: Record<string, null | number | string | Buffer>] {
-		const params: Record<string, null | number | string | Buffer> = {}
+	): [where: string | null, params: Record<string, null | number | string | Buffer | boolean>] {
+		const params: Record<string, null | number | string | Buffer | boolean> = {}
 		const filters = Object.entries(where).flatMap(([name, expression], i) => {
 			const property = this.#properties[name]
 			assert(property !== undefined, "property not found")

--- a/packages/modeldb/src/types.ts
+++ b/packages/modeldb/src/types.ts
@@ -1,7 +1,7 @@
 // These are "init types" for the `models` value used to initialize the database.
 
 export type PrimaryKeyType = "primary"
-export type PrimitiveType = "integer" | "float" | "string" | "bytes"
+export type PrimitiveType = "integer" | "float" | "string" | "bytes" | "boolean"
 export type OptionalPrimitiveType = `${PrimitiveType}?`
 export type ReferenceType = `@${string}`
 export type OptionalReferenceType = `@${string}?`
@@ -48,7 +48,7 @@ export type Config = {
 // These are types for the runtime model record values
 
 export type PrimaryKeyValue = string
-export type PrimitiveValue = number | string | Uint8Array | null
+export type PrimitiveValue = number | string | Uint8Array | null | boolean
 export type ReferenceValue = string | null
 export type RelationValue = string[]
 

--- a/packages/modeldb/src/utils.ts
+++ b/packages/modeldb/src/utils.ts
@@ -71,6 +71,10 @@ export function validatePropertyValue(modelName: string, property: Property, val
 			} else {
 				throw new TypeError(`${modelName}/${property.name} must be a Uint8Array`)
 			}
+		} else if (property.type === "boolean") {
+			if (typeof value !== "boolean") {
+				throw new TypeError(`${modelName}/${property.name} must be a boolean`)
+			}
 		} else {
 			signalInvalidType(property.type)
 		}

--- a/packages/modeldb/test/create.test.ts
+++ b/packages/modeldb/test/create.test.ts
@@ -11,6 +11,7 @@ testOnModelDB("create modeldb with a model with valid fields", async (t, openDB)
 		room: {
 			id: "primary",
 			name: "string",
+			isModerator: "boolean",
 			creator: "@user",
 			members: "@user[]",
 		},

--- a/packages/modeldb/test/operations.test.ts
+++ b/packages/modeldb/test/operations.test.ts
@@ -4,14 +4,14 @@ import { testOnModelDB } from "./utils.js"
 
 testOnModelDB("update a value", async (t, openDB) => {
 	const db = await openDB({
-		user: { id: "primary", name: "string" },
+		user: { id: "primary", name: "string", isModerator: "boolean" },
 	})
 
 	const id = nanoid()
 
-	await db.set("user", { id, name: "John" })
-	await db.set("user", { id, name: "John Doe" })
-	t.deepEqual(await db.get("user", id), { id, name: "John Doe" })
+	await db.set("user", { id, name: "John", isModerator: false })
+	await db.set("user", { id, name: "John Doe", isModerator: true })
+	t.deepEqual(await db.get("user", id), { id, isModerator: true, name: "John Doe" })
 })
 
 testOnModelDB("delete a value ", async (t, openDB) => {

--- a/packages/modeldb/test/query.test.ts
+++ b/packages/modeldb/test/query.test.ts
@@ -4,23 +4,23 @@ import { testOnModelDB } from "./utils.js"
 
 testOnModelDB("query (select)", async (t, openDB) => {
 	const db = await openDB({
-		user: { id: "primary", name: "string?" },
+		user: { id: "primary", isModerator: "boolean", name: "string?" },
 	})
 
 	const [a, b] = ["a", "b"]
-	await db.set("user", { id: a, name: "John Doe" })
-	await db.set("user", { id: b, name: null })
+	await db.set("user", { id: a, isModerator: true, name: "John Doe" })
+	await db.set("user", { id: b, isModerator: false, name: null })
 
 	t.deepEqual(await db.query("user", {}), [
-		{ id: a, name: "John Doe" },
-		{ id: b, name: null },
+		{ id: a, isModerator: true, name: "John Doe" },
+		{ id: b, isModerator: false, name: null },
 	])
 
 	t.deepEqual(await db.query("user", { select: { id: true } }), [{ id: a }, { id: b }])
 	t.deepEqual(await db.query("user", { select: { id: true, name: false } }), [{ id: a }, { id: b }])
-	t.deepEqual(await db.query("user", { select: { id: true, name: true } }), [
-		{ id: a, name: "John Doe" },
-		{ id: b, name: null },
+	t.deepEqual(await db.query("user", { select: { id: true, isModerator: true, name: true } }), [
+		{ id: a, isModerator: true, name: "John Doe" },
+		{ id: b, isModerator: false, name: null },
 	])
 	t.deepEqual(await db.query("user", { select: { id: true, name: true } }), [
 		{ id: a, name: "John Doe" },


### PR DESCRIPTION
## Description

Implements https://github.com/canvasxyz/canvas/issues/197

This implementation encodes TRUE = 1 and FALSE = 0 in Sqlite. It looks like we can just store booleans in indexeddb... 

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Contract language
- [ ] Core interface
- [ ] CLI arguments
- [ ] Data storage formats
