### PR TITLE
add ethers 6 dependency to chain-cosmos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32357,6 +32357,7 @@
         "@libp2p/logger": "^4.0.2",
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.2",
+        "ethers": "^6.9.0",
         "multiformats": "^13.0.1"
       }
     },

--- a/packages/chain-cosmos/package.json
+++ b/packages/chain-cosmos/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
+    "ethers": "^6.9.0",
     "@canvas-js/interfaces": "0.8.26",
     "@canvas-js/signed-cid": "0.8.26",
     "@cosmjs/amino": "^0.30.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above, and a description here -->

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
