### PR TITLE
require sqlite, postgres, indexeddb prefix when specifying db path

### DIFF
--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -3,8 +3,6 @@ import { logger } from "@libp2p/logger"
 import { sha256 } from "@noble/hashes/sha2"
 import { bytesToHex, randomBytes } from "@noble/hashes/utils"
 
-import type pg from "pg"
-
 import { Signature, Action, Session, Message, SessionSigner, SignerCache } from "@canvas-js/interfaces"
 import { AbstractModelDB, Model } from "@canvas-js/modeldb"
 import { SIWESigner } from "@canvas-js/chain-ethereum"
@@ -16,6 +14,7 @@ import target from "#target"
 import type { Contract, ActionImplementationFunction, ActionImplementationObject } from "./types.js"
 import { Runtime, createRuntime } from "./runtime/index.js"
 import { validatePayload } from "./schema.js"
+import { ModelDBPath } from "./targets/interface.js"
 
 export type { Model } from "@canvas-js/modeldb"
 export type { PeerId } from "@libp2p/interface"
@@ -26,7 +25,7 @@ export interface CanvasConfig<T extends Contract = Contract> extends NetworkConf
 	signers?: SessionSigner[]
 
 	/** data directory path (NodeJS/sqlite), or postgres connection config (NodeJS/pg) */
-	path?: string | pg.ConnectionConfig | null
+	path?: ModelDBPath
 
 	/** set a memory limit for the quickjs runtime, only used if `contract` is a string */
 	runtimeMemoryLimit?: number
@@ -106,8 +105,8 @@ export class Canvas<T extends Contract = Contract> extends TypedEventEmitter<Can
 		[K in keyof T["actions"]]: T["actions"][K] extends ActionImplementationFunction<infer Args>
 			? ActionAPI<Args>
 			: T["actions"][K] extends ActionImplementationObject<infer Args>
-				? ActionAPI<Args>
-				: never
+			? ActionAPI<Args>
+			: never
 	}
 
 	private readonly controller = new AbortController()

--- a/packages/core/src/runtime/ContractRuntime.ts
+++ b/packages/core/src/runtime/ContractRuntime.ts
@@ -13,10 +13,11 @@ import target from "#target"
 import { AbstractRuntime, ExecutionContext } from "./AbstractRuntime.js"
 import { sha256 } from "@noble/hashes/sha256"
 import { bytesToHex } from "@noble/hashes/utils"
