### PR TITLE
Handle optional/null fields in ContractRuntime

### DIFF
--- a/packages/core/test/canvas.test.ts
+++ b/packages/core/test/canvas.test.ts
@@ -16,14 +16,15 @@ export const models = {
     id: "primary",
     content: "string",
     timestamp: "integer",
-    isVisible: "boolean"
+    isVisible: "boolean",
+		something: "string?"
   },
 };
 
 export const actions = {
-  async createPost(db, { content, isVisible }, { id, address, timestamp }) {
+  async createPost(db, { content, isVisible, something }, { id, address, timestamp }) {
     const postId = [address, id].join("/")
-    await db.posts.set({ id: postId, content, isVisible, timestamp });
+    await db.posts.set({ id: postId, content, isVisible, timestamp, something });
     return postId
   },
 
@@ -55,7 +56,11 @@ test("open and close an app", async (t) => {
 test("apply an action and read a record from the database", async (t) => {
 	const app = await init(t)
 
-	const { id, result: postId } = await app.actions.createPost({ content: "hello world" })
+	const { id, result: postId } = await app.actions.createPost({
+		content: "hello world",
+		isVisible: true,
+		something: null,
+	})
 
 	t.log(`applied action ${id} and got result`, postId)
 	assert(typeof postId === "string")
@@ -66,7 +71,7 @@ test("apply an action and read a record from the database", async (t) => {
 test("create and delete a post", async (t) => {
 	const app = await init(t)
 
-	const { result: postId } = await app.actions.createPost({ content: "hello world" })
+	const { result: postId } = await app.actions.createPost({ content: "hello world", isVisible: true, something: "foo" })
 	assert(typeof postId === "string")
 	const value = await app.db.get("posts", postId)
 	t.is(value?.content, "hello world")
@@ -78,7 +83,7 @@ test("create and delete a post", async (t) => {
 test("insert a message created by another app", async (t) => {
 	const [a, b] = await Promise.all([init(t), init(t)])
 
-	const { id } = await a.actions.createPost({ content: "hello world" })
+	const { id } = await a.actions.createPost({ content: "hello world", isVisible: true, something: "bar" })
 	const [signature, message] = await a.messageLog.get(id)
 	assert(signature !== null && message !== null)
 


### PR DESCRIPTION
## Description

It turns out that in the implementation for `set` in `ContractRuntime` we were not handling optional model fields correctly - if a contract tried to set an optional field to null, the value would be treated as invalid.

This PR fixes this by changing the `set` implementation so that it uses `unwrapValue` (which permissively tries to unwrap whatever it can), then calls `validateModelValue` which does correctly validate the model value. This means that the implementation of `set` in `ContractRuntime` and `FunctionRuntime` is almost entirely the same (minus the unwrapping part). 

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Contract language
- [ ] Core interface
- [ ] CLI arguments
- [ ] Data storage formats
