### PR TITLE
Fix bug in `Canvas.getSession`, update code to use `did` not `address`

### DIFF
--- a/examples/network-explorer/server/server.ts
+++ b/examples/network-explorer/server/server.ts
@@ -147,17 +147,9 @@ expressApp.get("/index_api/latest_session/:topic", async (req, res) => {
 		return
 	}
 
-	// timestamp is optional but if given, it must be a string
-	if (req.query.timestamp && typeof req.query.timestamp !== "string") {
-		res.status(StatusCodes.BAD_REQUEST)
-		res.end()
-		return
-	}
-
 	const sessionId = await canvasApp.getSession({
 		did: req.query.did,
 		publicKey: req.query.public_key,
-		timestamp: req.query.timestamp ? parseInt(req.query.timestamp) : undefined,
 	})
 
 	if (!sessionId) {

--- a/examples/network-explorer/server/server.ts
+++ b/examples/network-explorer/server/server.ts
@@ -130,7 +130,6 @@ expressApp.get("/index_api/counts/:topic", (req, res) => {
 })
 
 expressApp.get("/index_api/latest_session/:topic", async (req, res) => {
-	// message.signature.publicKey
 	const canvasApp = canvasApps[req.params.topic]
 	if (!canvasApp) {
 		res.status(StatusCodes.NOT_FOUND)
@@ -138,8 +137,8 @@ expressApp.get("/index_api/latest_session/:topic", async (req, res) => {
 		return
 	}
 	if (
-		!req.query.address ||
-		typeof req.query.address !== "string" ||
+		!req.query.did ||
+		typeof req.query.did !== "string" ||
 		!req.query.public_key ||
 		typeof req.query.public_key !== "string"
 	) {
@@ -156,7 +155,7 @@ expressApp.get("/index_api/latest_session/:topic", async (req, res) => {
 	}
 
 	const sessionId = await canvasApp.getSession({
-		address: req.query.address,
+		did: req.query.did,
 		publicKey: req.query.public_key,
 		timestamp: req.query.timestamp ? parseInt(req.query.timestamp) : undefined,
 	})

--- a/examples/network-explorer/src/topic/ActionsTable.tsx
+++ b/examples/network-explorer/src/topic/ActionsTable.tsx
@@ -8,7 +8,7 @@ import { Result, fetchAndIpldParseJson, formatDistanceCustom } from "../utils.js
 
 function SessionField({ signature, message }: { signature: Signature; message: Message<Action> }) {
 	const { data: session, error } = useSWR(
-		`/index_api/latest_session/${message.topic}?address=${message.payload.did}&public_key=${signature.publicKey}`,
+		`/index_api/latest_session/${message.topic}?did=${message.payload.did}&public_key=${signature.publicKey}`,
 		fetchAndIpldParseJson<Session>,
 	)
 

--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -319,14 +319,13 @@ export class Canvas<T extends Contract = Contract> extends TypedEventEmitter<Can
 	/**
 	 * Get an existing session
 	 */
-	public async getSession(query: { did: string; publicKey: string; timestamp?: number }): Promise<string | null> {
+	public async getSession(query: { did: string; publicKey: string }): Promise<string | null> {
 		const sessions = await this.db.query<{ message_id: string }>("$sessions", {
 			select: { message_id: true },
 			orderBy: { message_id: "desc" },
 			where: {
 				public_key: query.publicKey,
 				did: query.did,
-				expiration: { gte: query.timestamp ?? 0 },
 			},
 		})
 

--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -319,14 +319,13 @@ export class Canvas<T extends Contract = Contract> extends TypedEventEmitter<Can
 	/**
 	 * Get an existing session
 	 */
-	public async getSession(query: { address: string; publicKey: string; timestamp?: number }): Promise<string | null> {
-		// TODO: change address to did (note that network explorer uses this)
+	public async getSession(query: { did: string; publicKey: string; timestamp?: number }): Promise<string | null> {
 		const sessions = await this.db.query<{ message_id: string }>("$sessions", {
 			select: { message_id: true },
 			orderBy: { message_id: "desc" },
 			where: {
 				public_key: query.publicKey,
-				address: query.address,
+				did: query.did,
 				expiration: { gte: query.timestamp ?? 0 },
 			},
 		})


### PR DESCRIPTION
This PR makes a few changes:
- remove the optional `options.timestamp` argument from `Canvas.getSession` - this wasn't being used and was causing a bug where it would never return sessions that have a `null` timestamp value
- replace `address` with `did` in the `/latest_session` API and `Canvas.getSession` - this is a new format for describing addresses that also encodes information about the type of address, blockchain id and so on. this has already been changed in most other parts of our apps

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

The only app that uses this endpoint is network explorer, which has been tested