### PR TITLE
packages/discovery, packages/core: Add presence:join, presence:leave events

### DIFF
--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -1,1 +1,8 @@
-export { discovery, DiscoveryService, DiscoveryServiceInit, DiscoveryServiceComponents } from "./service.js"
+export {
+	discovery,
+	DiscoveryService,
+	DiscoveryServiceInit,
+	DiscoveryServiceComponents,
+	PresenceStore,
+	PeerEnv,
+} from "./service.js"


### PR DESCRIPTION
Adds presence events using active discovery.
Improves when we send the first active discovery heartbeat so it's more likely to reach the mesh.

## How has this been tested?

- [] CI tests pass
- [X] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Other:

## Does this contain any breaking changes to external interfaces?

- [ ] Contract language
- [ ] Core interface
- [ ] CLI arguments
- [ ] Data storage formats
