### PR TITLE
make getCachedSession a public function

### DIFF
--- a/packages/interfaces/src/SessionSigner.ts
+++ b/packages/interfaces/src/SessionSigner.ts
@@ -26,6 +26,18 @@ export interface SessionSigner<AuthorizationData = any>
 	) => Awaitable<Session<AuthorizationData>>
 
 	/**
+	 * `getCachedSession` returns the stored `Session` and `Signer` for a given topic and
+	 * address. This can be used by applications to check if a user has already authorised
+	 * Canvas to sign actions.
+	 *
+	 * Note that `getCachedSession` does not check if the `Session` has expired.
+	 */
+	getCachedSession(
+		topic: string,
+		address: string,
+	): { session: Session; signer: Signer<Action | Session<AuthorizationData>> } | null
+
+	/**
 	 * Verify that `session.data` authorizes `session.publicKey`
 	 * to take actions on behalf of the user `${session.chain}:${session.address}`
 	 */

--- a/packages/signatures/src/AbstractSessionSigner.ts
+++ b/packages/signatures/src/AbstractSessionSigner.ts
@@ -116,7 +116,7 @@ export abstract class AbstractSessionSigner<AuthorizationData> implements Sessio
 
 	private getSessionKey = (topic: string, address: string) => `canvas/${topic}/${address}`
 
-	private getCachedSession(
+	public getCachedSession(
 		topic: string,
 		address: string,
 	): { session: Session; signer: Signer<Action | Session<AuthorizationData>> } | null {


### PR DESCRIPTION
This is needed for https://github.com/hicommonwealth/commonwealth/pull/6867

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
