### PR TITLE
network explorer: remove counts table, calculate counts using messages table

### DIFF
--- a/examples/network-explorer/server/server.ts
+++ b/examples/network-explorer/server/server.ts
@@ -67,19 +67,14 @@ for (const topic of topics) {
 		topic,
 	})
 
-	// create empty counts row for this topic in the index table
-	await queries.addCountsRow(topic)
-
 	canvasApp.addEventListener("message", async (event) => {
 		const message = event.detail
 
 		if (message.message.payload.type == "action") {
 			await queries.addAction(message.message.topic, message.id)
-			await queries.incrementActionCounts(message.message.topic)
 		} else if (message.message.payload.type == "session") {
 			await queries.addSession(message.message.topic, message.id)
 			await queries.addAddress(message.message.topic, message.message.payload.did)
-			await queries.incrementSessionCounts(message.message.topic)
 		}
 	})
 
@@ -165,7 +160,16 @@ expressApp.get("/index_api/messages/:topic", ipld(), async (req, res) => {
 })
 
 expressApp.get("/index_api/counts", async (req, res) => {
-	const queryResult = (await queries.selectCountsAll()).rows
+	const countsQueryResult = (await queries.selectCountsAll()).rows
+
+	const actionCountsMap: Record<string, number> = {}
+	const sessionCountsMap: Record<string, number> = {}
+
+	for (const row of countsQueryResult) {
+		if (row.type == "action") actionCountsMap[row.topic] = row.count
+		if (row.type == "session") sessionCountsMap[row.topic] = row.count
+	}
+
 	const addressCountResult = (await queries.selectAddressCountsAll()).rows
 	const addressCountsMap: Record<string, number> = {}
 	const connectionCountsMap: Record<string, number> = {}
@@ -179,34 +183,51 @@ expressApp.get("/index_api/counts", async (req, res) => {
 			.join(", ")
 	}
 
-	for (const row of queryResult) {
-		const r = row as any
-		r.address_count = addressCountsMap[row.topic] || 0
-		r.connection_count = connectionCountsMap[row.topic] || 0
-		r.connections = connectionsMap[row.topic] || "-"
+	const result = []
+	for (const topic of topics) {
+		result.push({
+			topic,
+			address_count: addressCountsMap[topic] || 0,
+			connection_count: connectionCountsMap[topic] || 0,
+			connections: connectionsMap[topic] || "-",
+			action_count: actionCountsMap[topic] || 0,
+			session_count: sessionCountsMap[topic] || 0,
+		})
 	}
 
-	res.json(queryResult)
+	res.json(result)
 })
 
 expressApp.get("/index_api/counts/total", async (req, res) => {
-	const queryResult = (await queries.selectCountsTotal()).rows[0]
+	const actionCount = (await queries.selectCountsForTypeTotal("action")).rows[0]
+	const sessionCount = (await queries.selectCountsForTypeTotal("session")).rows[0]
+
 	const addressCountResult = (await queries.selectAddressCountTotal()).rows[0]
 	const result = {
-		action_count: queryResult.action_count || 0,
-		session_count: queryResult.session_count || 0,
+		action_count: actionCount.count || 0,
+		session_count: sessionCount.count || 0,
 		address_count: addressCountResult.count || 0,
 	}
 	res.json(result)
 })
 
 expressApp.get("/index_api/counts/:topic", async (req, res) => {
-	const queryResult = (await queries.selectCounts(req.params.topic)).rows[0]
+	let actionCount = 0
+	let sessionCount = 0
+	for (const row of (await queries.selectCounts(req.params.topic)).rows) {
+		if (row.type === "action") {
+			actionCount = row.count
+		}
+		if (row.type === "session") {
+			sessionCount = row.count
+		}
+	}
+
 	const addressCountResult = (await queries.selectAddressCount(req.params.topic)).rows[0]
 	const result = {
 		topic: req.params.topic,
-		action_count: queryResult.action_count || 0,
-		session_count: queryResult.session_count || 0,
+		action_count: actionCount,
+		session_count: sessionCount,
 		address_count: addressCountResult.count || 0,
 		connection_count: canvasApps[req.params.topic]?.libp2p.getConnections().length || 0,
 	}


### PR DESCRIPTION
Changes:
- Remove the `counts` table from network explorer
- Use the `messages` table to calculate the action and session counts, using SQL
- Cast the result of `count(...)` to int - currently this value is being returned as a string

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
