### PR TITLE
modeldb - re-enable sqlite wasm tests

### DIFF
--- a/packages/modeldb-sqlite-wasm/src/ModelAPI.ts
+++ b/packages/modeldb-sqlite-wasm/src/ModelAPI.ts
@@ -160,6 +160,10 @@ export class ModelAPI {
 	}
 
 	public getMany(keys: string[]): (ModelValue | null)[] {
+		if (keys.length === 0) {
+			return []
+		}
+
 		const params: Record<`p${number}`, string> = {}
 		const whereParts = []
 		for (const [i, key] of keys.entries()) {

--- a/packages/modeldb/test/iterate.test.ts
+++ b/packages/modeldb/test/iterate.test.ts
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid"
-import { testOnModelDB } from "./utils.js"
+import { testOnModelDBNoWasm } from "./utils.js"
 
-testOnModelDB("iterate (select)", async (t, openDB) => {
+testOnModelDBNoWasm("iterate (select)", async (t, openDB) => {
 	const db = await openDB(t, {
 		user: { id: "primary", is_moderator: "boolean", name: "string?" },
 	})
@@ -28,7 +28,7 @@ testOnModelDB("iterate (select)", async (t, openDB) => {
 	])
 })
 
-testOnModelDB("iterate (orderBy)", async (t, openDB) => {
+testOnModelDBNoWasm("iterate (orderBy)", async (t, openDB) => {
 	const db = await openDB(t, {
 		user: { id: "primary" },
 	})

--- a/packages/modeldb/test/iterate.test.ts
+++ b/packages/modeldb/test/iterate.test.ts
@@ -1,5 +1,4 @@
-import { randomBytes } from "node:crypto"
-
+import { nanoid } from "nanoid"
 import { testOnModelDB } from "./utils.js"
 
 testOnModelDB("iterate (select)", async (t, openDB) => {
@@ -36,7 +35,7 @@ testOnModelDB("iterate (orderBy)", async (t, openDB) => {
 
 	const users: { id: string }[] = []
 	for (let i = 0; i < 100; i++) {
-		const user = { id: randomBytes(8).toString("hex") }
+		const user = { id: nanoid() }
 		await db.set("user", user)
 		users.push(user)
 	}

--- a/packages/modeldb/test/iterate.test.ts
+++ b/packages/modeldb/test/iterate.test.ts
@@ -1,4 +1,4 @@
-import { nanoid } from "nanoid"
+import { randomBytes } from "node:crypto"
 import { testOnModelDBNoWasm } from "./utils.js"
 
 testOnModelDBNoWasm("iterate (select)", async (t, openDB) => {
@@ -35,7 +35,7 @@ testOnModelDBNoWasm("iterate (orderBy)", async (t, openDB) => {
 
 	const users: { id: string }[] = []
 	for (let i = 0; i < 100; i++) {
-		const user = { id: nanoid() }
+		const user = { id: randomBytes(8).toString("hex") }
 		await db.set("user", user)
 		users.push(user)
 	}

--- a/packages/modeldb/test/server/src/main.ts
+++ b/packages/modeldb/test/server/src/main.ts
@@ -60,6 +60,39 @@ export async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
 	return values
 }
 
+const MAX_BYTES = 65536
+const MAX_UINT32 = 4294967295
+
+function randomBytes(size: number, cb: (err: Error | null, buf: Buffer) => void): Buffer | void {
+	// phantomjs needs to throw
+	if (size > MAX_UINT32) throw new RangeError("requested too many random bytes")
+
+	const bytes = Buffer.allocUnsafe(size)
+
+	if (size > 0) {
+		// getRandomValues fails on IE if size == 0
+		if (size > MAX_BYTES) {
+			// this is the max bytes crypto.getRandomValues
+			// can do at once see https://developer.mozilla.org/en-US/docs/Web/API/window.crypto.getRandomValues
+			for (let generated = 0; generated < size; generated += MAX_BYTES) {
+				// buffer.slice automatically checks if the end is past the end of
+				// the buffer so we don't have to here
+				crypto.getRandomValues(bytes.slice(generated, generated + MAX_BYTES))
+			}
+		} else {
+			crypto.getRandomValues(bytes)
+		}
+	}
+
+	if (typeof cb === "function") {
+		return process.nextTick(function () {
+			cb(null, bytes)
+		})
+	}
+
+	return bytes
+}
+
 // @ts-ignore
 global.nanoid = nanoid
 // @ts-ignore
@@ -72,3 +105,5 @@ global.openTransientDB = openTransientDB
 global.compareUnordered = compareUnordered
 // @ts-ignore
 global.collect = collect
+// @ts-ignore
+global.randomBytes = randomBytes

--- a/packages/modeldb/test/utils.ts
+++ b/packages/modeldb/test/utils.ts
@@ -104,7 +104,6 @@ export const testOnModelDB = (
 		do: true,
 	},
 ) => {
-	console.log(platforms)
 	const macro = test.macro(run)
 
 	const connectionConfig = getConnectionConfig()


### PR DESCRIPTION
Implements https://github.com/canvasxyz/canvas/issues/361

This adds the `modeldb-sqlite-wasm` implementations back into the ModelDB test suite. We do this by modifying `testOnModelDB` to take a new argument which lets us specify which ModelDB implementations the tests should run on, following https://github.com/canvasxyz/canvas/blob/main/packages/gossiplog/test/utils.ts#L56

I also had to change where in `packages/modeldb/test/utils.ts` we call the setup/teardown code for the Durable Objects worker - it seems like AVA doesn't like it if you have more than one `test.before` hook.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
