### PR TITLE
packages/core: Postgres Core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
 
       - name: Run @canvas-js/core tests
         run: npm run test --workspace=@canvas-js/core
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
 
       - name: Run @canvas-js/vm tests
         run: npm run test --workspace=@canvas-js/vm

--- a/package-lock.json
+++ b/package-lock.json
@@ -32347,6 +32347,7 @@
         "microcbor": "^0.3.0",
         "multiformats": "^13.0.1",
         "p-queue": "^8.0.0",
+        "pg": "^8.11.3",
         "prom-client": "^15.0.0",
         "quickjs-emscripten": "^0.26.0",
         "uint8arraylist": "^2.4.7",
@@ -32354,6 +32355,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.10.4",
+        "@types/pg": "^8.11.4",
         "dotenv": "^16.3.1",
         "nanoid": "^5.0.4",
         "p-defer": "^4.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,6 +72,7 @@
 		"microcbor": "^0.3.0",
 		"multiformats": "^13.0.1",
 		"p-queue": "^8.0.0",
+		"pg": "^8.11.3",
 		"prom-client": "^15.0.0",
 		"quickjs-emscripten": "^0.26.0",
 		"uint8arraylist": "^2.4.7",
@@ -79,6 +80,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^20.10.4",
+		"@types/pg": "^8.11.4",
 		"dotenv": "^16.3.1",
 		"nanoid": "^5.0.4",
 		"p-defer": "^4.0.0",

--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -4,6 +4,8 @@ import { logger } from "@libp2p/logger"
 import * as cbor from "@ipld/dag-cbor"
 import { hexToBytes } from "@noble/hashes/utils"
 
+import type pg from "pg"
+
 import { Signature, Action, Session, Message, Signer, SessionSigner, SignerCache } from "@canvas-js/interfaces"
 import { AbstractModelDB, Model } from "@canvas-js/modeldb"
 import { SIWESigner } from "@canvas-js/chain-ethereum"
@@ -45,8 +47,8 @@ export interface CanvasConfig<T extends Contract = Contract> extends NetworkConf
 	contract: string | T
 	signers?: SessionSigner[]
 
-	/** data directory path (NodeJS only) */
-	path?: string | null
+	/** data directory path (NodeJS/sqlite), or postgres connection config (NodeJS/pg) */
+	path?: string | pg.ConnectionConfig | null
 
 	/** provide an existing libp2p instance instead of creating a new one */
 	libp2p?: Libp2p<ServiceMap>
@@ -145,8 +147,8 @@ export class Canvas<T extends Contract = Contract> extends TypedEventEmitter<Can
 		[K in keyof T["actions"]]: T["actions"][K] extends ActionImplementationFunction<infer Args, infer Result>
 			? ActionAPI<Args, Result>
 			: T["actions"][K] extends ActionImplementationObject<infer Args, infer Result>
-			? ActionAPI<Args, Result>
-			: never
+				? ActionAPI<Args, Result>
+				: never
 	}
 
 	public readonly connections: Connections = {}

--- a/packages/core/src/runtime/ContractRuntime.ts
+++ b/packages/core/src/runtime/ContractRuntime.ts
@@ -1,6 +1,7 @@
 import { QuickJSHandle } from "quickjs-emscripten"
 import { TypeTransformerFunction, create } from "@ipld/schema/typed.js"
 import { fromDSL } from "@ipld/schema/from-dsl.js"
+import type pg from "pg"
 
 import type { SignerCache } from "@canvas-js/interfaces"
 
