### PR TITLE
packages/modeldb-sqlite: refactor internal api to use async iterators…

### DIFF
--- a/packages/modeldb-sqlite/src/ModelDB.ts
+++ b/packages/modeldb-sqlite/src/ModelDB.ts
@@ -68,7 +68,10 @@ export class ModelDB extends AbstractModelDB {
 		return api.get(key) as T | null
 	}
 
-	public async *iterate<T extends ModelValue<any> = ModelValue<any>>(modelName: string): AsyncIterable<T> {
+	public async *iterate<T extends ModelValue<any> = ModelValue<any>>(
+		modelName: string,
+		query: QueryParams = {},
+	): AsyncIterable<T> {
 		const api = this.#models[modelName]
 		assert(api !== undefined, `model ${modelName} not found`)
 		yield* api.values() as AsyncIterable<T>


### PR DESCRIPTION
… for query

<!--- Provide a general summary of your changes in the title above, and a description here -->

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
