### PR TITLE
Add aggregated presence fetching

### DIFF
--- a/examples/chat/src/App.tsx
+++ b/examples/chat/src/App.tsx
@@ -49,6 +49,7 @@ export const App: React.FC<{}> = ({}) => {
 		discoveryTopic: "canvas-discovery",
 		trackAllPeers: true,
 		bootstrapList: [
+			"/ip4/127.0.0.1/tcp/8080/ws/p2p/12D3KooWJ838UjmaNUEsy9dPwHdM8sYkPzVJKdFdou4zenZhevut",
 			"/dns4/canvas-chat-discovery-p0.fly.dev/tcp/443/wss/p2p/12D3KooWG1zzEepzv5ib5Rz16Z4PXVfNRffXBGwf7wM8xoNAbJW7",
 			"/dns4/canvas-chat-discovery-p1.fly.dev/tcp/443/wss/p2p/12D3KooWNfH4Z4ayppVFyTKv8BBYLLvkR1nfWkjcSTqYdS4gTueq",
 			"/dns4/canvas-chat-discovery-p2.fly.dev/tcp/443/wss/p2p/12D3KooWRBdFp5T1fgjWdPSCf9cDqcCASMBgcLqjzzBvptjAfAxN",
@@ -58,10 +59,6 @@ export const App: React.FC<{}> = ({}) => {
 			...defaultBootstrapList,
 		],
 	})
