### PR TITLE
packages/core: add reset option

### DIFF
--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -55,8 +55,14 @@ export interface CanvasConfig<T extends Contract = Contract> extends NetworkConf
 
 	/** set to `false` to disable history indexing and db.get(..) within actions */
 	indexHistory?: boolean
+
+	/** set a memory limit for the quickjs runtime, only used if `contract` is a string */
 	runtimeMemoryLimit?: number
+
+	/** don't throw an error when invalid messages are received */
 	ignoreMissingActions?: boolean
+
+	reset?: boolean
 }
 
 export type ActionOptions = { signer?: SessionSigner }
@@ -111,6 +117,7 @@ export class Canvas<T extends Contract = Contract> extends TypedEventEmitter<Can
 			ignoreMissingActions = false,
 			offline,
 			disablePing,
+			reset = false,
 		} = config
 
 		const signers = new SignerCache(initSigners.length === 0 ? [new SIWESigner()] : initSigners)
@@ -127,7 +134,7 @@ export class Canvas<T extends Contract = Contract> extends TypedEventEmitter<Can
 		const libp2p = await Promise.resolve(config.libp2p ?? target.createLibp2p({ topic, path }, { ...config, signers }))
 
 		const gossipLog = await target.openGossipLog<Action | Session, void | any>(
-			{ topic, path },
+			{ topic, path, clear: reset },
 			{
 				topic: runtime.topic,
 				apply: runtime.getConsumer(),


### PR DESCRIPTION
Closes #262.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
