### PR TITLE
implement count with where condition for modeldb sqlite

### DIFF
--- a/packages/modeldb-sqlite/src/ModelDB.ts
+++ b/packages/modeldb-sqlite/src/ModelDB.ts
@@ -2,7 +2,15 @@ import Database, * as sqlite from "better-sqlite3"
 
 import { assert, signalInvalidType } from "@canvas-js/utils"
 
-import { AbstractModelDB, parseConfig, Effect, ModelValue, ModelSchema, QueryParams } from "@canvas-js/modeldb"
+import {
+	AbstractModelDB,
+	parseConfig,
+	Effect,
+	ModelValue,
+	ModelSchema,
+	QueryParams,
+	WhereCondition,
+} from "@canvas-js/modeldb"
 
 import { ModelAPI } from "./api.js"
 
@@ -74,10 +82,10 @@ export class ModelDB extends AbstractModelDB {
 		yield* api.values()
 	}
 
-	public async count(modelName: string): Promise<number> {
+	public async count(modelName: string, where?: WhereCondition): Promise<number> {
 		const api = this.#models[modelName]
 		assert(api !== undefined, `model ${modelName} not found`)
-		return api.count()
+		return api.count(where)
 	}
 
 	public async query<T extends ModelValue = ModelValue>(modelName: string, query: QueryParams = {}): Promise<T[]> {

--- a/packages/modeldb-sqlite/src/api.ts
+++ b/packages/modeldb-sqlite/src/api.ts
@@ -197,7 +197,6 @@ export class ModelAPI {
 	}
 
 	public count(where?: WhereCondition): number {
-		console.log("where", where)
 		const sql: string[] = []
 
 		// SELECT

--- a/packages/modeldb-sqlite/src/api.ts
+++ b/packages/modeldb-sqlite/src/api.ts
@@ -196,9 +196,27 @@ export class ModelAPI {
 		}
 	}
 
-	public count(): number {
-		const { count = 0 } = this.#count.get({}) ?? {}
-		return count
+	public count(where?: WhereCondition): number {
+		console.log("where", where)
+		const sql: string[] = []
+
+		// SELECT
+		sql.push(`SELECT COUNT(*) AS count FROM "${this.#table}"`)
+
+		// WHERE
+		const [whereExpression, params] = this.getWhereExpression(where)
+
+		if (whereExpression) {
+			sql.push(`WHERE ${whereExpression}`)
+		}
+		const results = this.db.prepare(sql.join(" ")).all(params) as RecordValue[]
+
+		const countResult = results[0].count
+		if (typeof countResult === "number") {
+			return countResult
+		} else {
+			throw new Error("internal error")
+		}
 	}
 
 	public async *values(): AsyncIterable<ModelValue> {

--- a/packages/modeldb/src/AbstractModelDB.ts
+++ b/packages/modeldb/src/AbstractModelDB.ts
@@ -35,7 +35,7 @@ export abstract class AbstractModelDB {
 
 	abstract query<T extends ModelValue<any> = ModelValue<any>>(modelName: string, query?: QueryParams): Promise<T[]>
 
-	abstract count(modelName: string): Promise<number>
+	abstract count(modelName: string, where?: WhereCondition): Promise<number>
 
 	// Batch effect API
 

--- a/packages/modeldb/test/count.test.ts
+++ b/packages/modeldb/test/count.test.ts
@@ -80,5 +80,7 @@ test(`Sqlite - count entries in a modeldb table with a where condition`, async (
 	t.is(await db.count("user", { age: { gte: 15 } }), 3)
 	t.is(await db.count("user", { age: { gt: 18, lt: 22 } }), 1)
 
+	t.is(await db.count("user", { type: "user", age: { gt: 18 } }), 1)
+
 	db.close()
 })

--- a/packages/modeldb/test/count.test.ts
+++ b/packages/modeldb/test/count.test.ts
@@ -1,0 +1,84 @@
+import test from "ava"
+
+// test for the `count` function in the ModelDB class
+
+import { ModelDB as ModelDBSqlite } from "@canvas-js/modeldb-sqlite"
+import { nanoid } from "nanoid"
+import { testOnModelDB } from "./utils.js"
+
+testOnModelDB("count entries in a modeldb table", async (t, openDB) => {
+	const db = await openDB(t, {
+		user: {
+			id: "primary",
+			address: "string",
+			type: "string",
+		},
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		type: "admin",
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		type: "user",
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		type: "user",
+	})
+
+	t.is(await db.count("user"), 3)
+})
+
+test(`Sqlite - count entries in a modeldb table with a where condition`, async (t) => {
+	const db = new ModelDBSqlite({
+		path: null,
+		models: {
+			user: {
+				id: "primary",
+				address: "string",
+				age: "number",
+				type: "string",
+			},
+		},
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		age: 20,
+		type: "admin",
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		age: 25,
+		type: "user",
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		age: 15,
+		type: "user",
+	})
+
+	t.is(await db.count("user", { type: "user" }), 2)
+	t.is(await db.count("user", { type: "admin" }), 1)
+	t.is(await db.count("user", { type: "moderator" }), 0)
+	t.is(await db.count("user", { type: { neq: "user" } }), 1)
+
+	t.is(await db.count("user", { age: { gt: 21 } }), 1)
+	t.is(await db.count("user", { age: { gte: 20 } }), 2)
+	t.is(await db.count("user", { age: { gte: 15 } }), 3)
+	t.is(await db.count("user", { age: { gt: 18, lt: 22 } }), 1)
+
+	db.close()
+})


### PR DESCRIPTION
Partially implements https://github.com/canvasxyz/canvas/issues/338

This PR adds support for a where condition for the `count` method in the native Sqlite implementation of ModelDB. This takes an argument of type `WhereCondtion` and shares a lot of code with the existing query implementation.

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