+import { ModelDBPath } from "../targets/interface.js"
 
 export class ContractRuntime extends AbstractRuntime {
 	public static async init(
-		path: string | pg.ConnectionConfig | null,
+		path: ModelDBPath,
 		topic: string,
 		signers: SignerCache,
 		contract: string,

--- a/packages/core/src/runtime/FunctionRuntime.ts
+++ b/packages/core/src/runtime/FunctionRuntime.ts
@@ -10,12 +10,13 @@ import target from "#target"
 
 import { ActionImplementationFunction, Contract, ModelAPI } from "../types.js"
 import { AbstractRuntime, ExecutionContext } from "./AbstractRuntime.js"
+import { ModelDBPath } from "../targets/interface.js"
 
 const identity = (x: any) => x
 
 export class FunctionRuntime extends AbstractRuntime {
 	public static async init(
-		path: string | pg.ConnectionConfig | null,
+		path: ModelDBPath,
 		topic: string,
 		signers: SignerCache,
 		contract: Contract,

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,15 +1,15 @@
 import { SignerCache } from "@canvas-js/interfaces"
-import type pg from "pg"
 
 import type { Contract } from "../types.js"
 import { AbstractRuntime } from "./AbstractRuntime.js"
 import { ContractRuntime } from "./ContractRuntime.js"
 import { FunctionRuntime } from "./FunctionRuntime.js"
+import { ModelDBPath } from "../targets/interface.js"
 
 export { AbstractRuntime as Runtime } from "./AbstractRuntime.js"
 
 export async function createRuntime(
-	location: string | pg.ConnectionConfig | null,
+	location: ModelDBPath,
 	topic: string,
 	signers: SignerCache,
 	contract: string | Contract,

--- a/packages/core/src/targets/interface.ts
+++ b/packages/core/src/targets/interface.ts
@@ -6,14 +6,35 @@ import type { Action, Session } from "@canvas-js/interfaces"
 import type { AbstractModelDB, ModelSchema } from "@canvas-js/modeldb"
 import type { AbstractGossipLog, GossipLogInit, NetworkConfig, ServiceMap } from "@canvas-js/gossiplog"
 
+export type ModelDBPath = string | pg.ConnectionConfig | null
+
+export function isSqlitePath(path: ModelDBPath): path is `sqlite://${string}` {
+	return typeof path == "string" && path.startsWith("sqlite://")
+}
+
+export function isIndexedDbPath(path: ModelDBPath): path is `indexeddb://${string}` {
+	return typeof path == "string" && path.startsWith("indexeddb://")
+}
+
+type PostgresPath = `postgres://${string}` | `postgresql://${string}` | pg.ConnectionConfig
+export function isPostgresPath(path: ModelDBPath): path is PostgresPath {
+	if (typeof path == "string" && (path.startsWith("postgres://") || path.startsWith("postgresql://"))) {
+		return true
+	}
+	if (path != null && typeof path == "object") {
+		return true
+	}
+	return false
+}
+
 export interface PlatformTarget {
 	openGossipLog: (
-		location: { path: string | pg.ConnectionConfig | null; topic: string },
+		location: { path: ModelDBPath; topic: string; clear?: boolean },
 		init: GossipLogInit<Action | Session>,
 	) => Promise<AbstractGossipLog<Action | Session>>
 
 	openDB: (
-		location: { path: string | pg.ConnectionConfig | null; topic: string },
+		location: { path: ModelDBPath; topic: string; clear?: boolean },
 		models: ModelSchema,
 	) => Promise<AbstractModelDB>
 

--- a/packages/gossiplog/src/sqlite-wasm/index.ts
+++ b/packages/gossiplog/src/sqlite-wasm/index.ts
@@ -9,38 +9,38 @@ import { AbstractGossipLog, GossipLogInit } from "../AbstractGossipLog.js"
 import { MerkleIndex } from "../MerkleIndex.js"
 
 export class GossipLog<Payload> extends AbstractGossipLog<Payload> {
-  public static async open<Payload>(init: GossipLogInit<Payload>) {
-    const db = await ModelDB.initialize({
-      path: `canvas/v1/${init.topic}.sqlite`,
-      models: AbstractGossipLog.schema,
-    })
+	public static async open<Payload>(init: GossipLogInit<Payload>) {
+		const db = await ModelDB.initialize({
+			path: `canvas/v1/${init.topic}.sqlite`,
+			models: AbstractGossipLog.schema,
+		})
 
-    const messageCount = await db.count("$messages")
-    const merkleIndex = new MerkleIndex(db)
-    const start = performance.now()
-    const tree = await MemoryTree.fromEntries({ mode: Mode.Index }, merkleIndex.entries())
-    const root = await tree.read((txn) => txn.getRoot())
-    const delta = performance.now() - start
+		const messageCount = await db.count("$messages")
+		const merkleIndex = new MerkleIndex(db)
+		const start = performance.now()
+		const tree = await MemoryTree.fromEntries({ mode: Mode.Index }, merkleIndex.entries())
+		const root = await tree.read((txn) => txn.getRoot())
+		const delta = performance.now() - start
 
-    const gossipLog = new GossipLog(db, tree, init)
+		const gossipLog = new GossipLog(db, tree, init)
 
-    gossipLog.log(
-      `built in-memory merkle tree (root %d:%s, %d entries, %dms)`,
-      root.level,
-      toString(root.hash, "hex"),
-      messageCount,
-      Math.round(delta),
-    )
+		gossipLog.log(
+			`built in-memory merkle tree (root %d:%s, %d entries, %dms)`,
+			root.level,
+			toString(root.hash, "hex"),
+			messageCount,
+			Math.round(delta),
+		)
 
-    return gossipLog
-  }
+		return gossipLog
+	}
 
-  private constructor(public readonly db: ModelDB, public readonly tree: MemoryTree, init: GossipLogInit<Payload>) {
-    super(init)
-  }
+	private constructor(public readonly db: ModelDB, public readonly tree: MemoryTree, init: GossipLogInit<Payload>) {
+		super(init)
+	}
 
-  public async close() {
-    this.log("closing")
-    await this.db.close()
-  }
+	public async close() {
+		this.log("closing")
+		await this.db.close()
+	}
 }


### PR DESCRIPTION
After merging the Sqlite Wasm PR (https://github.com/canvasxyz/canvas/pull/314) we will have six available ways to run ModelDB (the new implementations are in bold):

| Database type    | Browser                   | Node                         |     
| ---------------- | ------------------------- | ---------------------------- |
| Sqlite in-memory | **Sqlite Wasm in-memory** | Native Sqlite in-memory      |
| Sqlite on disk   | **Sqlite Wasm OPFS**      | Native Sqlite Sqlite on disk |     
| IndexedDB        | IndexedDB                 | N/A                          |     
| PostgreSQL       | N/A                       | PostgreSQL                   |     

We need to update the arguments to `Canvas.initialize` so that if Canvas is running the browser, the developer has some way to choose which browser-based implementation to run.

I propose the following solution: 
path can be: 
- null - use Sqlite in-memory (Wasm or native depending on environment)
- `sqlite:${string]` - use Sqlite (Wasm or native depending on environment)
- `indexeddb:${string}` - use IndexedDB
- `postgres:` or `postgresql:` or a Postgres configuration object - use PostgreSQL


## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
