### PR TITLE
Rjwebb.fix ci apr 2024

### DIFF
--- a/examples/chat/package.json
+++ b/examples/chat/package.json
@@ -13,7 +13,6 @@
     "@canvas-js/chain-cosmos": "0.9.0",
     "@canvas-js/chain-ethereum": "0.9.0",
     "@canvas-js/chain-ethereum-viem": "0.9.0",
-    "@canvas-js/chain-near": "0.9.0",
     "@canvas-js/chain-solana": "0.9.0",
     "@canvas-js/chain-substrate": "0.9.0",
     "@canvas-js/core": "0.9.0",

--- a/examples/chat/src/connect/ConnectNEAR.tsx
+++ b/examples/chat/src/connect/ConnectNEAR.tsx
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import React, { useCallback, useContext, useEffect, useState } from "react"
 
 import { connect as nearConnect, keyStores, WalletConnection } from "near-api-js"

--- a/examples/chat/src/connect/index.tsx
+++ b/examples/chat/src/connect/index.tsx
@@ -12,7 +12,7 @@ import { ConnectCosmosEvmMetamask } from "./ConnectCosmosEvmMetamask.js"
 import { ConnectEthereumKeplr } from "./ConnectEthereumKeplr.js"
 import { ConnectPolkadot } from "./ConnectPolkadot.js"
 import { ConnectSolana } from "./ConnectSolana.js"
-import { ConnectNEAR } from "./ConnectNEAR.js"
+// import { ConnectNEAR } from "./ConnectNEAR.js"
 import { ConnectMagic } from "./ConnectMagic.js"
 import { ConnectLeap } from "./ConnectLeap.js"
 
@@ -35,7 +35,7 @@ export const Connect: React.FC<{}> = ({}) => {
 				<option value="solana">Solana</option>
 				<option value="cosmos-keplr">Cosmos/Keplr</option>
 				<option value="ethereum-keplr">Ethereum/Keplr</option>
-				<option value="near">NEAR</option>
+				{/* <option value="near">NEAR</option> */}
 				<option value="terra">Terra</option>
 				<option value="cosmos-evm">Cosmos/EVM</option>
 				<option value="bluesky">BlueSky</option>
@@ -67,8 +67,8 @@ const Method: React.FC<{ method: string }> = (props) => {
 			return <ConnectCosmosKeplr chainId="cosmoshub-4" />
 		case "ethereum-keplr":
 			return <ConnectEthereumKeplr chainId="evmos_9001-2" />
-		case "near":
-			return <ConnectNEAR contractId="example.near" network="mainnet" recipient="somebody" />
+		// case "near":
+		// 	return <ConnectNEAR contractId="example.near" network="mainnet" recipient="somebody" />
 		case "terra":
 			return <ConnectTerra />
 		case "cosmos-evm":

--- a/packages/core/src/targets/browser/index.ts
+++ b/packages/core/src/targets/browser/index.ts
@@ -28,9 +28,10 @@ async function getPeerId({ topic }: { topic: string }): Promise<PeerId> {
 	let peerId: PeerId
 
 	if (item === null) {
-		peerId = await createEd25519PeerId()
-		const privateKey = exportToProtobuf(peerId)
+		const ed25519PeerId = await createEd25519PeerId()
+		const privateKey = exportToProtobuf(ed25519PeerId)
 		localStorage.setItem(localStorageKey, base64.baseEncode(privateKey))
+		peerId = ed25519PeerId
 	} else {
 		peerId = await createFromProtobuf(base64.baseDecode(item))
 	}

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -18,7 +18,6 @@
     "@canvas-js/chain-cosmos": "0.9.0",
     "@canvas-js/chain-ethereum": "0.9.0",
     "@canvas-js/chain-ethereum-viem": "0.9.0",
-    "@canvas-js/chain-near": "0.9.0",
     "@canvas-js/chain-solana": "0.9.0",
     "@canvas-js/chain-substrate": "0.9.0",
     "@canvas-js/interfaces": "0.9.0",

--- a/packages/interfaces/test/signers.test.ts
+++ b/packages/interfaces/test/signers.test.ts
@@ -6,7 +6,7 @@ import { secp256k1 } from "@noble/curves/secp256k1"
 import { Action, Message, Session, SessionSigner as Signer } from "@canvas-js/interfaces"
 
 import { CosmosSigner } from "@canvas-js/chain-cosmos"
-import { NEARSigner } from "@canvas-js/chain-near"
+// import { NEARSigner } from "@canvas-js/chain-near"
 import { SIWESigner, Eip712Signer } from "@canvas-js/chain-ethereum"
 import { SIWESignerViem } from "@canvas-js/chain-ethereum-viem"
 import { SolanaSigner } from "@canvas-js/chain-solana"
@@ -37,10 +37,10 @@ const SIGNER_IMPLEMENTATIONS: SignerImplementation[] = [
 			})
 		},
 	},
-	{
-		name: "chain-near",
-		createSigner: async () => new NEARSigner(),
-	},
+	// {
+	// 	name: "chain-near",
+	// 	createSigner: async () => new NEARSigner(),
+	// },
 	{
 		name: "chain-ethereum",
 		createSigner: async () => new SIWESigner(),


### PR DESCRIPTION
We have a few typescript errors that are causing CI to break currently:
- `@canvas-js/chain-near` is imported by the example chat app and the signers tests - this is currently not being published
- a type error in `packages/core/src/targets/browser/index.ts`

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

No