### PR TITLE
Rjwebb.add pnpm dependencies ethereum contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,7 @@ jobs:
         image: postgres
         env:
           POSTGRES_PASSWORD: postgres
-        options:
-          --health-cmd pg_isready
+        options: --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -87,8 +86,8 @@ jobs:
       - name: Run @canvas-js/interfaces interface tests
         run: npm run test --workspace=@canvas-js/interfaces
 
-      # - name: Run @canvas-js/ethereum-contracts tests
-      #   run: npm run test --workspace=@canvas-js/ethereum-contracts
+      - name: Run @canvas-js/ethereum-contracts tests
+        run: npm run test --workspace=@canvas-js/ethereum-contracts
 
       - name: Run @canvas-js/chain-ethereum tests
         run: npm run test --workspace=@canvas-js/chain-ethereum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Run @canvas-js/interfaces interface tests
         run: npm run test --workspace=@canvas-js/interfaces
 
-      - name: Run @canvas-js/ethereum-contracts tests
-        run: npm run test --workspace=@canvas-js/ethereum-contracts
+      # - name: Run @canvas-js/ethereum-contracts tests
+      #   run: npm run test --workspace=@canvas-js/ethereum-contracts
 
       - name: Run @canvas-js/chain-ethereum tests
         run: npm run test --workspace=@canvas-js/chain-ethereum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
         image: postgres
         env:
           POSTGRES_PASSWORD: postgres
-        options: --health-cmd pg_isready
+        options:
+          --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -13,6 +13,8 @@
   "license": "ISC",
   "devDependencies": {
     "@canvas-js/signatures": "0.9.0",
+    "@ethersproject/abi": "^5.7.0",
+    "@ethersproject/providers": "^5.7.2",
     "@noble/hashes": "^1.4.0",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.10",
@@ -21,6 +23,7 @@
     "@types/chai": "^4.3.14",
     "@types/mocha": "^10.0.6",
     "chai-as-promised": "^7.1.1",
+    "ethers": "5.7.2",
     "hardhat": "^2.12.7",
     "hardhat-gas-reporter": "^1.0.10",
     "multiformats": "^13.0.1",


### PR DESCRIPTION
When I try to install dependencies using `pnpm i` I get the following warning:
```
 WARN  Issues with peer dependencies found
packages/ethereum-contracts
├─┬ @nomicfoundation/hardhat-chai-matchers 1.0.6
│ └── ✕ unmet peer ethers@^5.0.0: found 6.12.0 in @canvas-js/chain-ethereum
├─┬ @nomicfoundation/hardhat-toolbox 2.0.2
│ └── ✕ unmet peer ethers@^5.4.7: found 6.12.0 in @canvas-js/chain-ethereum
├─┬ @nomiclabs/hardhat-ethers 2.2.3
│ └── ✕ unmet peer ethers@^5.0.0: found 6.12.0 in @canvas-js/chain-ethereum
├─┬ @typechain/ethers-v5 10.2.1
│ └── ✕ unmet peer ethers@^5.1.3: found 6.12.0 in @canvas-js/chain-ethereum
└─┬ @typechain/hardhat 6.1.6
  └── ✕ unmet peer ethers@^5.4.7: found 6.12.0 in @canvas-js/chain-ethereum
```

I don't know why this doesn't appear on CI.

In any case, we should be specifying the dependencies of the generated typescript bindings (which are used to run the unit tests) for the ethereum contracts in `packages/ethereum-contracts/package.json` in the `devDependencies` section.

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
