### PR TITLE
Use raw multicodec

### DIFF
--- a/examples/chat/src/connect/ConnectEIP712.tsx
+++ b/examples/chat/src/connect/ConnectEIP712.tsx
@@ -1,0 +1,101 @@
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react"
+import { Eip1193Provider, BrowserProvider, EventEmitterable } from "ethers"
+
+import { EIP712Signer } from "@canvas-js/chain-ethereum"
+
+import { AppContext } from "../AppContext.js"
+
+declare global {
+	// eslint-disable-next-line no-var
+	var ethereum: undefined | null | (Eip1193Provider & EventEmitterable<"accountsChanged" | "chainChanged">)
+}
+
+export interface ConnectEIP712Props {}
+
+export const ConnectEIP712: React.FC<ConnectEIP712Props> = ({}) => {
+	const { app, sessionSigner, setSessionSigner, address, setAddress } = useContext(AppContext)
+
+	const [provider, setProvider] = useState<BrowserProvider | null>(null)
+	const [error, setError] = useState<Error | null>(null)
+
+	const connect = useCallback(async () => {
+		if (app === null) {
+			setError(new Error("app not initialized"))
+			return
+		}
+
+		if (provider === null) {
+			setError(new Error("window.ethereum not found"))
+			return
+		}
+
+		setProvider(provider)
+
+		const network = await provider.getNetwork()
+		const signer = await provider
+			.getSigner()
+			.then((signer) => new EIP712Signer({ signer, chainId: Number(network.chainId) }))
+
+		const { address } = await signer.getSession(app.topic)
+		setAddress(address)
+		setSessionSigner(signer)
+	}, [app, provider])
+
+	const initialRef = useRef(false)
+	useEffect(() => {
+		if (initialRef.current) {
+			return
+		}
+
+		initialRef.current = true
+
+		if (window.ethereum === undefined || window.ethereum === null) {
+			setError(new Error("window.ethereum not found"))
+			return
+		}
+
+		// TODO: handle these more gracefully
+		window.ethereum.on("chainChanged", (chainId) => window.location.reload())
+		window.ethereum.on("accountsChanged", (accounts) => window.location.reload())
+
+		const provider = new BrowserProvider(window.ethereum)
+		setProvider(provider)
+	}, [])
+
+	const disconnect = useCallback(async () => {
+		setAddress(null)
+		setSessionSigner(null)
+	}, [sessionSigner])
+
+	if (error !== null) {
+		return (
+			<div className="p-2 border rounded bg-red-100 text-sm">
+				<code>{error.message}</code>
+			</div>
+		)
+	} else if (provider === null) {
+		return (
+			<div className="p-2 border rounded bg-gray-200">
+				<button disabled>Loading...</button>
+			</div>
+		)
+	} else if (address !== null && sessionSigner instanceof EIP712Signer) {
+		return (
+			<button
+				onClick={() => disconnect()}
+				className="p-2 border rounded hover:cursor-pointer hover:bg-gray-100 active:bg-gray-200"
+			>
+				Disconnect ETH wallet
+			</button>
+		)
+	} else {
+		return (
+			<button
+				onClick={() => connect()}
+				className="p-2 border rounded hover:cursor-pointer hover:bg-gray-100 active:bg-gray-200"
+			>
+				Connect ETH wallet
+			</button>
+		)
+	}
+}

