### PR TITLE
Add a top level generate script for the prisma client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           INDEX_DATABASE_URL: file:./index.sqlite
 
       - name: Build Prisma client for network-explorer
-        run: npm run build:prisma --workspace=@canvas-js/network-explorer
+        run: npm run generate
         env:
           INDEX_DATABASE_URL: file:./index.sqlite
 
@@ -132,7 +132,7 @@ jobs:
           INDEX_DATABASE_URL: file:./index.sqlite
 
       - name: Build Prisma client for network-explorer
-        run: npm run build:prisma --workspace=@canvas-js/network-explorer
+        run: npm run generate
         env:
           INDEX_DATABASE_URL: file:./index.sqlite
 

--- a/examples/network-explorer/package.json
+++ b/examples/network-explorer/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev:server": "tsx --tsconfig server/tsconfig.json server/server.ts",
 		"dev:client": "vite",
-		"build:prisma": "prisma generate --sql",
+		"generate": "prisma generate --sql",
 		"migrate:prisma": "prisma migrate dev",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"start:server": "cross-env NODE_ENV=production node dist/server.js"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	},
 	"scripts": {
 		"dev": "tsc --build --watch",
+		"generate": "npm run generate -w examples/network-explorer",
 		"build": "tsc --build",
 		"clean": "tsc --build --clean",
 		"clean-all": "rm -rf packages/*/lib/* packages/*/test/lib/* packages/*/tsconfig.tsbuildinfo packages/ethereum-contracts/artifacts/* packages/ethereum-contracts/typechain-types/* examples/*/lib/* examples/*/tsconfig.tsbuildinfo examples/*/tsconfig.node.tsbuildinfo",


### PR DESCRIPTION
This PR just renames the `build:prisma` script in `examples/network-explorer` to `generate` and makes it available at the top level of the monorepo. We need to call this before we call `npm run build` as it generates type stubs based on the Prisma schema for network explorer.