### PR TITLE
replace multiple calls to ModelDB.get with ModelDB.getMany

### DIFF
--- a/packages/core/src/runtime/AbstractRuntime.ts
+++ b/packages/core/src/runtime/AbstractRuntime.ts
@@ -316,9 +316,12 @@ export abstract class AbstractRuntime {
 		type Position = { branch: number; clock: number }
 		const stack: Position[] = []
 
-		for (const parentMessageId of context.message.parents) {
-			const parentMessageRecord = await context.messageLog.db.get("$messages", parentMessageId)
-			if (!parentMessageRecord) {
+		const parentMessageRecords = await context.messageLog.db.getMany("$messages", context.message.parents)
+
+		for (let i = 0; i < parentMessageRecords.length; i++) {
+			const parentMessageRecord = parentMessageRecords[i]
+			const parentMessageId = context.message.parents[i]
+			if (parentMessageRecord == null) {
 				throw new Error(`message ${parentMessageId} not found`)
 			}
 			stack.push({ branch: parentMessageRecord.branch, clock: parentMessageRecord.message.clock })


### PR DESCRIPTION
We have a number of places in the codebase where we are retrieving multiple messages by id. We could make this operation faster by using the `getMany` function. I've looked through the code for places where we could m

## How has this been tested?

- [x] CI tests pass
- [x] Tested with network explorer

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