--- a/examples/chat/src/connect/ConnectEIP712Burner.tsx
+++ b/examples/chat/src/connect/ConnectEIP712Burner.tsx
@@ -1,0 +1,63 @@
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react"
+import { Eip1193Provider, BrowserProvider, EventEmitterable } from "ethers"
+
+import { EIP712Signer } from "@canvas-js/chain-ethereum"
+
+import { AppContext } from "../AppContext.js"
+
+declare global {
+	// eslint-disable-next-line no-var
+	var ethereum: undefined | null | (Eip1193Provider & EventEmitterable<"accountsChanged" | "chainChanged">)
+}
+
+export interface ConnectEIP712BurnerProps {}
+
+export const ConnectEIP712Burner: React.FC<ConnectEIP712BurnerProps> = ({}) => {
+	const { app, sessionSigner, setSessionSigner, address, setAddress } = useContext(AppContext)
+
+	const [provider, setProvider] = useState<BrowserProvider | null>(null)
+	const [error, setError] = useState<Error | null>(null)
+
+	const connect = useCallback(async () => {
+		if (app === null) {
+			setError(new Error("app not initialized"))
+			return
+		}
+
+		const signer = new EIP712Signer({ chainId: 1 })
+		const { address } = await signer.getSession(app.topic)
+		setAddress(address)
+		setSessionSigner(signer)
+	}, [app, provider])
+
+	const disconnect = useCallback(async () => {
+		setAddress(null)
+		setSessionSigner(null)
+	}, [sessionSigner])
+
+	if (error !== null) {
+		return (
+			<div className="p-2 border rounded bg-red-100 text-sm">
+				<code>{error.message}</code>
+			</div>
+		)
+	} else if (address !== null && sessionSigner instanceof EIP712Signer) {
+		return (
+			<button
+				onClick={() => disconnect()}
+				className="p-2 border rounded hover:cursor-pointer hover:bg-gray-100 active:bg-gray-200"
+			>
+				Disconnect burner wallet
+			</button>
+		)
+	} else {
+		return (
+			<button
+				onClick={() => connect()}
+				className="p-2 border rounded hover:cursor-pointer hover:bg-gray-100 active:bg-gray-200"
+			>
+				Connect burner wallet
+			</button>
+		)
+	}
+}

--- a/examples/chat/src/connect/index.tsx
+++ b/examples/chat/src/connect/index.tsx
@@ -2,6 +2,9 @@ import React, { useState } from "react"
 
 import { ConnectSIWEBurner } from "./ConnectSIWEBurner.js"
 import { ConnectSIWE } from "./ConnectSIWE.js"
+import { ConnectSIWEViem } from "./ConnectSIWEViem.js"
+import { ConnectEIP712Burner } from "./ConnectEIP712Burner.js"
+import { ConnectEIP712 } from "./ConnectEIP712.js"
 import { ConnectATP } from "./ConnectATP.js"
 import { ConnectCosmosKeplr } from "./ConnectCosmosKeplr.js"
 import { ConnectTerra } from "./ConnectTerra.js"
@@ -11,7 +14,6 @@ import { ConnectPolkadot } from "./ConnectPolkadot.js"
 import { ConnectSolana } from "./ConnectSolana.js"
 import { ConnectNEAR } from "./ConnectNEAR.js"
 import { ConnectMagic } from "./ConnectMagic.js"
