### PR TITLE
Make injected signer fields take an Awaitable instead of a Promise

### DIFF
--- a/packages/chain-cosmos/src/CosmosSigner.ts
+++ b/packages/chain-cosmos/src/CosmosSigner.ts
@@ -1,4 +1,4 @@
-import type { Session } from "@canvas-js/interfaces"
+import type { Awaitable, Session } from "@canvas-js/interfaces"
 import { AbstractSessionData, AbstractSessionSigner, Ed25519DelegateSigner } from "@canvas-js/signatures"
 
 import { addressPattern, parseAddress } from "./utils.js"
@@ -21,9 +21,9 @@ export interface CosmosSignerInit {
 }
 
 type GenericSigner = {
-	getChainId: () => Promise<string>
-	getAddress: (chainId: string) => Promise<string>
-	sign: (msg: CosmosMessage, signerAddress: string, chainId: string) => Promise<CosmosSessionData>
+	getChainId: () => Awaitable<string>
+	getAddress: (chainId: string) => Awaitable<string>
+	sign: (msg: CosmosMessage, signerAddress: string, chainId: string) => Awaitable<CosmosSessionData>
 }
 
 export class CosmosSigner extends AbstractSessionSigner<CosmosSessionData> {

--- a/packages/chain-cosmos/src/external_signers/amino.ts
+++ b/packages/chain-cosmos/src/external_signers/amino.ts
@@ -8,12 +8,13 @@ import { secp256k1 } from "@noble/curves/secp256k1"
 import { CosmosMessage } from "../types.js"
 import { getSessionSignatureData } from "../signatureData.js"
 import { constructSiwxMessage } from "../utils.js"
+import { Awaitable } from "@canvas-js/interfaces"
 
 export type AminoSigner = {
 	type: "amino"
-	getAddress: (chainId: string) => Promise<string>
-	getChainId: () => Promise<string>
-	signAmino(chainId: string, signer: string, signDoc: StdSignDoc): Promise<AminoSignResponse>
+	getAddress: (chainId: string) => Awaitable<string>
+	getChainId: () => Awaitable<string>
+	signAmino(chainId: string, signer: string, signDoc: StdSignDoc): Awaitable<AminoSignResponse>
 }
 
 export const createAminoSigner = (signer: AminoSigner) => ({

--- a/packages/chain-cosmos/src/external_signers/arbitrary.ts
+++ b/packages/chain-cosmos/src/external_signers/arbitrary.ts
@@ -5,12 +5,13 @@ import { fromBase64 } from "@cosmjs/encoding"
 import { CosmosMessage } from "../types.js"
 import { getSessionSignatureData } from "../signatureData.js"
 import { constructSiwxMessage } from "../utils.js"
+import { Awaitable } from "@canvas-js/interfaces"
 
 export type ArbitrarySigner = {
 	type: "arbitrary"
-	getAddress: (chainId: string) => Promise<string>
-	getChainId: () => Promise<string>
-	signArbitrary: (msg: string) => Promise<{
+	getAddress: (chainId: string) => Awaitable<string>
+	getChainId: () => Awaitable<string>
+	signArbitrary: (msg: string) => Awaitable<{
 		pub_key: {
 			type: string
 			value: string

--- a/packages/chain-cosmos/src/external_signers/bytes.ts
+++ b/packages/chain-cosmos/src/external_signers/bytes.ts
@@ -5,12 +5,13 @@ import { secp256k1 } from "@noble/curves/secp256k1"
 
 import { CosmosMessage } from "../types.js"
 import { constructSiwxMessage } from "../utils.js"
+import { Awaitable } from "@canvas-js/interfaces"
 
 export type BytesSigner = {
 	type: "bytes"
-	getAddress: (chainId: string) => Promise<string>
-	getChainId: () => Promise<string>
-	signBytes: (msg: Uint8Array) => Promise<{
+	getAddress: (chainId: string) => Awaitable<string>
+	getChainId: () => Awaitable<string>
+	signBytes: (msg: Uint8Array) => Awaitable<{
 		public_key: string
 		signature: string
 	}>

--- a/packages/chain-cosmos/src/external_signers/ethereum.ts
+++ b/packages/chain-cosmos/src/external_signers/ethereum.ts
@@ -2,12 +2,13 @@ import { fromBech32, toBech32 } from "@cosmjs/encoding"
 import { verifyMessage, getBytes, hexlify } from "ethers"
 import { CosmosMessage } from "../types.js"
 import { constructSiwxMessage } from "../utils.js"
+import { Awaitable } from "@canvas-js/interfaces"
 
 export type EthereumSigner = {
 	type: "ethereum"
-	getAddress: (chainId: string) => Promise<string>
-	getChainId: () => Promise<string>
-	signEthereum: (chainId: string, signerAddress: string, message: string) => Promise<string>
+	getAddress: (chainId: string) => Awaitable<string>
+	getChainId: () => Awaitable<string>
+	signEthereum: (chainId: string, signerAddress: string, message: string) => Awaitable<string>
 }
 
 export const createEthereumSigner = (signer: EthereumSigner, bech32Prefix: string) => ({

--- a/packages/chain-ethereum/src/siwe/SIWESigner.ts
+++ b/packages/chain-ethereum/src/siwe/SIWESigner.ts
@@ -1,7 +1,7 @@
 import { Wallet, verifyMessage, hexlify, getBytes } from "ethers"
 import * as siwe from "siwe"
 
-import type { Session } from "@canvas-js/interfaces"
+import type { Awaitable, Session } from "@canvas-js/interfaces"
 import { AbstractSessionData, AbstractSessionSigner, Ed25519DelegateSigner } from "@canvas-js/signatures"
 import { assert } from "@canvas-js/utils"
 
@@ -15,8 +15,8 @@ import {
 } from "./utils.js"
 
 type AbstractSigner = {
-	getAddress(): Promise<string>
-	signMessage(message: string): Promise<string>
+	getAddress(): Awaitable<string>
+	signMessage(message: string): Awaitable<string>
 }
 
 export interface SIWESignerInit {

--- a/packages/chain-solana/src/SolanaSigner.ts
+++ b/packages/chain-solana/src/SolanaSigner.ts
@@ -4,7 +4,7 @@ import * as json from "@ipld/dag-json"
 
 import { ed25519 } from "@noble/curves/ed25519"
 
-import type { Session } from "@canvas-js/interfaces"
+import type { Awaitable, Session } from "@canvas-js/interfaces"
 import { AbstractSessionData, AbstractSessionSigner, Ed25519DelegateSigner } from "@canvas-js/signatures"
 import { assert } from "@canvas-js/utils"
 
@@ -32,7 +32,7 @@ Resources:
 // https://github.com/solana-labs/wallet-adapter/commit/5a274e0a32c55d4376d63a802f0d512947b087af
 interface SolanaWindowSigner {
 	publicKey?: solw3.PublicKey
-	signMessage(message: Uint8Array): Promise<{ signature: Uint8Array }>
+	signMessage(message: Uint8Array): Awaitable<{ signature: Uint8Array }>
 }
 
 export interface SolanaSignerInit {

--- a/packages/chain-substrate/src/SubstrateSigner.ts
+++ b/packages/chain-substrate/src/SubstrateSigner.ts
@@ -6,7 +6,7 @@ import { InjectedExtension } from "@polkadot/extension-inject/types"
 import { cryptoWaitReady, decodeAddress } from "@polkadot/util-crypto"
 import { KeypairType } from "@polkadot/util-crypto/types"
 
-import type { Session } from "@canvas-js/interfaces"
+import type { Awaitable, Session } from "@canvas-js/interfaces"
 import { AbstractSessionData, AbstractSessionSigner, Ed25519DelegateSigner } from "@canvas-js/signatures"
 import { assert } from "@canvas-js/utils"
 
@@ -25,10 +25,10 @@ type SubstrateSignerInit = {
 
 type AbstractSigner = {
 	// substrate wallets support a variety of key pair types, such as sr25519, ed25519, and ecdsa
-	getSubstrateKeyType: () => Promise<KeypairType>
-	getAddress: () => Promise<string>
-	getChainId: () => Promise<string>
-	signMessage(message: Uint8Array): Promise<{
+	getSubstrateKeyType: () => Awaitable<KeypairType>
+	getAddress: () => Awaitable<string>
+	getChainId: () => Awaitable<string>
+	signMessage(message: Uint8Array): Awaitable<{
 		signature: Uint8Array
 		nonce: Uint8Array
 	}>


### PR DESCRIPTION
When creating a `SessionSigner`, we often want to pass in some kind of object that represents the external wallet that is signing the session. The specific interface that this external wallet or signer has depends on the particular wallet or chain so we have a bunch of them. It usually expects a function that gets the chain id and a function that signs messages. Currently we are assuming that these methods are always async, but they might not be. This is usually fine, because if you `await` a synchronous method it is just like calling it without await, but Commonwealth have implemented a stricter linting policy that insists that async functions should actually contain async code...

This PR just changes the expected input types, it doesn't change the return type of anything that is produced by Canvas.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
