### PR TITLE
implement count with where condition for modeldb

### DIFF
--- a/packages/modeldb-idb/src/ModelDB.ts
+++ b/packages/modeldb-idb/src/ModelDB.ts
@@ -137,8 +137,7 @@ export class ModelDB extends AbstractModelDB {
 		assert(api !== undefined, `model ${modelName} not found`)
 		checkForMissingObjectStores(this.db, [api.storeName])
 
-		const result = await this.read((txn) => api.count(txn, where), [api.storeName])
-		return result as number
+		return await this.read((txn) => api.count(txn, where), [api.storeName])
 	}
 
 	public async apply(effects: Effect[]): Promise<void> {

--- a/packages/modeldb-idb/src/api.ts
+++ b/packages/modeldb-idb/src/api.ts
@@ -60,10 +60,10 @@ export class ModelAPI {
 		await this.getStore(txn).delete(key)
 	}
 
-	async count(txn: IDBPTransaction<any, any, IDBTransactionMode>, where?: WhereCondition): Promise<number> {
+	async count(txn: IDBPTransaction<any, any, IDBTransactionMode>, where: WhereCondition = {}): Promise<number> {
 		const store = this.getStore(txn)
 
-		if (!where) {
+		if (Object.keys(where).length === 0) {
 			return store.count()
 		}
 

--- a/packages/modeldb-idb/src/api.ts
+++ b/packages/modeldb-idb/src/api.ts
@@ -67,14 +67,48 @@ export class ModelAPI {
 			return store.count()
 		}
 
-		const filter = getFilter(this.model, where)
+		// try to find an index over one of the properties in the where clause
+		// we can use this to "pre-filter" the results before performing a "table scan"
+		// choose the index that has the fewest matching entries
+		let bestIndex = null
+		let bestIndexCount = Infinity
+		for (const [property, expression] of Object.entries(where)) {
+			const modelProperty = this.model.properties.find((modelProperty) => modelProperty.name === property)
+			assert(modelProperty !== undefined, "model property does not exist")
 
-		let count = 0
-		for await (const { value } of store.iterate()) {
-			if (filter(value)) count++
+			if (modelProperty.kind === "primitive" && modelProperty.type === "json") {
+				throw new Error("json properties are not supported in where clauses")
+			}
+
+			if (expression === undefined) {
+				continue
+			}
+
+			const index = this.getIndex(store, modelProperty)
+			if (index === null) {
+				continue
+			}
+
+			const indexCount = await this.countIndex(property, index, expression)
+			if (indexCount < bestIndexCount) {
+				bestIndex = index
+				bestIndexCount = indexCount
+			}
 		}
 
-		// TODO: use index if available
+		// if our where clause has only one condition and it has an index, then just return the
+		// count from that index
+		if (Object.keys(where).length === 1 && bestIndex) {
+			return bestIndexCount
+		}
+
+		// otherwise iterate over all of the entries and count the ones that match the other conditions
+		const entriesToScan = bestIndex ? bestIndex.iterate() : store.iterate()
+		const filter = getFilter(this.model, where)
+		let count = 0
+		for await (const { value } of entriesToScan) {
+			if (filter(value)) count++
+		}
 
 		return count
 	}
@@ -227,6 +261,38 @@ export class ModelAPI {
 		}
 
 		return store.index(getIndexName(index))
+	}
+
+	private async countIndex(
+		propertyName: string,
+		storeIndex: IDBPObjectStore<any, any, string, "readonly"> | IDBPIndex<any, any, string, string, "readonly">,
+		expression: PropertyValue | NotExpression | RangeExpression | null,
+	): Promise<number> {
+		const property = this.model.properties.find((property) => property.name === propertyName)
+		assert(property !== undefined, "property not found")
+
+		if (isLiteralExpression(expression)) {
+			// Here we iterate over the index using an `only` key range
+			const range = IDBKeyRange.only(encodePropertyValue(property, expression))
+			return await storeIndex.count(range)
+		} else if (isNotExpression(expression)) {
+			// Here we iterate over the undex using an open `upperBound` key range
+			// followed by an open `lowerBound` key range. Unnecessary if expression.neq === null.
+
+			const keyRange =
+				expression.neq === undefined
+					? null
+					: expression.neq === null
+					? IDBKeyRange.lowerBound(encodePropertyValue(property, null), true)
+					: IDBKeyRange.upperBound(encodePropertyValue(property, expression.neq), true)
+
+			return await storeIndex.count(keyRange)
+		} else if (isRangeExpression(expression)) {
+			const range = getRange(property, expression)
+			return await storeIndex.count(range)
+		} else {
+			signalInvalidType(expression)
+		}
 	}
 
 	private async *queryIndex(

--- a/packages/modeldb-pg/src/ModelDB.ts
+++ b/packages/modeldb-pg/src/ModelDB.ts
@@ -2,7 +2,16 @@ import pg from "pg"
 
 import { assert, signalInvalidType } from "@canvas-js/utils"
 
-import { AbstractModelDB, Config, Effect, ModelValue, ModelSchema, QueryParams, parseConfig } from "@canvas-js/modeldb"
+import {
+	AbstractModelDB,
+	Config,
+	Effect,
+	ModelValue,
+	ModelSchema,
+	QueryParams,
+	parseConfig,
+	WhereCondition,
+} from "@canvas-js/modeldb"
 
 import { ModelAPI } from "./api.js"
 
@@ -100,10 +109,10 @@ export class ModelDB extends AbstractModelDB {
 		yield* api.values()
 	}
 
-	public async count(modelName: string): Promise<number> {
+	public async count(modelName: string, where?: WhereCondition): Promise<number> {
 		const api = this.#models[modelName]
 		assert(api !== undefined, `model ${modelName} not found`)
-		return api.count()
+		return api.count(where)
 	}
 
 	public async query<T extends ModelValue = ModelValue>(modelName: string, query: QueryParams = {}): Promise<T[]> {

--- a/packages/modeldb-pg/src/api.ts
+++ b/packages/modeldb-pg/src/api.ts
@@ -230,8 +230,20 @@ export class ModelAPI {
 		}
 	}
 
-	public async count(): Promise<number> {
-		const results = await this.client.query(`SELECT COUNT(*) AS count FROM "${this.#table}"`)
+	public async count(where?: WhereCondition): Promise<number> {
+		const sql: string[] = []
+
+		// SELECT
+		sql.push(`SELECT COUNT(*) AS count FROM "${this.#table}"`)
+
+		// WHERE
+		const [whereExpression, params] = this.getWhereExpression(where)
+
+		if (whereExpression) {
+			sql.push(`WHERE ${whereExpression}`)
+		}
+		const results = await this.client.query(sql.join(" "), params)
+
 		return parseInt(results.rows[0].count, 10) ?? 0
 	}
 

--- a/packages/modeldb-sqlite-wasm/src/InnerModelDB.ts
+++ b/packages/modeldb-sqlite-wasm/src/InnerModelDB.ts
@@ -1,6 +1,6 @@
 import * as Comlink from "comlink"
 import { Logger } from "@libp2p/logger"
-import { Config, Effect, ModelValue, QueryParams } from "@canvas-js/modeldb"
+import { Config, Effect, ModelValue, QueryParams, WhereCondition } from "@canvas-js/modeldb"
 import { assert, signalInvalidType } from "@canvas-js/utils"
 import { Database } from "@sqlite.org/sqlite-wasm"
 import { ModelAPI } from "./ModelAPI.js"
@@ -51,10 +51,10 @@ export class InnerModelDB {
 		return Comlink.proxy(api.values())
 	}
 
-	public count(modelName: string): number {
+	public count(modelName: string, where?: WhereCondition): number {
 		const api = this.#models[modelName]
 		assert(api !== undefined, `model ${modelName} not found`)
-		return api.count()
+		return api.count(where)
 	}
 
 	public query<T extends ModelValue = ModelValue>(modelName: string, query: QueryParams = {}): T[] {

--- a/packages/modeldb-sqlite-wasm/src/ModelDB.ts
+++ b/packages/modeldb-sqlite-wasm/src/ModelDB.ts
@@ -1,7 +1,16 @@
 import { logger } from "@libp2p/logger"
 import * as Comlink from "comlink"
 import sqlite3InitModule from "@sqlite.org/sqlite-wasm"
-import { AbstractModelDB, parseConfig, Effect, ModelValue, ModelSchema, QueryParams, Config } from "@canvas-js/modeldb"
+import {
+	AbstractModelDB,
+	parseConfig,
+	Effect,
+	ModelValue,
+	ModelSchema,
+	QueryParams,
+	Config,
+	WhereCondition,
+} from "@canvas-js/modeldb"
 import { InnerModelDB } from "./InnerModelDB.js"
 import "./worker.js"
 
@@ -79,8 +88,8 @@ export class ModelDB extends AbstractModelDB {
 		return this.wrappedDB.iterate(modelName)
 	}
 
-	public async count(modelName: string): Promise<number> {
-		return this.wrappedDB.count(modelName)
+	public async count(modelName: string, where?: WhereCondition): Promise<number> {
+		return this.wrappedDB.count(modelName, where)
 	}
 
 	public async query<T extends ModelValue = ModelValue>(modelName: string, query: QueryParams = {}): Promise<T[]> {

--- a/packages/modeldb-sqlite/src/ModelDB.ts
+++ b/packages/modeldb-sqlite/src/ModelDB.ts
@@ -2,7 +2,15 @@ import Database, * as sqlite from "better-sqlite3"
 
 import { assert, signalInvalidType } from "@canvas-js/utils"
 
-import { AbstractModelDB, parseConfig, Effect, ModelValue, ModelSchema, QueryParams } from "@canvas-js/modeldb"
+import {
+	AbstractModelDB,
+	parseConfig,
+	Effect,
+	ModelValue,
+	ModelSchema,
+	QueryParams,
+	WhereCondition,
+} from "@canvas-js/modeldb"
 
 import { ModelAPI } from "./api.js"
 
@@ -74,10 +82,10 @@ export class ModelDB extends AbstractModelDB {
 		yield* api.values()
 	}
 
-	public async count(modelName: string): Promise<number> {
+	public async count(modelName: string, where?: WhereCondition): Promise<number> {
 		const api = this.#models[modelName]
 		assert(api !== undefined, `model ${modelName} not found`)
-		return api.count()
+		return api.count(where)
 	}
 
 	public async query<T extends ModelValue = ModelValue>(modelName: string, query: QueryParams = {}): Promise<T[]> {

--- a/packages/modeldb-sqlite/src/api.ts
+++ b/packages/modeldb-sqlite/src/api.ts
@@ -197,7 +197,6 @@ export class ModelAPI {
 	}
 
 	public count(where?: WhereCondition): number {
-		console.log("where", where)
 		const sql: string[] = []
 
 		// SELECT

--- a/packages/modeldb-sqlite/src/api.ts
+++ b/packages/modeldb-sqlite/src/api.ts
@@ -196,9 +196,27 @@ export class ModelAPI {
 		}
 	}
 
-	public count(): number {
-		const { count = 0 } = this.#count.get({}) ?? {}
-		return count
+	public count(where?: WhereCondition): number {
+		console.log("where", where)
+		const sql: string[] = []
+
+		// SELECT
+		sql.push(`SELECT COUNT(*) AS count FROM "${this.#table}"`)
+
+		// WHERE
+		const [whereExpression, params] = this.getWhereExpression(where)
+
+		if (whereExpression) {
+			sql.push(`WHERE ${whereExpression}`)
+		}
+		const results = this.db.prepare(sql.join(" ")).all(params) as RecordValue[]
+
+		const countResult = results[0].count
+		if (typeof countResult === "number") {
+			return countResult
+		} else {
+			throw new Error("internal error")
+		}
 	}
 
 	public async *values(): AsyncIterable<ModelValue> {

--- a/packages/modeldb/src/AbstractModelDB.ts
+++ b/packages/modeldb/src/AbstractModelDB.ts
@@ -35,7 +35,7 @@ export abstract class AbstractModelDB {
 
 	abstract query<T extends ModelValue<any> = ModelValue<any>>(modelName: string, query?: QueryParams): Promise<T[]>
 
-	abstract count(modelName: string): Promise<number>
+	abstract count(modelName: string, where?: WhereCondition): Promise<number>
 
 	// Batch effect API
 

--- a/packages/modeldb/test/count.test.ts
+++ b/packages/modeldb/test/count.test.ts
@@ -43,6 +43,7 @@ testOnModelDB("count entries in a modeldb table with a where condition", async (
 			address: "string",
 			age: "number",
 			type: "string",
+			$indexes: [["age"]],
 		},
 	})
 

--- a/packages/modeldb/test/count.test.ts
+++ b/packages/modeldb/test/count.test.ts
@@ -80,5 +80,7 @@ test(`Sqlite - count entries in a modeldb table with a where condition`, async (
 	t.is(await db.count("user", { age: { gte: 15 } }), 3)
 	t.is(await db.count("user", { age: { gt: 18, lt: 22 } }), 1)
 
+	t.is(await db.count("user", { type: "user", age: { gt: 18 } }), 1)
+
 	db.close()
 })

--- a/packages/modeldb/test/count.test.ts
+++ b/packages/modeldb/test/count.test.ts
@@ -36,16 +36,13 @@ testOnModelDB("count entries in a modeldb table", async (t, openDB) => {
 	t.is(await db.count("user"), 3)
 })
 
-test(`Sqlite - count entries in a modeldb table with a where condition`, async (t) => {
-	const db = new ModelDBSqlite({
-		path: null,
-		models: {
-			user: {
-				id: "primary",
-				address: "string",
-				age: "number",
-				type: "string",
-			},
+testOnModelDB("count entries in a modeldb table with a where condition", async (t, openDB) => {
+	const db = await openDB(t, {
+		user: {
+			id: "primary",
+			address: "string",
+			age: "number",
+			type: "string",
 		},
 	})
 

--- a/packages/modeldb/test/count.test.ts
+++ b/packages/modeldb/test/count.test.ts
@@ -1,0 +1,84 @@
+import test from "ava"
+
+// test for the `count` function in the ModelDB class
+
+import { ModelDB as ModelDBSqlite } from "@canvas-js/modeldb-sqlite"
+import { nanoid } from "nanoid"
+import { testOnModelDB } from "./utils.js"
+
+testOnModelDB("count entries in a modeldb table", async (t, openDB) => {
+	const db = await openDB(t, {
+		user: {
+			id: "primary",
+			address: "string",
+			type: "string",
+		},
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		type: "admin",
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		type: "user",
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		type: "user",
+	})
+
+	t.is(await db.count("user"), 3)
+})
+
+test(`Sqlite - count entries in a modeldb table with a where condition`, async (t) => {
+	const db = new ModelDBSqlite({
+		path: null,
+		models: {
+			user: {
+				id: "primary",
+				address: "string",
+				age: "number",
+				type: "string",
+			},
+		},
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		age: 20,
+		type: "admin",
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		age: 25,
+		type: "user",
+	})
+
+	await db.set("user", {
+		id: nanoid(),
+		address: nanoid(),
+		age: 15,
+		type: "user",
+	})
+
+	t.is(await db.count("user", { type: "user" }), 2)
+	t.is(await db.count("user", { type: "admin" }), 1)
+	t.is(await db.count("user", { type: "moderator" }), 0)
+	t.is(await db.count("user", { type: { neq: "user" } }), 1)
+
+	t.is(await db.count("user", { age: { gt: 21 } }), 1)
+	t.is(await db.count("user", { age: { gte: 20 } }), 2)
+	t.is(await db.count("user", { age: { gte: 15 } }), 3)
+	t.is(await db.count("user", { age: { gt: 18, lt: 22 } }), 1)
+
+	db.close()
+})


### PR DESCRIPTION
Partially implements https://github.com/canvasxyz/canvas/issues/338

This PR adds support for a where condition for the `count` method in ModelDB. This takes an argument of type `WhereCondtion` and shares a lot of code with the existing query implementation.

To do:
- [x] `modeldb-sqlite`
- [x] `modeldb-pg`
- [x] `modeldb-sqlite-wasm`
- [x] `modeldb-idb`

IndexedDB is the most complex part here: it does not have a query planner so we have to write some code that specifies how the indexes can be used. This works by selecting an index for one of the conditions in the where clause to "pre-filter" the rows (if there are multiple conditions, we want to use the index whose condition matches the smallest number of rows), then scanning through the rows to check the other where conditions. This PR also updates the `query` method in the IndexedDB ModelDB implementation to select the index with the smallest number of matches.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
