### PR TITLE
Update CosmosSigner to support `signArbitrary`, add Leap wallet to chat app

### DIFF
--- a/examples/chat/src/connect/ConnectLeap.tsx
+++ b/examples/chat/src/connect/ConnectLeap.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useContext, useState } from "react"
+
+import { CosmosSigner } from "@canvas-js/chain-cosmos"
+
+import { AppContext } from "../AppContext.js"
+
+export interface ConnectLeapProps {
+	chainId: string
+}
+
+declare global {
+	interface Window {
+		leap?: any
+	}
+}
+
+export const ConnectLeap: React.FC<ConnectLeapProps> = ({ chainId }) => {
+	const { app, sessionSigner, setSessionSigner, address, setAddress } = useContext(AppContext)
+
+	// true if this signing method is being used
+	const [thisIsConnected, setThisIsConnected] = useState(false)
+
+	const [error, setError] = useState<Error | null>(null)
+
+	const connect = useCallback(async () => {
+		const leap = window.leap
+		if (!leap) {
+			setError(new Error("window.leap not found"))
+			return
+		}
+
+		await leap.enable(chainId)
+
+		const key = await leap.getKey(chainId)
+
+		setAddress(key.bech32Address)
+
+		setSessionSigner(
+			new CosmosSigner({
+				signer: {
+					type: "arbitrary",
+					signArbitrary: (msg) => leap.signArbitrary(chainId, key.bech32Address, msg),
+					getAddress: async () => key.bech32Address,
+					getChainId: async () => chainId,
+				},
+			}),
+		)
+		console.log("5")
+		setThisIsConnected(true)
+		console.log("6")
+	}, [])
+
+	const disconnect = useCallback(async () => {
+		setAddress(null)
+		setSessionSigner(null)
+		setThisIsConnected(false)
+	}, [sessionSigner])
+
+	if (error !== null) {
+		return (
+			<div className="p-2 border rounded bg-red-100 text-sm">
+				<code>{error.message}</code>
+			</div>
+		)
+	} else if (address !== null && thisIsConnected) {
+		return (
+			<button
+				onClick={() => disconnect()}
+				className="p-2 border rounded hover:cursor-pointer hover:bg-gray-100 active:bg-gray-200"
+			>
+				Disconnect Leap wallet
+			</button>
+		)
+	} else {
+		return (
+			<button
+				onClick={() => connect()}
+				className="p-2 border rounded hover:cursor-pointer hover:bg-gray-100 active:bg-gray-200"
+			>
+				Connect Leap wallet
+			</button>
+		)
+	}
+}

--- a/examples/chat/src/connect/index.tsx
+++ b/examples/chat/src/connect/index.tsx
@@ -14,6 +14,7 @@ import { ConnectPolkadot } from "./ConnectPolkadot.js"
 import { ConnectSolana } from "./ConnectSolana.js"
 import { ConnectNEAR } from "./ConnectNEAR.js"
 import { ConnectMagic } from "./ConnectMagic.js"