-import { ConnectSIWEViem } from "./ConnectSIWEViem.js"
 
 export const Connect: React.FC<{}> = ({}) => {
 	const [method, setMethod] = useState("burner")
@@ -24,8 +26,10 @@ export const Connect: React.FC<{}> = ({}) => {
 				onChange={(e) => setMethod(e.target.value)}
 			>
 				<option value="burner">Burner Wallet</option>
+				<option value="burner-eip712">Burner Wallet - EIP712</option>
 				<option value="ethereum">Ethereum</option>
 				<option value="ethereum-viem">Ethereum (Viem)</option>
+				<option value="ethereum-eip712">Ethereum (EIP712)</option>
 				<option value="polkadot">Polkadot</option>
 				<option value="solana">Solana</option>
 				<option value="cosmos-keplr">Cosmos/Keplr</option>
@@ -45,8 +49,12 @@ const Method: React.FC<{ method: string }> = (props) => {
 	switch (props.method) {
 		case "burner":
 			return <ConnectSIWEBurner />
+		case "burner-eip712":
+			return <ConnectEIP712Burner />
 		case "ethereum":
 			return <ConnectSIWE />
+		case "ethereum-eip712":
+			return <ConnectEIP712 />
 		case "ethereum-viem":
 			return <ConnectSIWEViem />
 		case "polkadot":

--- a/packages/chain-ethereum/src/EIP712Signer.ts
+++ b/packages/chain-ethereum/src/EIP712Signer.ts
@@ -2,7 +2,7 @@ import { AbstractSigner, Wallet, hexlify, getBytes, verifyTypedData, zeroPadValu
 import { logger } from "@libp2p/logger"
 
 import type { Signature, SessionSigner, Action, Message, Session } from "@canvas-js/interfaces"
-import { Secp256k1Signer, didKeyPattern, eip712Encode } from "@canvas-js/signed-cid"
+import { Secp256k1Signer, didKeyPattern } from "@canvas-js/signed-cid"
 
 import target from "#target"
 
@@ -145,14 +145,14 @@ export class EIP712Signer implements SessionSigner<EIP712AuthorizationData> {
 			assert(timestamp >= session.timestamp)
 			assert(timestamp <= session.timestamp + (session.duration ?? Infinity))
 
-			return signer.sign(eip712Encode(message), { codec: "raw", digest: "raw" })
+			return signer.sign(message, { codec: "raw", digest: "raw" })
 		} else if (message.payload.type === "session") {
 			const { signer, session } = this.#store.get(message.topic, message.payload.address) ?? {}
 			assert(signer !== undefined && session !== undefined)
 
 			// only sign our own current sessions
 			assert(message.payload === session)
-			return signer.sign(eip712Encode(message), { codec: "raw", digest: "raw" })
+			return signer.sign(message, { codec: "raw", digest: "raw" })
 		} else {
 			signalInvalidType(message.payload)
 		}

--- a/packages/chain-ethereum/src/EIP712Signer.ts
+++ b/packages/chain-ethereum/src/EIP712Signer.ts
@@ -2,7 +2,7 @@ import { AbstractSigner, Wallet, hexlify, getBytes, verifyTypedData, zeroPadValu
 import { logger } from "@libp2p/logger"
 
 import type { Signature, SessionSigner, Action, Message, Session } from "@canvas-js/interfaces"
-import { Secp256k1Signer, didKeyPattern } from "@canvas-js/signed-cid"
+import { Secp256k1Signer, didKeyPattern, eip712Encode } from "@canvas-js/signed-cid"
 
 import target from "#target"
 
@@ -145,14 +145,14 @@ export class EIP712Signer implements SessionSigner<EIP712AuthorizationData> {
 			assert(timestamp >= session.timestamp)
 			assert(timestamp <= session.timestamp + (session.duration ?? Infinity))
 
-			return signer.sign(message, { codec: "eip712", digest: "raw" })
+			return signer.sign(eip712Encode(message), { codec: "raw", digest: "raw" })
 		} else if (message.payload.type === "session") {
 			const { signer, session } = this.#store.get(message.topic, message.payload.address) ?? {}
 			assert(signer !== undefined && session !== undefined)
 
 			// only sign our own current sessions
 			assert(message.payload === session)
-			return signer.sign(message, { codec: "eip712", digest: "raw" })
+			return signer.sign(eip712Encode(message), { codec: "raw", digest: "raw" })
 		} else {
 			signalInvalidType(message.payload)
 		}

--- a/packages/chain-ethereum/test/EIP712Signer.test.ts
+++ b/packages/chain-ethereum/test/EIP712Signer.test.ts
@@ -1,7 +1,7 @@
 import test from "ava"
 import assert from "assert"
 
-import { verifySignedValue, eip712Encode } from "@canvas-js/signed-cid"
+import { verifySignedValue } from "@canvas-js/signed-cid"
 
 import { EIP712Signer, validateEIP712AuthorizationData } from "@canvas-js/chain-ethereum"
 import { Action } from "@canvas-js/interfaces"
@@ -14,7 +14,7 @@ test("create and verify session", async (t) => {
 
 	const sessionMessage = { topic, clock: 1, parents: [], payload: session }
 	const sessionSignature = await signer.sign(sessionMessage)
-	t.notThrows(() => verifySignedValue(sessionSignature, eip712Encode(sessionMessage)))
+	t.notThrows(() => verifySignedValue(sessionSignature, sessionMessage))
 })
 
 test("create and verify session and action", async (t) => {
@@ -25,7 +25,7 @@ test("create and verify session and action", async (t) => {
 
 	const sessionMessage = { topic, clock: 1, parents: [], payload: session }
 	const sessionSignature = await signer.sign(sessionMessage)
-	t.notThrows(() => verifySignedValue(sessionSignature, eip712Encode(sessionMessage)))
+	t.notThrows(() => verifySignedValue(sessionSignature, sessionMessage))
 
 	const action: Action = {
 		type: "action",
@@ -38,7 +38,7 @@ test("create and verify session and action", async (t) => {
 
 	const actionMessage = { topic, clock: 1, parents: [], payload: action }
 	const actionSignature = await signer.sign(actionMessage)
-	t.notThrows(() => verifySignedValue(actionSignature, eip712Encode(actionMessage)))
+	t.notThrows(() => verifySignedValue(actionSignature, actionMessage))
 })
 
 test("reject corrupt session signature", async (t) => {

--- a/packages/chain-ethereum/test/EIP712Signer.test.ts
+++ b/packages/chain-ethereum/test/EIP712Signer.test.ts
@@ -1,7 +1,7 @@
 import test from "ava"
 import assert from "assert"
 
-import { verifySignedValue } from "@canvas-js/signed-cid"
+import { verifySignedValue, eip712Encode } from "@canvas-js/signed-cid"
 
 import { EIP712Signer, validateEIP712AuthorizationData } from "@canvas-js/chain-ethereum"
 import { Action } from "@canvas-js/interfaces"
@@ -14,7 +14,7 @@ test("create and verify session", async (t) => {
 
 	const sessionMessage = { topic, clock: 1, parents: [], payload: session }
 	const sessionSignature = await signer.sign(sessionMessage)
-	t.notThrows(() => verifySignedValue(sessionSignature, sessionMessage))
+	t.notThrows(() => verifySignedValue(sessionSignature, eip712Encode(sessionMessage)))
 })
 
 test("create and verify session and action", async (t) => {
@@ -25,7 +25,7 @@ test("create and verify session and action", async (t) => {
 
 	const sessionMessage = { topic, clock: 1, parents: [], payload: session }
 	const sessionSignature = await signer.sign(sessionMessage)
-	t.notThrows(() => verifySignedValue(sessionSignature, sessionMessage))
+	t.notThrows(() => verifySignedValue(sessionSignature, eip712Encode(sessionMessage)))
 
 	const action: Action = {
 		type: "action",
@@ -38,7 +38,7 @@ test("create and verify session and action", async (t) => {
 
 	const actionMessage = { topic, clock: 1, parents: [], payload: action }
 	const actionSignature = await signer.sign(actionMessage)
-	t.notThrows(() => verifySignedValue(actionSignature, actionMessage))
+	t.notThrows(() => verifySignedValue(actionSignature, eip712Encode(actionMessage)))
 })
 
 test("reject corrupt session signature", async (t) => {

--- a/packages/signed-cid/src/cid.ts
+++ b/packages/signed-cid/src/cid.ts
@@ -3,9 +3,10 @@ import { CID } from "multiformats/cid"
 
 import { Codec, getCodec } from "./codecs.js"
 import { Digest, getDigest } from "./digests.js"
+import { encode as eip712Encode } from "./eip712.js"
 
 export function getCID(value: any, options: { codec?: string | Codec; digest?: string | Digest } = {}): CID {
 	const [codec, digest] = [getCodec(options), getDigest(options)]
-	const hash = digest.digest(codec.encode(value))
+	const hash = digest.digest(codec.encode(codec.code === 0x55 && digest.code === 0x55 ? eip712Encode(value) : value))
 	return CID.createV1(codec.code, createDigest(digest.code, hash))
 }

--- a/packages/signed-cid/src/codecs.ts
+++ b/packages/signed-cid/src/codecs.ts
@@ -3,7 +3,6 @@ import * as json from "@ipld/dag-json"
 import * as raw from "multiformats/codecs/raw"
 
 import { assert } from "./utils.js"
-import { encode as eip712Encode } from "./eip712Codec.js"
 
 export type Codec = { name: string; code: number; encode: (value: any) => Iterable<Uint8Array> }
 
@@ -26,9 +25,18 @@ export const codecs: Codec[] = [
 		name: "raw",
 		code: raw.code,
 
-		// TODO: define Canvas action/session messages as multicodecs
+		// TODO: add Canvas action/session messages to multicodecs table
 		// https://github.com/multiformats/multicodec/blob/master/table.csv
-		encode: eip712Encode,
+		encode: (value) => {
+			if (typeof value === "string") {
+				const encoder = new TextEncoder()
+				return [encoder.encode(value)]
+			} else if (value instanceof Uint8Array) {
+				return [value]
+			} else {
+				throw new TypeError("raw values must be strings or Uint8Arrays")
+			}
+		},
 	},
 ]
 

--- a/packages/signed-cid/src/codecs.ts
+++ b/packages/signed-cid/src/codecs.ts
@@ -25,8 +25,10 @@ export const codecs: Codec[] = [
 		name: "raw",
 		code: raw.code,
 
-		// TODO: add Canvas action/session messages to multicodecs table
+		// TODO: add codes for Canvas eip712 messages to the multicodecs table
 		// https://github.com/multiformats/multicodec/blob/master/table.csv
+		//
+		// right now, we assume messages with a `raw` codec are eip712 encoded data
 		encode: (value) => {
 			if (typeof value === "string") {
 				const encoder = new TextEncoder()

--- a/packages/signed-cid/src/codecs.ts
+++ b/packages/signed-cid/src/codecs.ts
@@ -3,7 +3,7 @@ import * as json from "@ipld/dag-json"
 import * as raw from "multiformats/codecs/raw"
 
 import { assert } from "./utils.js"
-import { eip712Codec } from "./eip712Codec.js"
+import { encode as eip712Encode } from "./eip712Codec.js"
 
 export type Codec = { name: string; code: number; encode: (value: any) => Iterable<Uint8Array> }
 
@@ -25,18 +25,11 @@ export const codecs: Codec[] = [
 	{
 		name: "raw",
 		code: raw.code,
-		encode: (value) => {
-			if (typeof value === "string") {
-				const encoder = new TextEncoder()
-				return [encoder.encode(value)]
-			} else if (value instanceof Uint8Array) {
-				return [value]
-			} else {
-				throw new TypeError("raw values must be strings or Uint8Arrays")
-			}
-		},
+
+		// TODO: define Canvas action/session messages as multicodecs
+		// https://github.com/multiformats/multicodec/blob/master/table.csv
+		encode: eip712Encode,
 	},
-	eip712Codec,
 ]
 
 export const defaultCodec = "dag-cbor"

--- a/packages/signed-cid/src/eip712.ts
+++ b/packages/signed-cid/src/eip712.ts
@@ -9,10 +9,13 @@ type Codec = { name: string; code: number; encode: (value: any) => Iterable<Uint
  * Encode `Message<Action | Session>` using Ethereum typed data encoding.
  *
  * Messages may contain dynamically typed data:
- * - Objects may contain nested objects, strings, numbers, or booleans.
- *   These are encoded as `bytes`, `string`, `int256`, and `bool`.
+ * - Objects may contain strings, numbers, or booleans.
+ *   These are encoded as `string`, `int256`, and `bool`.
  * - Numbers must be integers.
  * - 40-byte-long hex strings (starting with "0x") are encoded as `address`.
+ *
+ * TODO: Objects encoded as `bytes` as `getBytes(AbiCoder().encode(types, values))`.
+ * TODO: Null encoded as `bytes` with length zero.
  *
  * While the codec is implemented for dynamically typed data, if you are
  * writing an onchain verifier for offchain signed data, it must still be
@@ -123,7 +126,7 @@ export function getEIP712Args(args: Record<string, any>) {
 }
 
 /**
- * Convert a JS type to an EIP712-compatible type.
+ * Convert a JS primitive type to an EIP712-compatible type.
  */
 function getAbiTypeForValue(value: any) {
 	if (typeof value === "string") {
@@ -141,5 +144,5 @@ function getAbiTypeForValue(value: any) {
 	} else if (typeof value === "boolean") {
 		return "bool"
 	}
-	throw new TypeError(`invalid type ${typeof value}`)
+	throw new TypeError(`invalid type ${typeof value}: ${JSON.stringify(value)}`)
 }

--- a/packages/signed-cid/src/eip712.ts
+++ b/packages/signed-cid/src/eip712.ts
@@ -19,7 +19,7 @@ type Codec = { name: string; code: number; encode: (value: any) => Iterable<Uint
  * statically typed to a specific action schema beforehand. See
  * @canvas-js/ethereum-contracts for examples.
  */
-export const encode = (message: Message<Action | Session>) => {
+export const encode = (message: Message<Action | Session>): Uint8Array => {
 	let hashedPayload: string
 	if (message.payload.type === "session") {
 		const types = {
@@ -92,7 +92,7 @@ export const encode = (message: Message<Action | Session>) => {
 	} else {
 		throw new TypeError("invalid payload type")
 	}
-	return [getBytes(hashedPayload)]
+	return getBytes(hashedPayload)
 }
 
 /**

--- a/packages/signed-cid/src/eip712Codec.ts
+++ b/packages/signed-cid/src/eip712Codec.ts
@@ -6,105 +6,97 @@ import { Action, Message, Session } from "@canvas-js/interfaces"
 type Codec = { name: string; code: number; encode: (value: any) => Iterable<Uint8Array> }
 
 /**
- * This codec generates CIDs for (a subset of) JSON objects using
- * ABI encoding, and TypedDataEncoder for hashing.
+ * Encode `Message<Action | Session>` using Ethereum typed data encoding.
  *
- * Objects may contain nested objects, address strings, strings, numbers,
- * or booleans, which are mapped to `bytes`, `address`, `string`, `int256`,
- * or `bool` respectively.
- *
- * We enforce that numbers are integers, and 40-byte-long strings beginning
- * with "0x" are always encoded as addresses.
- *
+ * Messages may contain dynamically typed data:
+ * - Objects may contain nested objects, strings, numbers, or booleans.
+ *   These are encoded as `bytes`, `string`, `int256`, and `bool`.
+ * - Numbers must be integers.
+ * - 40-byte-long hex strings (starting with "0x") are encoded as `address`.
  *
  * While the codec is implemented for dynamically typed data, if you are
  * writing an onchain verifier for offchain signed data, it must still be
  * statically typed to a specific action schema beforehand. See
  * @canvas-js/ethereum-contracts for examples.
  */
-export const eip712Codec: Codec = {
-	name: "eip712",
-	code: 712,
-	encode: (message: Message<Action | Session>) => {
-		let hashedPayload: string
-		if (message.payload.type === "session") {
-			const types = {
-				Message: [
-					{ name: "clock", type: "uint256" },
-					{ name: "parents", type: "string[]" },
-					{ name: "payload", type: "Session" },
-					{ name: "topic", type: "string" },
-				],
-				Session: [
-					{ name: "address", type: "address" },
-					{ name: "blockhash", type: "string" },
-					{ name: "duration", type: "uint256" },
-					{ name: "publicKey", type: "string" },
-					{ name: "timestamp", type: "uint256" },
-				],
-			}
-			hashedPayload = TypedDataEncoder.hash(
-				{
-					name: message.topic,
-				},
-				types,
-				{
-					clock: message.clock,
-					parents: message.parents,
-					payload: {
-						address: message.payload.address.split(":")[2],
-						publicKey: message.payload.publicKey,
-						blockhash: message.payload.blockhash,
-						timestamp: message.payload.timestamp,
-						duration: message.payload.duration,
-					},
-					topic: message.topic,
-				},
-			)
-		} else if (message.payload.type === "action") {
-			const types = {
-				Message: [
-					{ name: "clock", type: "uint256" },
-					{ name: "parents", type: "string[]" },
-					{ name: "payload", type: "Action" },
-					{ name: "topic", type: "string" },
-				],
-				Action: [
-					{ name: "address", type: "address" },
-					{ name: "args", type: "bytes" },
-					{ name: "blockhash", type: "string" },
-					{ name: "name", type: "string" },
-					{ name: "timestamp", type: "uint256" },
-				],
-			}
-			hashedPayload = TypedDataEncoder.hash(
-				{
-					name: message.topic,
-				},
-				types,
-				{
-					clock: message.clock,
-					parents: message.parents,
-					payload: {
-						name: message.payload.name,
-						args: getAbiString(message.payload.args),
-						address: message.payload.address.split(":")[2],
-						blockhash: message.payload.blockhash || "",
-						timestamp: message.payload.timestamp,
-					},
-					topic: message.topic,
-				},
-			)
-		} else {
-			throw new TypeError("invalid payload type")
+export const encode = (message: Message<Action | Session>) => {
+	let hashedPayload: string
+	if (message.payload.type === "session") {
+		const types = {
+			Message: [
+				{ name: "clock", type: "uint256" },
+				{ name: "parents", type: "string[]" },
+				{ name: "payload", type: "Session" },
+				{ name: "topic", type: "string" },
+			],
+			Session: [
+				{ name: "address", type: "address" },
+				{ name: "blockhash", type: "string" },
+				{ name: "duration", type: "uint256" },
+				{ name: "publicKey", type: "string" },
+				{ name: "timestamp", type: "uint256" },
+			],
 		}
-		return [getBytes(hashedPayload)]
-	},
+		hashedPayload = TypedDataEncoder.hash(
+			{
+				name: message.topic,
+			},
+			types,
+			{
+				clock: message.clock,
+				parents: message.parents,
+				payload: {
+					address: message.payload.address.split(":")[2],
+					publicKey: message.payload.publicKey,
+					blockhash: message.payload.blockhash,
+					timestamp: message.payload.timestamp,
+					duration: message.payload.duration,
+				},
+				topic: message.topic,
+			},
+		)
+	} else if (message.payload.type === "action") {
+		const types = {
+			Message: [
+				{ name: "clock", type: "uint256" },
+				{ name: "parents", type: "string[]" },
+				{ name: "payload", type: "Action" },
+				{ name: "topic", type: "string" },
+			],
+			Action: [
+				{ name: "address", type: "address" },
+				{ name: "args", type: "bytes" },
+				{ name: "blockhash", type: "string" },
+				{ name: "name", type: "string" },
+				{ name: "timestamp", type: "uint256" },
+			],
+		}
+		hashedPayload = TypedDataEncoder.hash(
+			{
+				name: message.topic,
+			},
+			types,
+			{
+				clock: message.clock,
+				parents: message.parents,
+				payload: {
+					name: message.payload.name,
+					args: getAbiString(message.payload.args),
+					address: message.payload.address.split(":")[2],
+					blockhash: message.payload.blockhash || "",
+					timestamp: message.payload.timestamp,
+				},
+				topic: message.topic,
+			},
+		)
+	} else {
+		throw new TypeError("invalid payload type")
+	}
+	return [getBytes(hashedPayload)]
 }
 
 /**
- * Encode an argument object `Record<string, any>` as an
- * ABI-encoded bytestring.
+ * Encode an argument object `Record<string, any>` as an ABI-encoded bytestring.
  */
 export function getAbiString(args: Record<string, any>): string {
 	const { types, values } = getEIP712Args(args)
@@ -112,11 +104,7 @@ export function getAbiString(args: Record<string, any>): string {
 }
 
 /**
- * Convert an argument object `Record<string, any>` to a
- * set of EIP712-compatible types.
- *
- * This is exposed separately from `abiEncodeArgs` so both are
- * available for tests.
+ * Convert an argument object `Record<string, any>` to EIP712-compatible types.
  */
 export function getEIP712Args(args: Record<string, any>) {
 	const sortedArgs = Object.keys(args).sort()
@@ -135,8 +123,7 @@ export function getEIP712Args(args: Record<string, any>) {
 }
 
 /**
- * Get the type of a dynamically typed JS argument for typehash
- * generation.
+ * Convert a JS type to an EIP712-compatible type.
  */
 function getAbiTypeForValue(value: any) {
 	if (typeof value === "string") {
@@ -146,11 +133,10 @@ function getAbiTypeForValue(value: any) {
 			return "string"
 		}
 	} else if (typeof value === "number") {
-		// if is integer
 		if (Number.isInteger(value)) {
 			return "int256"
 		} else {
-			throw new TypeError(`non-integer numbers are not yet supported`)
+			throw new TypeError(`cannot encode floats`)
 		}
 	} else if (typeof value === "boolean") {
 		return "bool"

--- a/packages/signed-cid/src/index.ts
+++ b/packages/signed-cid/src/index.ts
@@ -1,6 +1,6 @@
 export type { Signature, Signer } from "@canvas-js/interfaces"
 
-export * from "./eip712Codec.js"
+export { getAbiString, getEIP712Args, encode as eip712Encode } from "./eip712.js"
 export * from "./Ed25519Signer.js"
 export * from "./Secp256k1Signer.js"
 export * from "./verify.js"


### PR DESCRIPTION
- Use `code = 0x55` raw multicodec for EIP712 signed data.
- Move EIP712 serialization and hashing logic out of the codec. EIP712 serialization now happens inside getCID() if the codec and digest used are `raw`. This means that we only need to provide EIP712Signer as a signer to process signed actions in its format.
- Applications *should not* mix onchain and offchain signers. If we want to support that use case, we can extend the signer matching function inside core/src/runtime/AbstractRuntime.ts to also pass a signed-CID to the matching function. Signed-CIDs are signatures, after all.
- Add EIP712 test to packages/core. No tests for rejecting invalid signatures/actions/sessions yet

## How has this been tested?

- [X] CI tests pass
- [X] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

This changes data encoding formats for EIP712 signers which have not been released.