@@ -18,7 +19,7 @@ import { bytesToHex } from "@noble/hashes/utils"
 
 export class ContractRuntime extends AbstractRuntime {
 	public static async init(
-		path: string | null,
+		path: string | pg.ConnectionConfig | null,
 		signers: SignerCache,
 		contract: string,
 		options: { runtimeMemoryLimit?: number; indexHistory?: boolean; ignoreMissingActions?: boolean } = {},

--- a/packages/core/src/runtime/FunctionRuntime.ts
+++ b/packages/core/src/runtime/FunctionRuntime.ts
@@ -1,5 +1,6 @@
 import { TypeTransformerFunction, create } from "@ipld/schema/typed.js"
 import { fromDSL } from "@ipld/schema/from-dsl.js"
+import type pg from "pg"
 
 import type { SignerCache } from "@canvas-js/interfaces"
 import { AbstractModelDB, ModelValue, validateModelValue } from "@canvas-js/modeldb"
@@ -15,7 +16,7 @@ const identity = (x: any) => x
 
 export class FunctionRuntime extends AbstractRuntime {
 	public static async init(
-		path: string | null,
+		path: string | pg.ConnectionConfig | null,
 		signers: SignerCache,
 		contract: Contract,
 		options: { indexHistory?: boolean; ignoreMissingActions?: boolean } = {},

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,4 +1,5 @@
 import { SignerCache } from "@canvas-js/interfaces"
+import type pg from 'pg'
 
 import type { Contract } from "../types.js"
 import { AbstractRuntime } from "./AbstractRuntime.js"
@@ -8,7 +9,7 @@ import { FunctionRuntime } from "./FunctionRuntime.js"
 export { AbstractRuntime as Runtime } from "./AbstractRuntime.js"
 
 export async function createRuntime(
-	location: string | null,
+	location: string | pg.ConnectionConfig | null,
 	signers: SignerCache,
 	contract: string | Contract,
 	options: { runtimeMemoryLimit?: number; indexHistory?: boolean; ignoreMissingActions?: boolean } = {},

--- a/packages/core/src/targets/default/index.ts
+++ b/packages/core/src/targets/default/index.ts
@@ -1,6 +1,7 @@
 import type { Libp2p } from "libp2p"
 import type { PeerId } from "@libp2p/interface"
 import type { GossipLogInit } from "@canvas-js/gossiplog"
+import type pg from 'pg'
 import type { PlatformTarget, ServiceMap } from "../interface.js"
 
 export default {
@@ -9,13 +10,13 @@ export default {
 	},
 
 	async openGossipLog<Payload, Result>(
-		location: { path: string | null; topic: string },
+		location: { path: string | pg.ConnectionConfig | null; topic: string },
 		init: GossipLogInit<Payload, Result>,
 	) {
 		throw new Error("Unsupported platform")
 	},
 
-	async createLibp2p(location: { topic: string; path: string | null }, options): Promise<Libp2p<ServiceMap>> {
+	async createLibp2p(location: { topic: string; path: string | pg.ConnectionConfig | null }, options): Promise<Libp2p<ServiceMap>> {
 		throw new Error("Unsupported platform")
 	},
 } satisfies PlatformTarget

--- a/packages/core/src/targets/interface.ts
+++ b/packages/core/src/targets/interface.ts
@@ -4,6 +4,8 @@ import type { Fetch as FetchService } from "@libp2p/fetch"
 import type { PubSub } from "@libp2p/interface"
 import type { GossipsubEvents } from "@chainsafe/libp2p-gossipsub"
 
+import type pg from 'pg'
+
 import type { AbstractModelDB, ModelsInit } from "@canvas-js/modeldb"
 import type { AbstractGossipLog, GossipLogInit } from "@canvas-js/gossiplog"
 import type { GossipLogService } from "@canvas-js/gossiplog/service"
@@ -14,18 +16,18 @@ import type { NetworkConfig } from "../Canvas.js"
 
 export interface PlatformTarget {
 	createLibp2p: (
-		location: { path: string | null; topic: string },
+		location: { path: string | pg.ConnectionConfig | null; topic: string },
 		config: NetworkConfig & { signers: SignerCache },
 	) => Promise<Libp2p<ServiceMap>>
 
 	openDB: (
-		location: { path: string | null; topic: string },
+		location: { path: string | pg.ConnectionConfig | null; topic: string },
 		models: ModelsInit,
 		options?: { indexHistory?: Record<string, boolean> },
 	) => Promise<AbstractModelDB>
 
 	openGossipLog: <Payload, Result>(
-		location: { path: string | null; topic: string },
+		location: { path: string | pg.ConnectionConfig | null; topic: string },
 		init: GossipLogInit<Payload, Result>,
 	) => Promise<AbstractGossipLog<Payload, Result>>
 }

--- a/packages/core/src/targets/node/index.ts
+++ b/packages/core/src/targets/node/index.ts
@@ -1,5 +1,6 @@
 import path from "node:path"
 import fs from "node:fs"
+import type pg from 'pg'
 
 import { createEd25519PeerId, createFromProtobuf, exportToProtobuf } from "@libp2p/peer-id-factory"
 import { PeerId } from "@libp2p/interface"
@@ -8,30 +9,38 @@ import { createLibp2p } from "libp2p"
 import { GossipLogInit } from "@canvas-js/gossiplog"
 import { GossipLog } from "@canvas-js/gossiplog/node"
 import { GossipLog as MemoryGossipLog } from "@canvas-js/gossiplog/memory"
+import { GossipLog as PostgresGossipLog } from "@canvas-js/gossiplog/pg"
 import { ModelDB } from "@canvas-js/modeldb/sqlite"
+import { ModelDB as PostgresModelDB } from "@canvas-js/modeldb/pg"
 
 import type { PlatformTarget } from "../interface.js"
 import { getLibp2pOptions } from "./libp2p.js"
 
 const PEER_ID_FILENAME = ".peer-id"
 
+const isPostgres = (path: string) => path.startsWith("postgres://") || path.startsWith("postgresql://")
+
 export default {
-	async openDB(location, models, { indexHistory } = {}) {
+	async openDB(location: { path: string | pg.ConnectionConfig | null; topic: string }, models, { indexHistory } = {}) {
 		if (location.path === null) {
 			return new ModelDB({ path: null, models, indexHistory })
-		} else {
+		} else if (typeof location.path === "string" && !isPostgres(location.path)) {
 			return new ModelDB({ path: path.resolve(location.path, "db.sqlite"), models, indexHistory })
+		} else {
+			return await PostgresModelDB.initialize({ connectionConfig: location.path, models, indexHistory })
 		}
 	},
 
 	async openGossipLog<Payload, Result>(
-		location: { path: string | null; topic: string },
+		location: { path: string | pg.ConnectionConfig | null; topic: string },
 		init: GossipLogInit<Payload, Result>,
 	) {
 		if (location.path === null) {
 			return await MemoryGossipLog.open(init)
-		} else {
+		} else if (typeof location.path === "string" && !isPostgres(location.path)) {
 			return await GossipLog.open(init, path.resolve(location.path, "topics", init.topic))
+		} else {
+			return await PostgresGossipLog.open(init, location.path)
 		}
 	},
 
@@ -41,13 +50,17 @@ export default {
 	},
 } satisfies PlatformTarget
 
-async function getPeerId(location: { topic: string; path: string | null }): Promise<PeerId> {
+async function getPeerId(location: { topic: string; path: string | pg.ConnectionConfig | null }): Promise<PeerId> {
 	if (process.env.PEER_ID !== undefined) {
 		return createFromProtobuf(Buffer.from(process.env.PEER_ID, "base64"))
 	}
 
 	if (location.path === null) {
 		return await createEd25519PeerId()
+	}
+
+	if (typeof location.path !== 'string') {
+		throw new Error('unimplemented: peerId in postgres')
 	}
 
 	const peerIdPath = path.resolve(location.path, PEER_ID_FILENAME)

--- a/packages/gossiplog/src/pg/insert_updating_ancestors.sql.ts
+++ b/packages/gossiplog/src/pg/insert_updating_ancestors.sql.ts
@@ -53,7 +53,7 @@ BEGIN
       END LOOP;
 
       SELECT array_to_json(array_agg(DISTINCT encode(tbl, 'hex')))::jsonb FROM unnest(links) AS tbl INTO tmp;
-      ancestor_links := jsonb_set(ancestor_links, array[i-1]::text[], tmp);
+      ancestor_links := jsonb_set(ancestor_links, array[i-1]::text[], COALESCE(tmp, '[]'::jsonb));
     END IF;
 
     i := i + 1;


### PR DESCRIPTION
Postgres support in `@canvas-js/core` using Postgres ModelDB and GossipLog.

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
