### PR TITLE
workaround for substrate ecdsa signing bug

### DIFF
--- a/packages/chain-substrate/src/SubstrateSigner.ts
+++ b/packages/chain-substrate/src/SubstrateSigner.ts
@@ -1,6 +1,6 @@
 import * as json from "@ipld/dag-json"
 import { logger } from "@libp2p/logger"
-import { bytesToHex, hexToBytes } from "@noble/hashes/utils"
+import { bytesToHex, hexToBytes, randomBytes } from "@noble/hashes/utils"
 import { Keyring } from "@polkadot/keyring"
 import type { Signature, SessionSigner, Action, Message, Session } from "@canvas-js/interfaces"
 import { InjectedExtension } from "@polkadot/extension-inject/types"
@@ -26,7 +26,10 @@ type AbstractSigner = {
 	getSubstrateKeyType: () => Promise<KeypairType>
 	getAddress: () => Promise<string>
 	getChainId: () => Promise<string>
-	signMessage(message: Uint8Array): Promise<Uint8Array>
+	signMessage(message: Uint8Array): Promise<{
+		signature: Uint8Array
+		nonce: Uint8Array
+	}>
 }
 
 export class SubstrateSigner implements SessionSigner {
@@ -64,10 +67,17 @@ export class SubstrateSigner implements SessionSigner {
 				signMessage: async (message: Uint8Array) => {
 					const account = await extension.accounts.get()
 					const address = account[0].address
-					const signerResult = await signRaw({ address, data: bytesToHex(message), type: "bytes" })
+
+					const nonce = randomBytes(16)
+					const data = bytesToHex(nonce) + bytesToHex(message)
+
+					const signerResult = await signRaw({ address, data, type: "bytes" })
 					const signature = signerResult.signature
 					// signerResult.signature is encoded as 0x{hex}, just get the hex part
-					return hexToBytes(signature.slice(2))
+					return {
+						signature: hexToBytes(signature.slice(2)),
+						nonce,
+					}
 				},
 			}
 		} else {
@@ -91,12 +101,15 @@ export class SubstrateSigner implements SessionSigner {
 					const genesisHash = "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"
 					return genesisHash.slice(2, 34)
 				},
-				signMessage: async (data: Uint8Array) => {
+				signMessage: async (message: Uint8Array) => {
 					await cryptoWaitReady()
 					if (!keyring) {
 						keyring = randomKeypair(keyType)
 					}
-					return keyring.sign(bytesToHex(data))
+					const nonce = randomBytes(16)
+					const data = bytesToHex(nonce) + bytesToHex(message)
+					const signature = keyring.sign(data)
+					return { nonce, signature }
 				},
 			}
 		}
@@ -108,10 +121,10 @@ export class SubstrateSigner implements SessionSigner {
 	public readonly match = (address: string) => addressPattern.test(address)
 
 	public async verifySession(topic: string, session: Session) {
-		const { publicKey, address, authorizationData: data, timestamp, duration } = session
+		const { publicKey, address, authorizationData, timestamp, duration } = session
 
 		assert(didKeyPattern.test(publicKey), "invalid signing key")
-		assert(validateSessionData(data), "invalid session")
+		assert(validateSessionData(authorizationData), "invalid session")
 		const [chainId, walletAddress] = parseAddress(address)
 
 		const issuedAt = new Date(timestamp).toISOString()
@@ -126,7 +139,7 @@ export class SubstrateSigner implements SessionSigner {
 
 		const decodedAddress = decodeAddress(walletAddress)
 
-		const substrateKeyType = data.substrateKeyType
+		const substrateKeyType = authorizationData.substrateKeyType
 		// some cryptography code used by polkadot requires a wasm environment which is initialised
 		// asynchronously so we have to wait for it to be ready
 		await cryptoWaitReady()
@@ -135,7 +148,10 @@ export class SubstrateSigner implements SessionSigner {
 			ss58Format: 42,
 		}).addFromAddress(decodedAddress)
 
-		const valid = signerKeyring.verify(bytesToHex(json.encode(message)), data.signature, decodedAddress)
+		const { nonce, signature } = authorizationData.signatureResult
+		const signedData = bytesToHex(nonce) + bytesToHex(json.encode(message))
+
+		const valid = signerKeyring.verify(signedData, signature, decodedAddress)
 
 		assert(valid, "invalid signature")
 	}
@@ -183,14 +199,14 @@ export class SubstrateSigner implements SessionSigner {
 			expirationTime: null,
 		}
 
-		const signature = await this.#signer.signMessage(json.encode(message))
+		const signatureResult = await this.#signer.signMessage(json.encode(message))
 		const substrateKeyType = await this.#signer.getSubstrateKeyType()
 
 		const session: Session<SubstrateSessionData> = {
 			type: "session",
 			address,
 			publicKey: signer.uri,
-			authorizationData: { signature, data: message, substrateKeyType },
+			authorizationData: { signatureResult, data: message, substrateKeyType },
 			blockhash: null,
 			timestamp,
 			duration: this.sessionDuration,

--- a/packages/chain-substrate/src/types.ts
+++ b/packages/chain-substrate/src/types.ts
@@ -1,7 +1,10 @@
 import { KeypairType } from "@polkadot/util-crypto/types"
 
 export type SubstrateSessionData = {
-	signature: Uint8Array
+	signatureResult: {
+		signature: Uint8Array
+		nonce: Uint8Array
+	}
 	substrateKeyType: KeypairType
 	data: SubstrateMessage
 }

--- a/packages/chain-substrate/src/utils.ts
+++ b/packages/chain-substrate/src/utils.ts
@@ -42,9 +42,8 @@ export function validateSessionData(data: unknown): data is SubstrateSessionData
 		return false
 	}
 
-	const { signature, substrateKeyType, data: messageData } = data as Record<string, any>
-	if (!signature) {
-		console.log("a")
+	const { signatureResult, substrateKeyType, data: messageData } = data as Record<string, any>
+	if (!signatureResult) {
 		return false
 	}
 
@@ -56,7 +55,11 @@ export function validateSessionData(data: unknown): data is SubstrateSessionData
 		return false
 	}
 
-	if (!(signature instanceof Uint8Array)) {
+	if (!(signatureResult.signature instanceof Uint8Array)) {
+		return false
+	}
+
+	if (!(signatureResult.nonce instanceof Uint8Array)) {
 		return false
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is a bug in the polkadot implementation of ECDSA that means that sometimes the signer (deterministically) produces a seemingly invalid signature. This PR provides a workaround that modifies the SubstrateSigner so that it uses a nonce, then if the signature fails to verify, it generates a new nonce and tries to sign the message again. 

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Contract language
- [ ] Core interface
- [ ] CLI arguments
- [ ] Data storage formats