+import { ConnectLeap } from "./ConnectLeap.js"
 
 export const Connect: React.FC<{}> = ({}) => {
 	const [method, setMethod] = useState("burner")
@@ -38,6 +39,7 @@ export const Connect: React.FC<{}> = ({}) => {
 				<option value="terra">Terra</option>
 				<option value="cosmos-evm">Cosmos/EVM</option>
 				<option value="bluesky">BlueSky</option>
+				<option value="leap">Leap</option>
 				<option value="magic">Magic</option>
 			</select>
 			<Method method={method} />
@@ -73,6 +75,8 @@ const Method: React.FC<{ method: string }> = (props) => {
 			return <ConnectCosmosEvmMetamask chainId="osmosis-1" />
 		case "bluesky":
 			return <ConnectATP />
+		case "leap":
+			return <ConnectLeap chainId="osmosis-1" />
 		case "magic":
 			return (
 				<ConnectMagic

--- a/packages/chain-cosmos/src/external_signers/amino.ts
+++ b/packages/chain-cosmos/src/external_signers/amino.ts
@@ -21,7 +21,7 @@ export const createAminoSigner = (signer: AminoSigner) => ({
 	getChainId: signer.getChainId,
 	sign: async (cosmosMessage: CosmosMessage, address: string, chainId: string) => {
 		const msg = cbor.encode(cosmosMessage)
-		const signDoc = await getSessionSignatureData(msg, address)
+		const signDoc = getSessionSignatureData(msg, address)
 		const signRes = await signer.signAmino(chainId, address, signDoc)
 		const stdSig = signRes.signature
 
@@ -38,7 +38,7 @@ export const verifyAmino = async (message: CosmosMessage, { signature }: AminoSi
 
 	// the payload can either be signed directly, or encapsulated in a SignDoc
 	const encodedMessage = cbor.encode(message)
-	const signDocPayload = await getSessionSignatureData(encodedMessage, walletAddress)
+	const signDocPayload = getSessionSignatureData(encodedMessage, walletAddress)
 	const signDocDigest = sha256(serializeSignDoc(signDocPayload))
 
 	// try with both values of the recovery bit

--- a/packages/chain-cosmos/src/external_signers/amino.ts
+++ b/packages/chain-cosmos/src/external_signers/amino.ts
@@ -55,3 +55,7 @@ export const verifyAmino = async (message: CosmosMessage, { signature }: AminoSi
 }
 
 export type AminoSignedSessionData = Awaited<ReturnType<ReturnType<typeof createAminoSigner>["sign"]>>
+
+export function validateAminoSignedSessionData(data: any): data is AminoSignedSessionData {
+	return data.signatureType == "amino" && data.signature instanceof Uint8Array
+}

--- a/packages/chain-cosmos/src/external_signers/arbitrary.ts
+++ b/packages/chain-cosmos/src/external_signers/arbitrary.ts
@@ -5,7 +5,19 @@ import { fromBase64 } from "@cosmjs/encoding"
 import { getSessionSignatureData } from "../signatureData.js"
 
 const createSiwxMessage = (message: CosmosMessage): string => {
-	return "siwx message"
+	// this is a SIWX-style message that will be signed and displayed to the user when they sign in
+	// see https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-122.md
+	// there is no set format for this message, but it should be human-readable and contain all of the
+	// fields in the `CosmosMessage` object
+	return `
+	A Canvas app with Topic: ${message.topic} wants you to sign in with your Cosmos wallet.
+	Address: ${message.address}
+	Public Key: ${message.publicKey}
+
+	Issued At: ${message.issuedAt}
+	Expiration Time: ${message.expirationTime}
+	Chain ID: ${message.chainId}
+	`
 }
 
 export type ArbitrarySigner = {
@@ -28,10 +40,8 @@ export const createArbitrarySigner = (signer: ArbitrarySigner) => ({
 		// make SIWx message
 		const siwxMessage = createSiwxMessage(cosmosMessage)
 		// call sign
-		const res = await signer.signArbitrary(siwxMessage)
-		console.log(res)
 		return {
-			signature: res,
+			signature: await signer.signArbitrary(siwxMessage),
 			signatureType: "arbitrary" as const,
 		}
 	},

--- a/packages/chain-cosmos/src/external_signers/arbitrary.ts
+++ b/packages/chain-cosmos/src/external_signers/arbitrary.ts
@@ -1,8 +1,8 @@
 import { Secp256k1, Secp256k1Signature, Sha256 } from "@cosmjs/crypto"
 import { CosmosMessage } from "../types.js"
-import { getAdr036SignablePayload } from "./getAdr036SignablePayload.js"
 import { serializeSignDoc } from "@cosmjs/amino"
 import { fromBase64 } from "@cosmjs/encoding"
+import { getSessionSignatureData } from "../signatureData.js"
 
 const createSiwxMessage = (message: CosmosMessage): string => {
 	return "siwx message"
@@ -40,7 +40,7 @@ export const createArbitrarySigner = (signer: ArbitrarySigner) => ({
 export const verifyArbitrary = async (message: CosmosMessage, sessionData: ArbitrarySignedSessionData) => {
 	const siwxMessage = createSiwxMessage(message)
 	// how is the string encoded?
-	const signDoc = getAdr036SignablePayload(new TextEncoder().encode(siwxMessage), message.address)
+	const signDoc = getSessionSignatureData(new TextEncoder().encode(siwxMessage), message.address)
 
 	const { signature, pub_key } = sessionData.signature
 	const secpSignature = Secp256k1Signature.fromFixedLength(fromBase64(signature))

--- a/packages/chain-cosmos/src/external_signers/arbitrary.ts
+++ b/packages/chain-cosmos/src/external_signers/arbitrary.ts
@@ -1,0 +1,63 @@
+import { Secp256k1, Secp256k1Signature, Sha256 } from "@cosmjs/crypto"
+import { CosmosMessage } from "../types.js"
+import { getAdr036SignablePayload } from "./getAdr036SignablePayload.js"
+import { serializeSignDoc } from "@cosmjs/amino"
+import { fromBase64 } from "@cosmjs/encoding"
+
+const createSiwxMessage = (message: CosmosMessage): string => {
+	return "siwx message"
+}
+
+export type ArbitrarySigner = {
+	type: "arbitrary"
+	getAddress: (chainId: string) => Promise<string>
+	getChainId: () => Promise<string>
+	signArbitrary: (msg: string) => Promise<{
+		pub_key: {
+			type: string
+			value: string
+		}
+		signature: string
+	}>
+}
+
+export const createArbitrarySigner = (signer: ArbitrarySigner) => ({
+	getAddress: signer.getAddress,
+	getChainId: signer.getChainId,
+	sign: async (cosmosMessage: CosmosMessage) => {
+		// make SIWx message
+		const siwxMessage = createSiwxMessage(cosmosMessage)
+		// call sign
+		const res = await signer.signArbitrary(siwxMessage)
+		console.log(res)
+		return {
+			signature: res,
+			signatureType: "arbitrary" as const,
+		}
+	},
+})
+
+export const verifyArbitrary = async (message: CosmosMessage, sessionData: ArbitrarySignedSessionData) => {
+	const siwxMessage = createSiwxMessage(message)
+	// how is the string encoded?
+	const signDoc = getAdr036SignablePayload(new TextEncoder().encode(siwxMessage), message.address)
+
+	const { signature, pub_key } = sessionData.signature
+	const secpSignature = Secp256k1Signature.fromFixedLength(fromBase64(signature))
+	const messageHash = new Sha256(serializeSignDoc(signDoc)).digest()
+	const isValid = await Secp256k1.verifySignature(secpSignature, messageHash, fromBase64(pub_key.value))
+	if (!isValid) {
+		throw Error("not valid")
+	}
+}
+
+export type ArbitrarySignedSessionData = Awaited<ReturnType<ReturnType<typeof createArbitrarySigner>["sign"]>>
+
+export function validateArbitrarySignedSessionData(data: any): data is ArbitrarySignedSessionData {
+	return (
+		data.signatureType == "arbitrary" &&
+		data.signature instanceof Object &&
+		typeof data.signature.pub_key === "object" &&
+		typeof data.signature.signature === "string"
+	)
+}

--- a/packages/chain-cosmos/src/external_signers/bytes.ts
+++ b/packages/chain-cosmos/src/external_signers/bytes.ts
@@ -47,3 +47,14 @@ export const verifyBytes = (message: CosmosMessage, sessionData: BytesSignedSess
 }
 
 export type BytesSignedSessionData = Awaited<ReturnType<ReturnType<typeof createBytesSigner>["sign"]>>
+
+export function validateBytesSignedSessionData(data: any): data is BytesSignedSessionData {
+	return (
+		data.signatureType == "bytes" &&
+		data.signature instanceof Uint8Array &&
+		data.signature.pub_key instanceof Object &&
+		data.signature.pub_key.value instanceof Uint8Array &&
+		typeof data.signature.pub_key.type === "string" &&
+		data.signature.pub_key.type == pubkeyType.secp256k1
+	)
+}

--- a/packages/chain-cosmos/src/external_signers/ethereum.ts
+++ b/packages/chain-cosmos/src/external_signers/ethereum.ts
@@ -53,3 +53,7 @@ export const verifyEthereum = (message: CosmosMessage, sessionData: EthereumSign
 }
 
 export type EthereumSignedSessionData = Awaited<ReturnType<ReturnType<typeof createEthereumSigner>["sign"]>>
+
+export function validateEthereumSignedSessionData(data: any): data is EthereumSignedSessionData {
+	return data.signatureType == "ethereum" && data.signature instanceof Uint8Array
+}

--- a/packages/chain-cosmos/src/signatureData.ts
+++ b/packages/chain-cosmos/src/signatureData.ts
@@ -1,12 +1,8 @@
-import type { AminoMsg, StdSignDoc, StdFee } from "@cosmjs/amino"
+import type { AminoMsg, StdFee } from "@cosmjs/amino"
 import { makeSignDoc } from "@cosmjs/amino"
 import { toBase64 } from "@cosmjs/encoding"
 
-export const getSessionSignatureData = async (
-	sessionPayload: Uint8Array,
-	address: string,
-	chain_id?: string,
-): Promise<StdSignDoc> => {
+export const getSessionSignatureData = (sessionPayload: Uint8Array, address: string, chain_id?: string) => {
 	const accountNumber = 0
 	const sequence = 0
 	const chainId = chain_id ?? ""

--- a/packages/chain-cosmos/src/types.ts
+++ b/packages/chain-cosmos/src/types.ts
@@ -1,6 +1,7 @@
 import type { EthereumSignedSessionData, EthereumSigner } from "./external_signers/ethereum.js"
 import type { BytesSignedSessionData, BytesSigner } from "./external_signers/bytes.js"
 import type { AminoSignedSessionData, AminoSigner } from "./external_signers/amino.js"
+import { ArbitrarySignedSessionData, ArbitrarySigner } from "./external_signers/arbitrary.js"
 
 export type CosmosMessage = {
 	topic: string
@@ -11,6 +12,10 @@ export type CosmosMessage = {
 	expirationTime: string | null
 }
 
-export type CosmosSessionData = EthereumSignedSessionData | BytesSignedSessionData | AminoSignedSessionData
+export type CosmosSessionData =
+	| EthereumSignedSessionData
+	| BytesSignedSessionData
+	| AminoSignedSessionData
+	| ArbitrarySignedSessionData
 
-export type ExternalCosmosSigner = EthereumSigner | AminoSigner | BytesSigner
+export type ExternalCosmosSigner = EthereumSigner | AminoSigner | BytesSigner | ArbitrarySigner

--- a/packages/chain-cosmos/src/utils.ts
+++ b/packages/chain-cosmos/src/utils.ts
@@ -1,3 +1,4 @@
+import { EthereumSignedSessionData } from "./external_signers/ethereum.js"
 import type { CosmosSessionData } from "./types.js"
 
 export const addressPattern = /^cosmos:([0-9a-z\-_]+):([a-zA-Fa-f0-9]+)$/
@@ -10,16 +11,6 @@ export function parseAddress(address: string): [chain: string, walletAddress: st
 
 	const [_, chain, walletAddress] = result
 	return [chain, walletAddress]
-}
-
-export function validateSessionData(data: unknown): data is CosmosSessionData {
-	try {
-		extractSessionData(data)
-	} catch (error) {
-		return false
-	}
-
-	return true
 }
 
 function extractSessionData(data: any): CosmosSessionData {
@@ -58,6 +49,20 @@ function extractSessionData(data: any): CosmosSessionData {
 			return {
 				signatureType: "ethereum",
 				signature: signature,
+			}
+		}
+	} else if (data.signatureType == "arbitrary") {
+		const signature = data.signature
+		if (signature.pub_key instanceof Object && signature.signature instanceof Uint8Array) {
+			return {
+				signatureType: "arbitrary",
+				signature: {
+					pub_key: {
+						type: signature.pub_key.type,
+						value: signature.pub_key.value,
+					},
+					signature: signature.signature,
+				},
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds an `arbitrary` signature type to `CosmosSigner`, so called because it uses the `signArbitrary` method that is available in Keplr and Leap wallet. `signArbitrary` takes a string and wraps it in an ADR-36 message. The string we display is a SIWX-style message (no official SIWX spec exists for Cosmos), e.g.
<img width="381" alt="Screenshot 2024-03-26 at 1 23 50 pm" src="https://github.com/canvasxyz/canvas/assets/457206/eaf68b7f-5962-4703-8672-3df9ec67aa8f">

To test this, I have added Leap wallet to the chat app using `signArbitrary`. I've also tested this out in my working branch on the Commonwealth project.

## How has this been tested?

- [x] CI tests pass
- [x] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
