### PR TITLE
Rjwebb/cosmos signer should use bech32 prefix in localstorage address

### DIFF
--- a/examples/chat/src/connect/ConnectCosmosKeplr.tsx
+++ b/examples/chat/src/connect/ConnectCosmosKeplr.tsx
@@ -37,13 +37,14 @@ export const ConnectCosmosKeplr: React.FC<ConnectCosmosKeplrProps> = ({ chainId 
 		setAddress(address)
 		setSessionSigner(
 			new CosmosSigner({
+				bech32Prefix: "osmo",
 				signer: {
 					type: "amino",
 					signAmino: keplr.signAmino,
 					getAddress: async () => address,
 					getChainId: async () => chainId,
 				},
-			})
+			}),
 		)
 		setThisIsConnected(true)
 	}, [])

--- a/examples/chat/src/connect/ConnectLeap.tsx
+++ b/examples/chat/src/connect/ConnectLeap.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext, useState } from "react"
 
 import { CosmosSigner } from "@canvas-js/chain-cosmos"
+import { fromBech32 } from "@cosmjs/encoding"
 
 import { AppContext } from "../AppContext.js"
 
@@ -32,11 +33,13 @@ export const ConnectLeap: React.FC<ConnectLeapProps> = ({ chainId }) => {
 		await leap.enable(chainId)
 
 		const key = await leap.getKey(chainId)
+		const { prefix } = fromBech32(key.bech32Address)
 
 		setAddress(key.bech32Address)
 
 		setSessionSigner(
 			new CosmosSigner({
+				bech32Prefix: prefix,
 				signer: {
 					type: "arbitrary",
 					signArbitrary: (msg) => leap.signArbitrary(chainId, key.bech32Address, msg),

--- a/examples/chat/src/connect/ConnectSIWEViem.tsx
+++ b/examples/chat/src/connect/ConnectSIWEViem.tsx
@@ -21,7 +21,7 @@ export const ConnectSIWEViem: React.FC<ConnectSIWEViemProps> = ({}) => {
 
 		const client = createWalletClient({
 			chain: mainnet,
-			transport: custom(window.ethereum),
+			transport: custom(window.ethereum as any),
 		})
 
 		const chainId = await client.getChainId()

--- a/examples/chat/src/connect/ConnectTerra.tsx
+++ b/examples/chat/src/connect/ConnectTerra.tsx
@@ -1,12 +1,16 @@
 import React, { useCallback, useContext, useState } from "react"
-
-import { Extension } from "@terra-money/feather.js"
 import { CosmosSigner } from "@canvas-js/chain-cosmos"
+import { toBase64 } from "@cosmjs/encoding"
 
 import { AppContext } from "../AppContext.js"
-import { Buffer } from "buffer"
 
 export interface ConnectTerraProps {}
+
+declare global {
+	interface Window {
+		station?: any
+	}
+}
 
 export const ConnectTerra: React.FC<ConnectTerraProps> = ({}) => {
 	const { app, sessionSigner, setSessionSigner, address, setAddress } = useContext(AppContext)
@@ -17,41 +21,25 @@ export const ConnectTerra: React.FC<ConnectTerraProps> = ({}) => {
 	const [error, setError] = useState<Error | null>(null)
 
 	const connect = useCallback(async () => {
-		const extension = new Extension()
+		const accountData = await window.station.connect()
 
-		const accountData = await new Promise<{ address: string; network: string }>((resolve) => {
-			extension.once("onConnect", ({ address, network }) => resolve({ address, network }))
-			extension.connect()
-		}).catch((error) => {
-			console.log(error)
-			console.error(`Failed to enable Station ${error.message}`)
-		})
 		if (!accountData) {
 			setError(new Error("address not found"))
 			return
 		}
 
-		setAddress(accountData.address)
+		const accountAddr = accountData?.address
+		setAddress(accountAddr)
 		setSessionSigner(
 			new CosmosSigner({
+				bech32Prefix: "terra",
 				signer: {
 					type: "bytes",
 					getAddress: async () => accountData.address,
 					getChainId: async () => accountData.network,
-					signBytes: async (signBytes: Uint8Array) =>
-						new Promise((resolve, reject) => {
-							extension.on("onSign", (payload) => {
-								if (payload.result?.signature) resolve(payload.result)
-								else reject(new Error("no signature"))
-							})
-							try {
-								extension.signBytes({ bytes: Buffer.from(signBytes) })
-							} catch (error) {
-								reject(error)
-							}
-						}),
+					signBytes: (message) => window.station.signBytes(toBase64(message)),
 				},
-			})
+			}),
 		)
 		setThisIsConnected(true)
 	}, [address])

--- a/packages/chain-cosmos/src/external_signers/bytes.ts
+++ b/packages/chain-cosmos/src/external_signers/bytes.ts
@@ -51,7 +51,7 @@ export type BytesSignedSessionData = Awaited<ReturnType<ReturnType<typeof create
 export function validateBytesSignedSessionData(data: any): data is BytesSignedSessionData {
 	return (
 		data.signatureType == "bytes" &&
-		data.signature instanceof Uint8Array &&
+		data.signature.signature instanceof Uint8Array &&
 		data.signature.pub_key instanceof Object &&
 		data.signature.pub_key.value instanceof Uint8Array &&
 		typeof data.signature.pub_key.type === "string" &&


### PR DESCRIPTION
We should be using the `bech32Prefix` constructor argument in `CosmosSigner` to determine what address to use when generating sessions, i.e. if we want to instantiate a signer for Osmosis, the `bech32Prefix` argument should be `"osmo"` which would then produce an address like `osmo1x124jabskjabfsafksajfklas9124`.

TODO:
- [x] Update example-chat

## How has this been tested?

- [x] CI tests pass
- [x] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
