### PR TITLE
Rjwebb/add users table endpoint count

### DIFF
--- a/examples/network-explorer/src/HomePage.tsx
+++ b/examples/network-explorer/src/HomePage.tsx
@@ -16,6 +16,10 @@ function HomePage() {
 		},
 	)
 
+	const { data: userCountData } = useSWR(`/users/count`, fetchAndIpldParseJson<{ count: number }>, {
+		refreshInterval: 1000,
+	})
+
 	const location = useLocation()
 	const actionsPath = useResolvedPath("./actions")
 	const sessionsPath = useResolvedPath("./sessions")
@@ -39,7 +43,7 @@ function HomePage() {
 						</Flex>
 						<Flex gap="2">
 							<Text weight="bold">Unique addresses:</Text>
-							<Text weight="medium">{countsData ? countsData.address_count : "-"}</Text>
+							<Text weight="medium">{userCountData ? userCountData.count : "-"}</Text>
 						</Flex>
 					</Flex>
 				</Grid>

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -172,6 +172,18 @@ export function createAPI(app: Canvas): express.Express {
 		return void res.end(json.encode(results))
 	})
 
+	api.get("/users", async (req, res) => {
+		const users = await app.db.query("$users")
+		res.writeHead(StatusCodes.OK, { "content-type": "application/json" })
+		return void res.end(json.encode(users))
+	})
+
+	api.get("/users/count", async (req, res) => {
+		const count = await app.db.count("$users")
+		res.writeHead(StatusCodes.OK, { "content-type": "application/json" })
+		return void res.end(json.encode(count))
+	})
+
 	api.get("/models/:model/:key", async (req, res) => {
 		const { model, key } = req.params
 		if (app.db.models[model] === undefined) {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -181,7 +181,7 @@ export function createAPI(app: Canvas): express.Express {
 	api.get("/users/count", async (req, res) => {
 		const count = await app.db.count("$users")
 		res.writeHead(StatusCodes.OK, { "content-type": "application/json" })
-		return void res.end(json.encode(count))
+		return void res.end(json.encode({ count: count }))
 	})
 
 	api.get("/models/:model/:key", async (req, res) => {


### PR DESCRIPTION
This PR adds a new `$users` table to core, consisting of a single column `did`. This is updated whenever a session is applied to enable us to maintain a set of all of the addresses. We can also use this table to count the number of unique addresses, which is used in network explorer.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
