### PR TITLE
in abstractgossiplog.iterate, replace query with the new modeldb iterate function

### DIFF
--- a/packages/gossiplog/src/AbstractGossipLog.ts
+++ b/packages/gossiplog/src/AbstractGossipLog.ts
@@ -203,15 +203,15 @@ export abstract class AbstractGossipLog<Payload = unknown> extends TypedEventEmi
 		range: { lt?: string; lte?: string; gt?: string; gte?: string; reverse?: boolean; limit?: number } = {},
 	): AsyncIterable<SignedMessage<Payload>> {
 		const { reverse = false, limit, ...where } = range
-		// TODO: use this.db.iterate()
-		const query = await this.db.query<{ id: string; signature: Signature; message: Message<Payload> }>("$messages", {
-			where: { id: where },
-			select: { id: true, signature: true, message: true },
-			orderBy: { id: reverse ? "desc" : "asc" },
-			limit,
-		})
-
-		for await (const row of query) {
+		for await (const row of this.db.iterate<{ id: string; signature: Signature; message: Message<Payload> }>(
+			"$messages",
+			{
+				where: { id: where },
+				select: { id: true, signature: true, message: true },
+				orderBy: { id: reverse ? "desc" : "asc" },
+				limit,
+			},
+		)) {
 			yield this.encode(row.signature, row.message)
 		}
 	}


### PR DESCRIPTION
This TODO can now be implemented that we have https://github.com/canvasxyz/canvas/commit/b59ed289d7f8bed84047e39fd774859967cdfd18

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
