### PR TITLE
[CANV-243] remove unused models from encrypted-chat

### DIFF
--- a/examples/encrypted-chat/src/App.tsx
+++ b/examples/encrypted-chat/src/App.tsx
@@ -36,13 +36,6 @@ const useChat = (topic: string, wallet: ethers.Wallet) => {
 					groupKeys: "string",
 					key: "string",
 				},
-				messages: {
-					id: "primary",
-					address: "string",
-					text: "string",
-					timestamp: "string",
-					$indexes: [["timestamp"] /*["address", "timestamp"]*/],
-				},
 				privateMessages: {
 					id: "primary",
 					ciphertext: "string",
@@ -66,9 +59,6 @@ const useChat = (topic: string, wallet: ethers.Wallet) => {
 						key: groupPublicKey,
 					})
 				},
-				sendLobbyMessage: (db, { text }, { address, timestamp, id }) => {
-					db.set("messages", { msgid: id, address: address, text, timestamp })
-				},
 				sendPrivateMessage: (db, { group, ciphertext }, { timestamp, id }) => {
 					// TODO: check address is in group
 					db.set("privateMessages", { id, ciphertext, group, timestamp })
@@ -78,16 +68,11 @@ const useChat = (topic: string, wallet: ethers.Wallet) => {
 	})
 
 	const people = useLiveQuery(app, "encryptionKeys", { orderBy: { address: "desc" } })
-	// const lobby = useLiveQuery(app, "messages", { orderBy: { timestamp: "desc" } })
 
 	return {
 		wallet,
 		app,
 		people,
-		sendLobbyMessage: async (message: string) => {
-			if (!app) throw new Error()
-			return app.actions.sendLobbyMessage(message)
-		},
 		registerEncryptionKey: async (privateKey: string) => {
 			if (!app) throw new Error()
 			const key = getEncryptionPublicKey(privateKey.slice(2))
@@ -136,12 +121,6 @@ const useChat = (topic: string, wallet: ethers.Wallet) => {
 		},
 	}
 }
-
-// const chat = useChat('my-app', mud.burnerWallet.privateKey)
-// chat.sendLobbyMessage('hi')
-// chat.sendPrivateMessage('hey whats going on', theirAddress)
-// const messages = useLobby() // useLobbyConversation?
-// const privateMessages = usePrivateMessages() // does this need separate hooks for DMSelector, DMConversation?
 
 function Wrapper() {
 	const privkey1 = usePrivkey("wallet-privkey1")


### PR DESCRIPTION
Cleaning up some models, actions, and unused code in examples/encrypted-chat

## How has this been tested?

- [/] CI tests pass
  - No tests for this example
- [/] Tested with example-chat (including login, all signers, and exchanging messages)
  - Example-chat still broken :/
- [/] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [X] Contract interfaces
- [X] Core interface
- [X] CLI
- [X] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