-
-	useEffect(() => {
-		;(window as any).app = app
-	}, [app])
 
 	return (
 		<AppContext.Provider value={{ address, setAddress, sessionSigner, setSessionSigner, app }}>

--- a/examples/chat/src/App.tsx
+++ b/examples/chat/src/App.tsx
@@ -18,18 +18,36 @@ import { SessionStatus } from "./SessionStatus.js"
 import { ConnectionStatus } from "./ConnectionStatus.js"
 import { Connect } from "./connect/index.js"
 
-import contract from "../contract.canvas.js?raw"
+export const contract = {
+	models: {
+		message: {
+			id: "primary",
+			address: "string",
+			content: "string",
+			timestamp: "integer",
+			$indexes: ["address", "timestamp"],
+		},
+	},
+	actions: {
+		async createMessage(db, { content }, { id, address, timestamp }) {
+			console.log("received message:", content)
+			await db.set("message", { id, address, content, timestamp })
+		},
+	},
+}
 
 export const App: React.FC<{}> = ({}) => {
 	const [sessionSigner, setSessionSigner] = useState<SessionSigner | null>(null)
 	const [address, setAddress] = useState<string | null>(null)
 
+	const topicRef = useRef("chat-example.canvas.xyz")
+
 	const { app } = useCanvas({
-		contract,
+		contract: { ...contract, topic: topicRef.current },
 		signers: sessionSigner ? [sessionSigner] : undefined,
 		indexHistory: false,
-		offline: true,
 		discoveryTopic: "canvas-discovery",
+		trackAllPeers: true,
 		bootstrapList: [
 			"/dns4/canvas-chat-discovery-p0.fly.dev/tcp/443/wss/p2p/12D3KooWG1zzEepzv5ib5Rz16Z4PXVfNRffXBGwf7wM8xoNAbJW7",
 			"/dns4/canvas-chat-discovery-p1.fly.dev/tcp/443/wss/p2p/12D3KooWNfH4Z4ayppVFyTKv8BBYLLvkR1nfWkjcSTqYdS4gTueq",
@@ -41,7 +59,9 @@ export const App: React.FC<{}> = ({}) => {
 		],
 	})
 
-	;(window as any).app = app
+	useEffect(() => {
+		;(window as any).app = app
+	}, [app])
 
 	return (
 		<AppContext.Provider value={{ address, setAddress, sessionSigner, setSessionSigner, app }}>
@@ -57,7 +77,7 @@ export const App: React.FC<{}> = ({}) => {
 						<div className="min-w-[480px] flex flex-col gap-4">
 							<Connect />
 							<SessionStatus />
-							<ConnectionStatus />
+							<ConnectionStatus topic={topicRef.current} />
 							<ControlPanel />
 						</div>
 					</div>

--- a/examples/chat/src/ConnectionStatus.tsx
+++ b/examples/chat/src/ConnectionStatus.tsx
@@ -6,9 +6,11 @@ import { AppContext } from "./AppContext.js"
 
 import { PeerIdView } from "./components/PeerIdView.js"
 
-export interface ConnectionStatusProps {}
+export interface ConnectionStatusProps {
+	topic: string
+}
 
-export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({}) => {
+export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({ topic }) => {
 	const { app } = useContext(AppContext)
 
 	const [status, setStatus] = useState("--")
@@ -39,6 +41,12 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({}) => {
 	return (
 		<div className="p-2 border rounded flex flex-col gap-2">
 			<div>
+				<span className="text-sm">Topic</span>
+			</div>
+			<div>
+				<code className="text-sm">{topic}</code>
+			</div>
+			<div>
 				<span className="text-sm">Peer Id</span>
 			</div>
 			<div>
@@ -48,7 +56,7 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({}) => {
 			<div>
 				<span className="text-sm">Online</span>
 			</div>
-			<OnlineList onlinePeers={onlinePeers} />
+			<OnlineList onlinePeers={onlinePeers} topic={topic} />
 			<hr />
 			<div>
 				<span className="text-sm">Connections (Status: {status})</span>
@@ -58,7 +66,7 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({}) => {
 	)
 }
 
-const OnlineList = ({ onlinePeers }: { onlinePeers: PresenceList }) => {
+const OnlineList = ({ onlinePeers, topic }: { onlinePeers: PresenceList; topic: string }) => {
 	const browserPeers = Object.entries(onlinePeers).filter(([peerId, { lastSeen, env }]) => env === "browser")
 	const [time, setTime] = useState()
 
@@ -85,7 +93,8 @@ const OnlineList = ({ onlinePeers }: { onlinePeers: PresenceList }) => {
 							)}
 							<div>
 								<code className="text-sm break-all text-gray-500">
-									{env} - last seen {lastSeen === null ? "awhile ago" : Math.ceil((time - lastSeen) / 1000) + "s"}
+									{env} - last seen {lastSeen === null ? "awhile ago" : Math.ceil((time - lastSeen) / 1000) + "s"}{" "}
+									{!topics.includes(topic) && `[${topics.join(", ")}]`}
 								</code>
 							</div>
 						</li>

--- a/examples/chat/src/ConnectionStatus.tsx
+++ b/examples/chat/src/ConnectionStatus.tsx
@@ -85,7 +85,7 @@ const OnlineList = ({ onlinePeers }: { onlinePeers: PresenceList }) => {
 							)}
 							<div>
 								<code className="text-sm break-all text-gray-500">
-									{env} - last seen {Math.ceil((time - lastSeen) / 1000)}s
+									{env} - last seen {lastSeen === null ? "awhile ago" : Math.ceil((time - lastSeen) / 1000) + "s"}
 								</code>
 							</div>
 						</li>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -121,36 +121,45 @@ export type ActionContext = {
 import { Signature, Action, Session, SessionSigner } from "@canvas-js/interfaces"
 import { AbstractModelDB } from "@canvas-js/modeldb"
 
-export interface CanvasConfig {
-  contract: string | Contract
-
-  /** data directory path (NodeJS only) */
-  path?: string | null
-  signers?: SessionSigner[]
-
-  // libp2p options
-  offline?: boolean
-  start?: boolean
-  listen?: string[]
-  announce?: string[]
-  bootstrapList?: string[]
-  minConnections?: number
-  maxConnections?: number
-  discoveryTopic?: string
-
-  /** set to `false` to disable history indexing and db.get(..) within actions */
-  indexHistory?: boolean
-  runtimeMemoryLimit?: number
+export interface NetworkConfig {
+    offline?: boolean;
+    disablePing?: boolean;
+    /** array of local WebSocket multiaddrs, e.g. "/ip4/127.0.0.1/tcp/3000/ws" */
+    listen?: string[];
+    /** array of public WebSocket multiaddrs, e.g. "/dns4/myapp.com/tcp/443/wss" */
+    announce?: string[];
+    bootstrapList?: string[];
+    minConnections?: number;
+    maxConnections?: number;
+    discoveryTopic?: string;
+    discoveryInterval?: number;
+    trackAllPeers?: boolean;
+    enableWebRTC?: boolean;
+}
+export interface CanvasConfig<T extends Contract = Contract> extends NetworkConfig {
+    contract: string | T;
+    signers?: SessionSigner[];
+    /** data directory path (NodeJS only) */
+    path?: string | null;
+    /** provide an existing libp2p instance instead of creating a new one */
+    libp2p?: Libp2p<ServiceMap>;
+    /** set to `false` to disable history indexing and db.get(..) within actions */
+    indexHistory?: boolean;
+    runtimeMemoryLimit?: number;
+    ignoreMissingActions?: boolean;
 }
 
-export interface CanvasEvents {
-  close: Event
-  connect: CustomEvent<{ peer: PeerId }>
-  disconnect: CustomEvent<{ peer: PeerId }>
-
-  message: CustomEvent<{ id: string; signature: Signature; message: Message<Action | Session> }>
-  commit: CustomEvent<{ root: Node }>
-  sync: CustomEvent<{ peer: string | null }>
+export interface CanvasEvents extends GossipLogEvents<Action | Session, unknown> {
+    close: Event;
+    connect: CustomEvent<{
+        peer: PeerId;
+    }>;
+    disconnect: CustomEvent<{
+        peer: PeerId;
+    }>;
+    "connections:updated": CustomEvent<ConnectionsInfo>;
+    "presence:join": CustomEvent<PresenceInfo>;
+    "presence:leave": CustomEvent<PresenceInfo>;
 }
 
 export declare class Canvas extends EventEmitter<CanvasEvents> {

--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -35,6 +35,7 @@ export interface NetworkConfig {
 	maxConnections?: number
 	discoveryTopic?: string
 	discoveryInterval?: number
+	trackAllPeers?: boolean
 	enableWebRTC?: boolean
 }
 

--- a/packages/core/src/runtime/FunctionRuntime.ts
+++ b/packages/core/src/runtime/FunctionRuntime.ts
@@ -20,6 +20,10 @@ export class FunctionRuntime extends AbstractRuntime {
 		contract: Contract,
 		options: { indexHistory?: boolean; ignoreMissingActions?: boolean } = {},
 	): Promise<FunctionRuntime> {
+		assert(contract.actions !== undefined, "contract initialized without actions")
+		assert(contract.models !== undefined, "contract initialized without models")
+		assert(contract.topic !== undefined, "contract initialized without topic")
+
 		const { indexHistory = true, ignoreMissingActions = false } = options
 		const models = AbstractRuntime.getModelSchema(contract.models, { indexHistory })
 		const db = await target.openDB({ path, topic: contract.topic }, models)

--- a/packages/core/src/targets/browser/libp2p.ts
+++ b/packages/core/src/targets/browser/libp2p.ts
@@ -109,6 +109,7 @@ export function getLibp2pOptions(
 			discovery: discovery({
 				discoveryTopic: options.discoveryTopic,
 				discoveryInterval: options.discoveryInterval,
+				trackAllPeers: options.trackAllPeers,
 				topicFilter: (topic) => topic.startsWith(GossipLogService.topicPrefix),
 				addressFilter: (addr) =>
 					WebSockets.matches(addr) || WebSocketsSecure.matches(addr) || (enableWebRTC && WebRTC.matches(addr)),

--- a/packages/core/src/targets/node/libp2p.ts
+++ b/packages/core/src/targets/node/libp2p.ts
@@ -114,6 +114,8 @@ export function getLibp2pOptions(peerId: PeerId, options: NetworkConfig): Libp2p
 			fetch: fetchService({ protocolPrefix: "canvas" }),
 			discovery: discovery({
 				discoveryTopic: options.discoveryTopic,
+				discoveryInterval: options.discoveryInterval,
+				trackAllPeers: options.trackAllPeers,
 				topicFilter: (topic) => topic.startsWith(GossipLogService.topicPrefix),
 				addressFilter: (addr) => WebSockets.matches(addr) || WebSocketsSecure.matches(addr),
 			}),

--- a/packages/discovery/src/service.ts
+++ b/packages/discovery/src/service.ts
@@ -242,7 +242,12 @@ export class DiscoveryService extends TypedEventEmitter<DiscoveryServiceEvents> 
 			this.components.events.addEventListener(
 				"connection:open",
 				({ detail: connection }) => {
-					setTimeout(() => this.publishHeartbeat(), 1000)
+					setTimeout(() => {
+						this.publishHeartbeat()
+						this.lastResponseHeartbeat = 0
+						// reset response heartbeat, so we send it again on the next incoming connection
+						// this helps ensure we get an actual `lastSeen` value for very small meshes
+					}, 1000)
 				},
 				{ once: true },
 			)
@@ -257,7 +262,7 @@ export class DiscoveryService extends TypedEventEmitter<DiscoveryServiceEvents> 
 			}, this.evictionInterval)
 
 			this.addEventListener("presence:join", ({ detail: { peerId } }) => {
-				if (this.lastResponseHeartbeat > new Date().getTime() + this.responseHeartbeatThreshold) return
+				if (this.lastResponseHeartbeat > new Date().getTime() - this.responseHeartbeatThreshold) return
 				this.lastResponseHeartbeat = new Date().getTime()
 				this.publishHeartbeat()
 			})

--- a/packages/discovery/src/service.ts
+++ b/packages/discovery/src/service.ts
@@ -341,7 +341,7 @@ export class DiscoveryService extends TypedEventEmitter<DiscoveryServiceEvents> 
 		}
 
 		// for fetch_all, return the union of peers in the discovery cache, and the currently subscribed peers
-		let peers = this.pubsub.getSubscribers(topic)
+		const peers = this.pubsub.getSubscribers(topic)
 		if (fetchAll) {
 			const peerIds = peers.map((p) => p.toString())
 			for (const peerId of Object.values(this.discoveryPeers).map((p) => p.peerId)) {

--- a/packages/replication-server/README.md
+++ b/packages/replication-server/README.md
@@ -8,6 +8,12 @@ The universal replication server discovers peers through a discovery topic, and 
 npm run start
 ```
 
+or
+
+```
+PEER_ID=... npm run start
+```
+
 Configure the replication server using environment variables:
 
 - DISCOVERY_TOPIC: A discovery topic to serve, by default `canvas-discovery`.


### PR DESCRIPTION
Let peers fetch presence information for all peers on a discovery topic.

Tested using example-chat + mud-example.

## How has this been tested?

- [x] CI tests pass
- [x] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
