### PR TITLE
Add signers test: if sessionDuration is passed into constructor, it must be included in session

### DIFF
--- a/packages/chain-ethereum/src/eip712/Eip712Signer.ts
+++ b/packages/chain-ethereum/src/eip712/Eip712Signer.ts
@@ -27,8 +27,8 @@ export class Eip712Signer extends AbstractSessionSigner<Eip712SessionData> {
 	public readonly chainId: number
 	#signer: AbstractSigner
 
-	constructor(init: { signer?: AbstractSigner; chainId?: number } = {}) {
-		super("chain-ethereum-eip712", Secp256k1SignatureScheme)
+	constructor(init: { signer?: AbstractSigner; chainId?: number; sessionDuration?: number } = {}) {
+		super("chain-ethereum-eip712", Secp256k1SignatureScheme, { sessionDuration: init.sessionDuration })
 		this.#signer = init.signer ?? Wallet.createRandom()
 		this.chainId = init.chainId ?? 1
 	}

--- a/packages/interfaces/test/signers.test.ts
+++ b/packages/interfaces/test/signers.test.ts
@@ -101,6 +101,15 @@ function runTestSuite({ createSessionSigner: createSessionSigner, name }: Sessio
 		await t.notThrowsAsync(() => Promise.resolve(sessionSigner.verifySession(topic, session)))
 	})
 
+	test(`${name} - create and verify session with no session duration given`, async (t) => {
+		const topic = "example:signer"
+		const sessionSigner = await createSessionSigner({})
+		const { payload: session } = await sessionSigner.newSession(topic)
+		// if no sessionDuration is given, the session duration should be null
+		t.is(session.duration, null)
+		await t.notThrowsAsync(() => Promise.resolve(sessionSigner.verifySession(topic, session)))
+	})
+
 	test(`${name} - create and verify session fails on incorrect signature`, async (t) => {
 		const topic = "example:signer"
 		const sessionSigner = await createSessionSigner()

--- a/packages/signatures/src/AbstractSessionSigner.ts
+++ b/packages/signatures/src/AbstractSessionSigner.ts
@@ -51,7 +51,7 @@ export abstract class AbstractSessionSigner<AuthorizationData> implements Sessio
 			address,
 			publicKey: signer.publicKey,
 			timestamp: Date.now(),
-			duration: null,
+			duration: this.sessionDuration,
 		})
 
 		const key = `canvas/${topic}/${address}`


### PR DESCRIPTION
I found that if I passed in `sessionDuration` to the constructor of the session signers then it wasn't actually being included in the created sessions. It looks like particular behaviour was not covered by tests so I have added a test for this, plus a test that asserts that if the sessionDuration is not set then `session.duration` is null.

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

It does contain a change but not a breaking on, this brings the code in line with what we expected it to do.

