### PR TITLE
Refactor @canvas-js/discovery

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -94,6 +94,10 @@ export const builder = (yargs: Argv) =>
 			desc: "Stop accepting connections above a limit",
 			default: MAX_CONNECTIONS,
 		})
+		.option("discovery-topic", {
+			type: "string",
+			desc: "Enable active peer discovery via GossipSub",
+		})
 		.option("verbose", {
 			type: "boolean",
 			desc: "Log messages to stdout",
@@ -148,6 +152,7 @@ export async function handler(args: Args) {
 		maxConnections: args["max-connections"],
 		bootstrapList: bootstrapList,
 		offline: args.offline,
+		discoveryTopic: args["discovery-topic"],
 	})
 
 	console.log(`${chalk.gray("[canvas] Starting app on topic")} ${chalk.whiteBright(app.topic)}`)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -87,7 +87,7 @@ export type ActionImplementationObject = {
 export type ActionImplementationFunction = (
   db: Record<string, ModelAPI>,
   args: Args,
-  context: ActionContext
+  context: ActionContext,
 ) => Awaitable<Result>
 
 export type ModelAPI = {
@@ -126,6 +126,7 @@ export interface CanvasConfig {
   bootstrapList?: string[]
   minConnections?: number
   maxConnections?: number
+  discoveryTopic?: string
 
   /** set to `false` to disable history indexing and db.get(..) within actions */
   indexHistory?: boolean
@@ -155,7 +156,7 @@ export declare class Canvas extends EventEmitter<CanvasEvents> {
     string,
     (
       args: any,
-      options: { chain?: string; signer?: SessionSigner }
+      options: { chain?: string; signer?: SessionSigner },
     ) => Promise<{ id: string; recipients: Promise<PeerId[]> }>
   >
 
@@ -167,7 +168,7 @@ export declare class Canvas extends EventEmitter<CanvasEvents> {
   public getMessageStream(
     lowerBound?: { id: string; inclusive: boolean } | null,
     upperBound?: { id: string; inclusive: boolean } | null,
-    options?: { reverse?: boolean }
+    options?: { reverse?: boolean },
   ): AsyncIterable<[id: string, signature: Signature, message: Message<Action | Session>]>
 }
 ```

--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -32,6 +32,7 @@ export interface CanvasConfig<T extends Contract = Contract> {
 	bootstrapList?: string[]
 	minConnections?: number
 	maxConnections?: number
+	discoveryTopic?: string
 
 	/** set to `false` to disable history indexing and db.get(..) within actions */
 	indexHistory?: boolean

--- a/packages/core/src/targets/browser/libp2p.ts
+++ b/packages/core/src/targets/browser/libp2p.ts
@@ -14,7 +14,7 @@ import { bootstrap } from "@libp2p/bootstrap"
 import { gossipsub } from "@chainsafe/libp2p-gossipsub"
 import { Multiaddr, multiaddr } from "@multiformats/multiaddr"
 
-import { gossiplog } from "@canvas-js/gossiplog/service"
+import { GossipLogService, gossiplog } from "@canvas-js/gossiplog/service"
 import { discovery } from "@canvas-js/discovery"
 
 import { defaultBootstrapList } from "@canvas-js/core/bootstrap"
@@ -38,6 +38,7 @@ export function getLibp2pOptions(
 		bootstrapList?: string[]
 		minConnections?: number
 		maxConnections?: number
+		discoveryTopic?: string
 	},
 ): Libp2pOptions<ServiceMap> {
 	const announce = options.announce ?? []
@@ -106,7 +107,10 @@ export function getLibp2pOptions(
 
 			gossiplog: gossiplog({}),
 			fetch: fetchService({ protocolPrefix: "canvas" }),
-			discovery: discovery({}),
+			discovery: discovery({
+				discoveryTopic: options.discoveryTopic,
+				topicFilter: (topic) => topic.startsWith(GossipLogService.topicPrefix),
+			}),
 		},
 	}
 }

--- a/packages/core/src/targets/interface.ts
+++ b/packages/core/src/targets/interface.ts
@@ -23,6 +23,7 @@ export interface PlatformTarget {
 			bootstrapList?: string[]
 			minConnections?: number
 			maxConnections?: number
+			discoveryTopic?: string
 		},
 	) => Promise<Libp2p<ServiceMap>>
 

--- a/packages/core/src/targets/node/libp2p.ts
+++ b/packages/core/src/targets/node/libp2p.ts
@@ -18,7 +18,7 @@ import { register } from "prom-client"
 
 import { Multiaddr, multiaddr } from "@multiformats/multiaddr"
 
-import { gossiplog } from "@canvas-js/gossiplog/service"
+import { GossipLogService, gossiplog } from "@canvas-js/gossiplog/service"
 import { discovery } from "@canvas-js/discovery"
 
 import { defaultBootstrapList } from "@canvas-js/core/bootstrap"
@@ -42,6 +42,7 @@ export function getLibp2pOptions(
 		bootstrapList?: string[]
 		minConnections?: number
 		maxConnections?: number
+		discoveryTopic?: string
 	},
 ): Libp2pOptions<ServiceMap> {
 	const announce = options.announce ?? []
@@ -117,7 +118,10 @@ export function getLibp2pOptions(
 			gossiplog: gossiplog({ sync: true }),
 
 			fetch: fetchService({ protocolPrefix: "canvas" }),
-			discovery: discovery({}),
+			discovery: discovery({
+				discoveryTopic: options.discoveryTopic,
+				topicFilter: (topic) => topic.startsWith(GossipLogService.topicPrefix),
+			}),
 		},
 	}
 }

--- a/packages/discovery/README.md
+++ b/packages/discovery/README.md
@@ -1,1 +1,16 @@
 # @canvas-js/discovery
+
+This is a general-purpose discovery service for Canvas peers. Bootstrap peers, replication servers, and browser peers all use `@canvas-js/discovery` to find each other.
+
+There are two forms of discovery: active and passive.
+
+1. in **passive** discovery, peers use the libp2p `fetch` protocol to query their existing connections for additional peers
+2. in **active** discovery, peers broadcast regular heartbeat messages via GossipSub on a dedicated "discovery topic"
+
+Peers either run passive discovery or passive+active discovery.
+
+For active discovery, there isn't a single global discovery topic. App developers can re-use an app topic for discovery, or might want to use a separate discovery topic for a family of app topics.
+
+Not all peers of an app have to be doing the same thing; it might make sense to only have replication servers participate in active discovery, and have browser peers only do passive discovery.
+
+Both forms of discovery expose real-time presence data through `join` and `leave` events. For passive discovery, these only track local-neighborhood peers (ie they're only emitted for peers we directly connect to and disconnect from). For passive+active discovery, they track all peers through their heartbeats on the discovery topic.

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -10,7 +10,6 @@
   "types": "./lib/index.d.ts",
   "sideEffects": false,
   "dependencies": {
-    "@canvas-js/interfaces": "0.6.1",
     "@ipld/dag-cbor": "^9.0.6",
     "@libp2p/interface": "^0.1.6",
     "@libp2p/interface-internal": "^0.1.9",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -10,6 +10,7 @@
   "types": "./lib/index.d.ts",
   "sideEffects": false,
   "dependencies": {
+    "@canvas-js/interfaces": "0.6.1",
     "@ipld/dag-cbor": "^9.0.6",
     "@libp2p/interface": "^0.1.6",
     "@libp2p/interface-internal": "^0.1.9",

--- a/packages/discovery/src/cache/MemoryCache.ts
+++ b/packages/discovery/src/cache/MemoryCache.ts
@@ -1,0 +1,41 @@
+import type { PeerId } from "@libp2p/interface/peer-id"
+import { peerIdFromString } from "@libp2p/peer-id"
+import { logger } from "@libp2p/logger"
+
+import { CacheMap } from "../utils.js"
+import { TopicCache } from "./interface.js"
+
+export class MemoryCache implements TopicCache {
+	private readonly log = logger("canvas:discovery:cache")
+
+	#cache = new CacheMap<string, CacheMap<string, null>>(this.maxTopics)
+	#peerRecords = new CacheMap<string, Uint8Array>(this.maxPeers)
+
+	public constructor(private readonly maxTopics = 100, private readonly maxPeers = 100) {}
+
+	public observe(topic: string, peerId: PeerId): void {
+		this.log("observing peer %p on topic %s", peerId, topic)
+		const peers = this.#cache.get(topic)
+		if (peers !== undefined) {
+			peers.set(peerId.toString(), null)
+		} else {
+			this.#cache.set(topic, new CacheMap(this.maxPeers, [[peerId.toString(), null]]))
+		}
+	}
+
+	public identify(peerId: PeerId, peerRecordEnvelope: Uint8Array): void {
+		this.#peerRecords.set(peerId.toString(), peerRecordEnvelope)
+	}
+
+	public query(topic: string): { peerId: PeerId; peerRecordEnvelope?: Uint8Array }[] {
+		this.log("querying for peers on topic %s", topic)
+
+		const results: { peerId: PeerId; peerRecordEnvelope?: Uint8Array }[] = []
+		for (const [peerId] of this.#cache.get(topic) ?? []) {
+			const peerRecordEnvelope = this.#peerRecords.get(peerId)
+			results.push({ peerId: peerIdFromString(peerId), peerRecordEnvelope })
+		}
+
+		return results
+	}
+}

--- a/packages/discovery/src/cache/interface.ts
+++ b/packages/discovery/src/cache/interface.ts
@@ -1,8 +1,7 @@
 import type { PeerId } from "@libp2p/interface/peer-id"
-import type { Awaitable } from "@canvas-js/interfaces"
 
 export interface TopicCache {
 	observe(topic: string, peerId: PeerId): void
 	identify(peerId: PeerId, peerRecordEnvelope: Uint8Array): void
-	query(topic: string): Awaitable<{ peerId: PeerId; peerRecordEnvelope?: Uint8Array }[]>
+	query(topic: string): { peerId: PeerId; peerRecordEnvelope?: Uint8Array }[]
 }

--- a/packages/discovery/src/cache/interface.ts
+++ b/packages/discovery/src/cache/interface.ts
@@ -1,0 +1,8 @@
+import type { PeerId } from "@libp2p/interface/peer-id"
+import type { Awaitable } from "@canvas-js/interfaces"
+
+export interface TopicCache {
+	observe(topic: string, peerId: PeerId): void
+	identify(peerId: PeerId, peerRecordEnvelope: Uint8Array): void
+	query(topic: string): Awaitable<{ peerId: PeerId; peerRecordEnvelope?: Uint8Array }[]>
+}

--- a/packages/discovery/src/service.ts
+++ b/packages/discovery/src/service.ts
@@ -18,7 +18,7 @@ import { GossipSub } from "@chainsafe/libp2p-gossipsub"
 import * as cbor from "@ipld/dag-cbor"
 import PQueue from "p-queue"
 
-import { assert, minute, second, topicPattern } from "./utils.js"
+import { assert, minute, second } from "./utils.js"
 import { TopicCache } from "./cache/interface.js"
 import { MemoryCache } from "./cache/MemoryCache.js"
 
@@ -31,7 +31,6 @@ export interface DiscoveryServiceComponents {
 
 	pubsub?: GossipSub
 	fetch?: FetchService
-	identify?: IdentifyService
 }
 
 export interface DiscoveryServiceInit {
@@ -65,14 +64,8 @@ export class DiscoveryService extends EventEmitter<PeerDiscoveryEvents> implemen
 		return components.fetch
 	}
 
-	private static extractIdentifyService(components: DiscoveryServiceComponents): IdentifyService {
-		assert(components.identify !== undefined)
-		return components.identify
-	}
-
 	private readonly pubsub: GossipSub
 	private readonly fetch: FetchService
-	private readonly identify: IdentifyService
 
 	private readonly log = logger("canvas:discovery")
 	private readonly cache: TopicCache
@@ -89,7 +82,6 @@ export class DiscoveryService extends EventEmitter<PeerDiscoveryEvents> implemen
 		super()
 		this.pubsub = DiscoveryService.extractGossipSub(components)
 		this.fetch = DiscoveryService.extractFetchService(components)
-		this.identify = DiscoveryService.extractIdentifyService(components)
 
 		this.minPeersPerTopic = init.minPeersPerTopic ?? DiscoveryService.MIN_PEERS_PER_TOPIC
 		this.autoDialPriority = init.autoDialPriority ?? DiscoveryService.AUTO_DIAL_PRIORITY

--- a/packages/discovery/src/utils.ts
+++ b/packages/discovery/src/utils.ts
@@ -1,8 +1,36 @@
 export const second = 1000
 export const minute = 60 * second
 
+// eslint-disable-next-line no-useless-escape
+export const topicPattern = /^[a-zA-Z0-9\.\-]+$/
+
 export function assert(condition: unknown, message?: string): asserts condition {
 	if (!condition) {
 		throw new Error(message ?? "assertion failed")
+	}
+}
+
+// add elements with CacheMap.add(key, value) and they'll
+// get shifted out in the order they were added.
+export class CacheMap<K, V> extends Map<K, V> {
+	constructor(public readonly capacity: number, entries?: Iterable<[K, V]>) {
+		super()
+
+		for (const [key, value] of entries ?? []) {
+			this.set(key, value)
+		}
+	}
+
+	set(key: K, value: V) {
+		super.set(key, value)
+		for (const key of this.keys()) {
+			if (this.size > this.capacity) {
+				this.delete(key)
+			} else {
+				break
+			}
+		}
+
+		return this
 	}
 }

--- a/packages/discovery/src/utils.ts
+++ b/packages/discovery/src/utils.ts
@@ -1,9 +1,6 @@
 export const second = 1000
 export const minute = 60 * second
 
-// eslint-disable-next-line no-useless-escape
-export const topicPattern = /^[a-zA-Z0-9\.\-]+$/
-
 export function assert(condition: unknown, message?: string): asserts condition {
 	if (!condition) {
 		throw new Error(message ?? "assertion failed")

--- a/packages/discovery/tsconfig.json
+++ b/packages/discovery/tsconfig.json
@@ -6,6 +6,5 @@
 		"moduleResolution": "Node16",
 		"rootDir": "src",
 		"outDir": "lib"
-	},
-	"references": [{ "path": "../interfaces" }]
+	}
 }

--- a/packages/discovery/tsconfig.json
+++ b/packages/discovery/tsconfig.json
@@ -1,10 +1,11 @@
 {
-  "include": ["src"],
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "rootDir": "src",
-    "outDir": "lib"
-  }
+	"include": ["src"],
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"rootDir": "src",
+		"outDir": "lib"
+	},
+	"references": [{ "path": "../interfaces" }]
 }

--- a/packages/gossiplog/src/service.ts
+++ b/packages/gossiplog/src/service.ts
@@ -14,7 +14,7 @@ import type { Message, Signer } from "@canvas-js/interfaces"
 
 import { AbstractGossipLog, GossipLogEvents } from "./AbstractGossipLog.js"
 
-import { decodeId, encodeId } from "./schema.js"
+import { decodeId } from "./schema.js"
 import { SyncService, SyncOptions } from "./sync/service.js"
 import { assert } from "./utils.js"
 
@@ -37,7 +37,7 @@ export class GossipLogService extends EventEmitter<GossipLogEvents<unknown, unkn
 		return pubsub
 	}
 
-	private static topicPrefix = "canvas/"
+	public static topicPrefix = "canvas/" as const
 
 	private readonly sync: boolean
 	private readonly log = logger(`canvas:gossiplog`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds a `discoveryTopic?: string` option that enables "active discovery" via GossipSub.

## How has this been tested?

- [x] CI tests pass
- [x] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Other:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Does this contain any breaking changes to external interfaces?

<!--- Please describe in detail, if applicable, what changes this -->
<!--- PR makes to Canvas external interfaces. -->

- [ ] Contract language
- [ ] Core interface
- [ ] CLI arguments
- [ ] Data storage formats
