### PR TITLE
network explorer: add 'limit' parameter to messages endpoints to enable pagination

### DIFF
--- a/examples/network-explorer/server/server.ts
+++ b/examples/network-explorer/server/server.ts
@@ -88,7 +88,16 @@ for (const topic of topics) {
 }
 
 expressApp.get("/index_api/messages", ipld(), async (req, res) => {
-	const numMessagesToReturn = 10
+	let numMessagesToReturn: number
+	if (!req.query.limit) {
+		numMessagesToReturn = 10
+	} else if (typeof req.query.limit == "string") {
+		numMessagesToReturn = parseInt(req.query.limit)
+	} else {
+		res.status(StatusCodes.BAD_REQUEST)
+		res.end()
+		return
+	}
 
 	let before: string
 	if (!req.query.before) {
@@ -120,7 +129,16 @@ expressApp.get("/index_api/messages", ipld(), async (req, res) => {
 })
 
 expressApp.get("/index_api/messages/:topic", ipld(), async (req, res) => {
-	const numMessagesToReturn = 10
+	let numMessagesToReturn: number
+	if (!req.query.limit) {
+		numMessagesToReturn = 10
+	} else if (typeof req.query.limit == "string") {
+		numMessagesToReturn = parseInt(req.query.limit)
+	} else {
+		res.status(StatusCodes.BAD_REQUEST)
+		res.end()
+		return
+	}
 
 	if (req.query.type !== "session" && req.query.type !== "action") {
 		console.log("invalid type", req.query.type)

--- a/examples/network-explorer/src/topic/ActionsTable.tsx
+++ b/examples/network-explorer/src/topic/ActionsTable.tsx
@@ -26,6 +26,7 @@ function ActionsTable({ topic }: { topic: string }) {
 	// if the length of the result is n + 1, then there is another page
 	const params = new URLSearchParams({
 		type: "action",
+		limit: (entriesPerPage + 1).toString(),
 	})
 	if (currentCursor) {
 		params.append("before", currentCursor)

--- a/examples/network-explorer/src/topic/SessionsTable.tsx
+++ b/examples/network-explorer/src/topic/SessionsTable.tsx
@@ -11,7 +11,7 @@ function SessionsTable({ topic }: { topic: string }) {
 
 	// in order to determine if another page exists, we retrieve n + 1 entries
 	// if the length of the result is n + 1, then there is another page
-	const params = new URLSearchParams({ type: "session" })
+	const params = new URLSearchParams({ type: "session", limit: (entriesPerPage + 1).toString() })
 	if (currentCursor) {
 		params.append("before", currentCursor)
 	}


### PR DESCRIPTION
When displaying paginated data, we want to be able to show the user if there are more available pages. We can do this by displaying N entries but requesting N + 1 entries from the server. Then if the server returns N + 1 entries, we know that we are not looking at the last page. This PR adds a `limit` parameter to the `/index_api/messages` and `/index_api/messages/:topic` endpoints on the network explorer server.

## How has this been tested?

- [x] QA with running network explorer passes

## Does this contain any breaking changes to external interfaces?

No