### PR TITLE
packages/modeldb: Implement clearing tables

### DIFF
--- a/packages/modeldb-idb/src/ModelDB.ts
+++ b/packages/modeldb-idb/src/ModelDB.ts
@@ -140,6 +140,12 @@ export class ModelDB extends AbstractModelDB {
 		return await this.read((txn) => api.count(txn, where), [api.storeName])
 	}
 
+	public async clear(modelName: string): Promise<void> {
+		const api = this.#models[modelName]
+		assert(api !== undefined, `model ${modelName} not found`)
+		return await this.write((txn) => api.clear(txn))
+	}
+
 	public async apply(effects: Effect[]): Promise<void> {
 		await this.write(async (txn) => {
 			for (const effect of effects) {

--- a/packages/modeldb-idb/src/api.ts
+++ b/packages/modeldb-idb/src/api.ts
@@ -60,6 +60,10 @@ export class ModelAPI {
 		await this.getStore(txn).delete(key)
 	}
 
+	async clear(txn: IDBPTransaction<any, any, "readwrite">) {
+		await this.getStore(txn).clear()
+	}
+
 	async count(txn: IDBPTransaction<any, any, IDBTransactionMode>, where: WhereCondition = {}): Promise<number> {
 		const store = this.getStore(txn)
 
@@ -297,8 +301,8 @@ export class ModelAPI {
 				expression.neq === undefined
 					? null
 					: expression.neq === null
-					? IDBKeyRange.lowerBound(encodePropertyValue(property, null), true)
-					: IDBKeyRange.upperBound(encodePropertyValue(property, expression.neq), true)
+						? IDBKeyRange.lowerBound(encodePropertyValue(property, null), true)
+						: IDBKeyRange.upperBound(encodePropertyValue(property, expression.neq), true)
 
 			return await storeIndex.count(keyRange)
 		} else if (isRangeExpression(expression)) {
@@ -331,8 +335,8 @@ export class ModelAPI {
 				expression.neq === undefined
 					? null
 					: expression.neq === null
-					? IDBKeyRange.lowerBound(encodePropertyValue(property, null), true)
-					: IDBKeyRange.upperBound(encodePropertyValue(property, expression.neq), true)
+						? IDBKeyRange.lowerBound(encodePropertyValue(property, null), true)
+						: IDBKeyRange.upperBound(encodePropertyValue(property, expression.neq), true)
 
 			for (let cursor = await storeIndex.openCursor(keyRange); cursor !== null; cursor = await cursor.continue()) {
 				yield this.decodeObject(cursor.value)

--- a/packages/modeldb-pg/src/ModelDB.ts
+++ b/packages/modeldb-pg/src/ModelDB.ts
@@ -115,6 +115,12 @@ export class ModelDB extends AbstractModelDB {
 		return api.count(where)
 	}
 
+	public async clear(modelName: string): Promise<void> {
+		const api = this.#models[modelName]
+		assert(api !== undefined, `model ${modelName} not found`)
+		return api.clear()
+	}
+
 	public async query<T extends ModelValue = ModelValue>(modelName: string, query: QueryParams = {}): Promise<T[]> {
 		const api = this.#models[modelName]
 		assert(api !== undefined, `model ${modelName} not found`)

--- a/packages/modeldb-sqlite-wasm/src/InnerModelDB.ts
+++ b/packages/modeldb-sqlite-wasm/src/InnerModelDB.ts
@@ -62,4 +62,10 @@ export class InnerModelDB {
 		assert(api !== undefined, `model ${modelName} not found`)
 		return api.query(query) as T[]
 	}
+
+	public clear(modelName: string): void {
+		const api = this.#models[modelName]
+		assert(api !== undefined, `model ${modelName} not found`)
+		return api.clear()
+	}
 }

--- a/packages/modeldb-sqlite-wasm/src/ModelAPI.ts
+++ b/packages/modeldb-sqlite-wasm/src/ModelAPI.ts
@@ -69,6 +69,7 @@ export class ModelAPI {
 	#insert: Method<Params>
 	#update: Method<RecordValue>
 	#delete: Method<Record<`p${string}`, string>>
+	#clear: Method<{}>
 
 	// Queries
 	#selectAll: Query<{}, RecordValue>
@@ -79,7 +80,10 @@ export class ModelAPI {
 	readonly #primaryKeyName: string
 	readonly #primaryKeyParam: `p${string}`
 
-	public constructor(readonly db: OpfsDatabase, readonly model: Model) {
+	public constructor(
+		readonly db: OpfsDatabase,
+		readonly model: Model,
+	) {
 		const columns: string[] = []
 		const columnNames: `"${string}"`[] = [] // quoted column names for non-relation properties
 		const columnParams: `:p${string}`[] = [] // query params for non-relation properties
@@ -139,6 +143,8 @@ export class ModelAPI {
 
 		this.#delete = new Method<Record<`p${string}`, string>>(db, `DELETE FROM "${this.#table}" ${where}`)
 
+		this.#clear = new Method<Record<`p${string}`, string>>(db, `DELETE FROM "${this.#table}"`)
+
 		// Prepare queries
 		this.#count = new Query<{}, { count: number }>(this.db, `SELECT COUNT(*) AS count FROM "${this.#table}"`)
 
@@ -193,6 +199,20 @@ export class ModelAPI {
 		this.#delete.run({ [this.#primaryKeyParam]: key })
 		for (const relation of Object.values(this.#relations)) {
 			relation.delete(key)
+		}
+	}
+
+	public clear() {
+		const existingRecords = this.#select.all({})
+
+		this.#clear.run({})
+
+		for (const record of existingRecords) {
+			const key = record[this.#primaryKeyParam]
+			for (const relation of Object.values(this.#relations)) {
+				if (!key || typeof key !== "string") continue
+				relation.delete(key)
+			}
 		}
 	}
 
@@ -556,7 +576,10 @@ export class RelationAPI {
 	readonly #insert: Method<{ _source: string; _target: string }>
 	readonly #delete: Method<{ _source: string }>
 
-	public constructor(readonly db: OpfsDatabase, readonly relation: Relation) {
+	public constructor(
+		readonly db: OpfsDatabase,
+		readonly relation: Relation,
+	) {
 		const columns = [`_source TEXT NOT NULL`, `_target TEXT NOT NULL`]
 		db.exec(`CREATE TABLE IF NOT EXISTS "${this.table}" (${columns.join(", ")})`)
 

--- a/packages/modeldb-sqlite-wasm/src/ModelDB.ts
+++ b/packages/modeldb-sqlite-wasm/src/ModelDB.ts
@@ -92,6 +92,10 @@ export class ModelDB extends AbstractModelDB {
 		return this.wrappedDB.count(modelName, where)
 	}
 
+	public async clear(modelName: string): Promise<void> {
+		return this.wrappedDB.clear(modelName)
+	}
+
 	public async query<T extends ModelValue = ModelValue>(modelName: string, query: QueryParams = {}): Promise<T[]> {
 		// @ts-ignore
 		return this.wrappedDB.query(modelName, query)

--- a/packages/modeldb-sqlite/src/ModelDB.ts
+++ b/packages/modeldb-sqlite/src/ModelDB.ts
@@ -88,6 +88,12 @@ export class ModelDB extends AbstractModelDB {
 		return api.count(where)
 	}
 
+	public async clear(modelName: string): Promise<void> {
+		const api = this.#models[modelName]
+		assert(api !== undefined, `model ${modelName} not found`)
+		return api.clear()
+	}
+
 	public async query<T extends ModelValue<any> = ModelValue<any>>(
 		modelName: string,
 		query: QueryParams = {},

--- a/packages/modeldb-sqlite/src/api.ts
+++ b/packages/modeldb-sqlite/src/api.ts
@@ -70,6 +70,7 @@ export class ModelAPI {
 	#insert: Method<Params>
 	#update: Method<RecordValue>
 	#delete: Method<Record<`p${string}`, string>>
+	#clear: Method<{}>
 
 	// Queries
 	#selectAll: Query<{}, RecordValue>
@@ -80,7 +81,10 @@ export class ModelAPI {
 	readonly #primaryKeyName: string
 	readonly #primaryKeyParam: `p${string}`
 
-	public constructor(readonly db: Database, readonly model: Model) {
+	public constructor(
+		readonly db: Database,
+		readonly model: Model,
+	) {
 		const columns: string[] = []
 		const columnNames: `"${string}"`[] = [] // quoted column names for non-relation properties
 		const columnParams: `:p${string}`[] = [] // query params for non-relation properties
@@ -140,6 +144,8 @@ export class ModelAPI {
 
 		this.#delete = new Method<Record<`p${string}`, string>>(db, `DELETE FROM "${this.#table}" ${where}`)
 
+		this.#clear = new Method<{}>(db, `DELETE FROM "${this.#table}"`)
+
 		// Prepare queries
 		this.#count = new Query<{}, { count: number }>(this.db, `SELECT COUNT(*) AS count FROM "${this.#table}"`)
 		this.#select = new Query<Record<string, `p${string}`>, RecordValue>(
@@ -193,6 +199,20 @@ export class ModelAPI {
 		this.#delete.run({ [this.#primaryKeyParam]: key })
 		for (const relation of Object.values(this.#relations)) {
 			relation.delete(key)
+		}
+	}
+
+	public clear() {
+		const existingRecords = this.#selectAll.all({}) // TODO: use this.#selectAll.iterate({})
+
+		this.#clear.run({})
+
+		for (const record of existingRecords) {
+			const key = record[this.#primaryKeyParam]
+			for (const relation of Object.values(this.#relations)) {
+				if (!key || typeof key !== "string") continue
+				relation.delete(key)
+			}
 		}
 	}
 
@@ -547,7 +567,10 @@ export class RelationAPI {
 	readonly #insert: Method<{ _source: string; _target: string }>
 	readonly #delete: Method<{ _source: string }>
 
-	public constructor(readonly db: Database, readonly relation: Relation) {
+	public constructor(
+		readonly db: Database,
+		readonly relation: Relation,
+	) {
 		const columns = [`_source TEXT NOT NULL`, `_target TEXT NOT NULL`]
 		db.exec(`CREATE TABLE IF NOT EXISTS "${this.table}" (${columns.join(", ")})`)
 

--- a/packages/modeldb/src/AbstractModelDB.ts
+++ b/packages/modeldb/src/AbstractModelDB.ts
@@ -40,6 +40,8 @@ export abstract class AbstractModelDB {
 
 	abstract count(modelName: string, where?: WhereCondition): Promise<number>
 
+	abstract clear(modelName: string): Promise<void>
+
 	// Batch effect API
 
 	public abstract apply(effects: Effect[]): Promise<void>

--- a/packages/modeldb/test/count.test.ts
+++ b/packages/modeldb/test/count.test.ts
@@ -34,6 +34,8 @@ testOnModelDB("count entries in a modeldb table", async (t, openDB) => {
 	})
 
 	t.is(await db.count("user"), 3)
+	db.clear("user")
+	t.is(await db.count("user"), 0)
 })
 
 testOnModelDB("count entries in a modeldb table with a where condition", async (t, openDB) => {


### PR DESCRIPTION
- Tested by checking in the packages/modeldb/test/count.test.ts that tables are cleared
- Relation deletions not tested

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
