### PR TITLE
packages/modeldb: add include option to QueryParams, implement in modeldb-idb

### DIFF
--- a/packages/modeldb-durable-objects/src/api.ts
+++ b/packages/modeldb-durable-objects/src/api.ts
@@ -365,6 +365,11 @@ export class ModelAPI {
 			params.push(query.offset)
 		}
 
+		// JOIN (not supported)
+		if (query.include) {
+			throw new Error("cannot use 'include' in queries outside the browser/idb")
+		}
+
 		return [sql.join(" "), relations, params]
 	}
 

--- a/packages/modeldb-idb/src/ModelDB.ts
+++ b/packages/modeldb-idb/src/ModelDB.ts
@@ -8,7 +8,7 @@ import {
 	Effect,
 	ModelValue,
 	ModelSchema,
-	MergedModelValue,
+	ModelValueWithIncludes,
 	QueryParams,
 	WhereCondition,
 	parseConfig,
@@ -172,7 +172,7 @@ export class ModelDB extends AbstractModelDB {
 				const cache: Record<string, Record<string, ModelValue>> = {} // { [table]: { [id]: ModelValue } }
 
 				const { include, ...rootQuery } = query
-				const modelValues = (await root.query(txn, rootQuery)) as MergedModelValue[]
+				const modelValues = (await root.query(txn, rootQuery)) as ModelValueWithIncludes[]
 
 				// Two-pass recursive query to populate includes. The first pass populates
 				// the cache with all models in the response, but doesn't join any of them.
@@ -182,7 +182,7 @@ export class ModelDB extends AbstractModelDB {
 				// This is necessary because making joins automatically in one recursive
 				// query would cause the same join to be applied everywhere, because the
 				// cache only maintains one instance for every record.
-				const populateCache = async (records: MergedModelValue[], include: IncludeExpression) => {
+				const populateCache = async (records: ModelValueWithIncludes[], include: IncludeExpression) => {
 					for (const includeKey of Object.keys(include)) {
 						// mergedCache[table] ||= {}
 						cache[includeKey] ||= {}
@@ -214,7 +214,7 @@ export class ModelDB extends AbstractModelDB {
 						}
 					}
 				}
-				const populateRecords = async (records: MergedModelValue[], include: IncludeExpression) => {
+				const populateRecords = async (records: ModelValueWithIncludes[], include: IncludeExpression) => {
 					if (Object.keys(include).length === 0) return
 					for (const record of records) {
 						for (const includeKey of Object.keys(include)) {

--- a/packages/modeldb-idb/src/ModelDB.ts
+++ b/packages/modeldb-idb/src/ModelDB.ts
@@ -8,10 +8,10 @@ import {
 	Effect,
 	ModelValue,
 	ModelSchema,
+	MergedModelValue,
 	QueryParams,
 	WhereCondition,
 	parseConfig,
-	MergedModelValue,
 	IncludeExpression,
 } from "@canvas-js/modeldb"
 

--- a/packages/modeldb-idb/src/ModelDB.ts
+++ b/packages/modeldb-idb/src/ModelDB.ts
@@ -12,6 +12,7 @@ import {
 	WhereCondition,
 	parseConfig,
 	MergedModelValue,
+	IncludeExpression,
 } from "@canvas-js/modeldb"
 
 import { ModelAPI } from "./api.js"
@@ -160,8 +161,6 @@ export class ModelDB extends AbstractModelDB {
 		query: QueryParams = {},
 	): Promise<T[]> {
 		assert(query.include)
-		const include = query.include
-
 		const root = this.#models[modelName]
 		const modelNames = Array.from(new Set([...flattenKeys({ [modelName]: query.include })]))
 		for (const modelName of modelNames) {
@@ -171,67 +170,82 @@ export class ModelDB extends AbstractModelDB {
 		const result = await this.read(
 			async (txn) => {
 				const cache: Record<string, Record<string, ModelValue>> = {} // { [table]: { [id]: ModelValue } }
+
 				const { include, ...rootQuery } = query
 				const modelValues = (await root.query(txn, rootQuery)) as MergedModelValue[]
 
-				const populate = async (records: MergedModelValue[], include: any, visited = new Set<string>()) => {
-					for (const table of Object.keys(include)) {
-						cache[table] ||= {}
+				// Two-pass recursive query to populate includes. The first pass populates
+				// the cache with all models in the response, but doesn't join any of them.
+				// The second pass makes joins on-copy for every reference/relation in
+				// `include` and updates the result record in-place to add the joins.
+				//
+				// This is necessary because making joins automatically in one recursive
+				// query would cause the same join to be applied everywhere, because the
+				// cache only maintains one instance for every record.
+				const populateCache = async (records: MergedModelValue[], include: IncludeExpression) => {
+					for (const includeKey of Object.keys(include)) {
+						// mergedCache[table] ||= {}
+						cache[includeKey] ||= {}
 						for (const record of records) {
-							const propertyValue = record[table]
+							const includeValue = record[includeKey]
 							// Reference type
-							if (!Array.isArray(propertyValue)) {
-								assert(typeof propertyValue === "string", "include should only be used with references or relations")
-								if (cache[table][propertyValue] || visited.has(propertyValue)) continue
-								visited.add(propertyValue)
-								const [result] = await this.#models[table].query(txn, { where: { id: propertyValue } })
+							if (!Array.isArray(includeValue)) {
+								assert(typeof includeValue === "string", "include should only be used with references or relations")
+								if (cache[includeKey][includeValue]) continue
+								const [result] = await this.#models[includeKey].query(txn, { where: { id: includeValue } })
 								if (result === undefined) throw new Error("expected a reference to be populated")
-								cache[table][propertyValue] = result
-								// Recursively fetch nested includes
-								if (include[table]) {
-									await populate([result], include[table], visited)
+								cache[includeKey][includeValue] = { ...result }
+								if (include[includeKey]) {
+									await populateCache([result], include[includeKey])
 								}
 								continue
 							}
 							// Relation type
-							for (const item of propertyValue) {
+							for (const item of includeValue) {
 								assert(typeof item === "string", "include should only be used with references or relations")
-								if (cache[table][item] || visited.has(item)) continue
-								visited.add(item)
-								const [result] = await this.#models[table].query(txn, { where: { id: item } })
+								if (cache[includeKey][item]) continue
+								const [result] = await this.#models[includeKey].query(txn, { where: { id: item } })
 								if (result === undefined) throw new Error("expected a relation to be populated")
-								cache[table][item] = result
-								// Recursively fetch nested includes
-								if (include[table]) {
-									await populate([result], include[table], visited)
+								cache[includeKey][item] = { ...result }
+								if (include[includeKey]) {
+									await populateCache([result], include[includeKey])
 								}
 							}
 						}
 					}
-
-					// Populate references and relations
+				}
+				const populateRecords = async (records: MergedModelValue[], include: IncludeExpression) => {
+					if (Object.keys(include).length === 0) return
 					for (const record of records) {
-						for (const includeModel of Object.keys(include)) {
-							if (!Array.isArray(record[includeModel])) {
+						for (const includeKey of Object.keys(include)) {
+							const includeValue = record[includeKey]
+							if (!Array.isArray(includeValue)) {
 								// Reference type
-								assert(typeof record[includeModel] === "string", "expected reference to be a string")
-								record[includeModel] = cache[includeModel][record[includeModel]]
+								assert(typeof includeValue === "string", "expected reference to be a string")
+								record[includeKey] = { ...cache[includeKey][includeValue] } // replace propertyValue
+								if (include[includeKey]) {
+									await populateRecords([record[includeKey]], include[includeKey])
+								}
 							} else {
 								// Relation type
-								record[includeModel] = record[includeModel].map((pk) => {
+								record[includeKey] = includeValue.map((pk) => {
 									assert(typeof pk === "string", "expected relation to be a string[]")
-									return cache[includeModel][pk]
-								})
+									return { ...cache[includeKey][pk] }
+								}) // replace propertyValue
+								if (include[includeKey]) {
+									await populateRecords(record[includeKey], include[includeKey])
+								}
 							}
 						}
 					}
 				}
-
-				await populate(modelValues, include)
+				await populateCache(modelValues, query.include ?? {})
+				await populateRecords(modelValues, query.include ?? {})
 				return modelValues
 			},
 			modelNames.map((m: string) => this.#models[m].storeName),
 		)
+
 		return result as T[]
 	}
 

--- a/packages/modeldb-idb/src/useLiveQuery.ts
+++ b/packages/modeldb-idb/src/useLiveQuery.ts
@@ -15,20 +15,6 @@ export function useLiveQuery<T extends ModelValue = ModelValue>(
 
 	const [results, setResults] = useState<null | T[]>(null)
 
-	// const { isLoading, error, data } = db.useQuery({
-	//   game: {
-	//     $: { where: { id: gameId } },
-	//     player: {
-	//       unit: {
-	//         player: {},
-	//       },
-	//       city: {
-	//         player: {},
-	//       },
-	//     },
-	//   },
-	// });
-
 	useEffect(() => {
 		// Unsubscribe from the cached database handle, if necessary
 		if (

--- a/packages/modeldb-idb/src/useLiveQuery.ts
+++ b/packages/modeldb-idb/src/useLiveQuery.ts
@@ -15,6 +15,20 @@ export function useLiveQuery<T extends ModelValue = ModelValue>(
 
 	const [results, setResults] = useState<null | T[]>(null)
 
+	// const { isLoading, error, data } = db.useQuery({
+	//   game: {
+	//     $: { where: { id: gameId } },
+	//     player: {
+	//       unit: {
+	//         player: {},
+	//       },
+	//       city: {
+	//         player: {},
+	//       },
+	//     },
+	//   },
+	// });
+
 	useEffect(() => {
 		// Unsubscribe from the cached database handle, if necessary
 		if (

--- a/packages/modeldb-idb/src/utils.ts
+++ b/packages/modeldb-idb/src/utils.ts
@@ -1,3 +1,4 @@
+import { IncludeExpression } from "@canvas-js/modeldb"
 import type { IDBPDatabase } from "idb"
 
 export const getIndexName = (index: string[]) => index.join("/")
@@ -12,6 +13,15 @@ If necessary, you can clear IndexedDB by running this in the console:
 
 const dbs = await window.indexedDB.databases()
 dbs.forEach(db => { window.indexedDB.deleteDatabase(db.name) })`)
+		}
+	}
+}
+
+export function* flattenKeys(obj: IncludeExpression): Generator<string> {
+	for (const key of Object.keys(obj)) {
+		yield key;
+		for (const nestedKey of flattenKeys(obj[key])) {
+			yield nestedKey;
 		}
 	}
 }

--- a/packages/modeldb-pg/src/api.ts
+++ b/packages/modeldb-pg/src/api.ts
@@ -415,6 +415,11 @@ export class ModelAPI {
 			params.push(query.offset)
 		}
 
+		// JOIN (not supported)
+		if (query.include) {
+			throw new Error("cannot use 'include' in queries outside the browser/idb")
+		}
+
 		return [sql.join(" "), relations, params]
 	}
 

--- a/packages/modeldb-sqlite-wasm/src/ModelAPI.ts
+++ b/packages/modeldb-sqlite-wasm/src/ModelAPI.ts
@@ -266,6 +266,7 @@ export class ModelAPI {
 	}
 
 	public async *iterate(query: QueryParams = {}): AsyncIterable<ModelValue> {
+		// TODO: implement iterate (needs special handling over comlink)
 		if (Object.keys(query).length > 0) {
 			throw new Error("not implemented")
 		}
@@ -365,6 +366,11 @@ export class ModelAPI {
 		if (typeof query.offset === "number") {
 			sql.push(`LIMIT :offset`)
 			params.limit = query.offset
+		}
+
+		// JOIN (not supported)
+		if (query.include) {
+			throw new Error("cannot use 'include' in queries outside the browser/idb")
 		}
 
 		return [sql.join(" "), relations, params]

--- a/packages/modeldb-sqlite/src/api.ts
+++ b/packages/modeldb-sqlite/src/api.ts
@@ -336,6 +336,11 @@ export class ModelAPI {
 			params.offset = query.offset
 		}
 
+		// JOIN (not supported)
+		if (query.include) {
+			throw new Error("cannot use 'include' in queries outside the browser/idb")
+		}
+
 		return [sql.join(" "), relations, params]
 	}
 

--- a/packages/modeldb/ava.config.js
+++ b/packages/modeldb/ava.config.js
@@ -1,6 +1,6 @@
 export default {
 	watchMode: {
-		ignoreChanges: [".wrangler/**/*"],
+		ignoreChanges: ["test/server/vite.config.js*", ".wrangler/**/*"],
 	},
 	files: ["./test/*.test.ts"],
 	concurrency: 1,

--- a/packages/modeldb/src/types.ts
+++ b/packages/modeldb/src/types.ts
@@ -69,8 +69,11 @@ export type WhereCondition = Record<string, PropertyValue | NotExpression | Rang
 export type NotExpression = { neq: PropertyValue | undefined }
 export type RangeExpression = { gt?: PrimitiveValue; gte?: PrimitiveValue; lt?: PrimitiveValue; lte?: PrimitiveValue }
 
+export type IncludeExpression = { [key: string]: IncludeExpression }
+
 export type QueryParams = {
-	select?: Record<string, boolean> // TODO: add support for joining reference/relation values a la primsa
+	select?: Record<string, boolean>
+	include?: IncludeExpression
 	where?: WhereCondition
 	orderBy?: Record<string, "asc" | "desc">
 	limit?: number

--- a/packages/modeldb/src/types.ts
+++ b/packages/modeldb/src/types.ts
@@ -74,7 +74,7 @@ export type IncludeExpression = { [key: string]: IncludeExpression }
 
 export type QueryParams = {
 	select?: Record<string, boolean>
-	include?: IncludeExpression
+	include?: IncludeExpression // TODO: only supported on modeldb-idb right now
 	where?: WhereCondition
 	orderBy?: Record<string, "asc" | "desc">
 	limit?: number

--- a/packages/modeldb/src/types.ts
+++ b/packages/modeldb/src/types.ts
@@ -63,7 +63,8 @@ export type RelationValue = string[]
 
 export type PropertyValue = PrimaryKeyValue | PrimitiveValue | ReferenceValue | RelationValue | JSONValue
 
-export type ModelValue<T = PropertyValue> = Record<string, T>
+export type ModelValue<T = PropertyValue> = { [key: string]: T }
+export type MergedModelValue<T = PropertyValue> = { [key: string]: T | MergedModelValue<T> | MergedModelValue<T>[] }
 
 export type WhereCondition = Record<string, PropertyValue | NotExpression | RangeExpression | undefined>
 export type NotExpression = { neq: PropertyValue | undefined }

--- a/packages/modeldb/src/types.ts
+++ b/packages/modeldb/src/types.ts
@@ -64,7 +64,7 @@ export type RelationValue = string[]
 export type PropertyValue = PrimaryKeyValue | PrimitiveValue | ReferenceValue | RelationValue | JSONValue
 
 export type ModelValue<T = PropertyValue> = { [key: string]: T }
-export type MergedModelValue<T = PropertyValue> = { [key: string]: T | MergedModelValue<T> | MergedModelValue<T>[] }
+export type ModelValueWithIncludes<T = PropertyValue> = { [key: string]: T | ModelValueWithIncludes<T> | ModelValueWithIncludes<T>[] }
 
 export type WhereCondition = Record<string, PropertyValue | NotExpression | RangeExpression | undefined>
 export type NotExpression = { neq: PropertyValue | undefined }

--- a/packages/modeldb/test/relations.test.ts
+++ b/packages/modeldb/test/relations.test.ts
@@ -1,203 +1,288 @@
 import { nanoid } from "nanoid"
 import { testOnModelDB } from "./utils.js"
 
-testOnModelDB("set and get reference and relation values", async (t, openDB) => {
-	const db = await openDB(t, {
-		user: { address: "primary" },
-		room: {
-			id: "primary",
-			creator: "@user",
-			members: "@user[]",
-		},
-	})
+// testOnModelDB("set and get reference and relation values", async (t, openDB) => {
+// 	const db = await openDB(t, {
+// 		user: { address: "primary" },
+// 		room: {
+// 			id: "primary",
+// 			creator: "@user",
+// 			members: "@user[]",
+// 		},
+// 	})
 
-	await db.set("user", { address: "a" })
-	await db.set("user", { address: "b" })
+// 	await db.set("user", { address: "a" })
+// 	await db.set("user", { address: "b" })
 
-	t.is(await db.count("user"), 2)
+// 	t.is(await db.count("user"), 2)
 
-	const roomId = nanoid()
-	await db.set("room", { id: roomId, creator: "a", members: ["a", "b"] })
-	t.deepEqual(await db.get("room", roomId), { id: roomId, creator: "a", members: ["a", "b"] })
-})
+// 	const roomId = nanoid()
+// 	await db.set("room", { id: roomId, creator: "a", members: ["a", "b"] })
+// 	t.deepEqual(await db.get("room", roomId), { id: roomId, creator: "a", members: ["a", "b"] })
+// })
 
-testOnModelDB("select reference and relation values", async (t, openDB) => {
-	const db = await openDB(t, {
-		user: { address: "primary" },
-		room: {
-			id: "primary",
-			creator: "@user",
-			members: "@user[]",
-		},
-	})
+// testOnModelDB("select reference and relation values", async (t, openDB) => {
+// 	const db = await openDB(t, {
+// 		user: { address: "primary" },
+// 		room: {
+// 			id: "primary",
+// 			creator: "@user",
+// 			members: "@user[]",
+// 		},
+// 	})
 
-	await db.set("user", { address: "a" })
-	await db.set("user", { address: "b" })
-	await db.set("user", { address: "c" })
-	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
-	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
-	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
+// 	await db.set("user", { address: "a" })
+// 	await db.set("user", { address: "b" })
+// 	await db.set("user", { address: "c" })
+// 	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
+// 	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
+// 	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
 
-	t.deepEqual(await db.query("room", { select: { id: true, creator: true } }), [
-		{ id: "x", creator: "a" },
-		{ id: "y", creator: "b" },
-		{ id: "z", creator: "a" },
-	])
+// 	t.deepEqual(await db.query("room", { select: { id: true, creator: true } }), [
+// 		{ id: "x", creator: "a" },
+// 		{ id: "y", creator: "b" },
+// 		{ id: "z", creator: "a" },
+// 	])
 
-	t.deepEqual(await db.query("room", { select: { id: true, members: true } }), [
-		{ id: "x", members: ["a", "b"] },
-		{ id: "y", members: ["b", "c"] },
-		{ id: "z", members: ["a", "c"] },
-	])
+// 	t.deepEqual(await db.query("room", { select: { id: true, members: true } }), [
+// 		{ id: "x", members: ["a", "b"] },
+// 		{ id: "y", members: ["b", "c"] },
+// 		{ id: "z", members: ["a", "c"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { select: { id: true, creator: true, members: true } }), [
-		{ id: "x", creator: "a", members: ["a", "b"] },
-		{ id: "y", creator: "b", members: ["b", "c"] },
-		{ id: "z", creator: "a", members: ["a", "c"] },
-	])
-})
+// 	t.deepEqual(await db.query("room", { select: { id: true, creator: true, members: true } }), [
+// 		{ id: "x", creator: "a", members: ["a", "b"] },
+// 		{ id: "y", creator: "b", members: ["b", "c"] },
+// 		{ id: "z", creator: "a", members: ["a", "c"] },
+// 	])
+// })
 
-testOnModelDB("query reference values", async (t, openDB) => {
-	const db = await openDB(t, {
-		user: { address: "primary" },
-		room: {
-			id: "primary",
-			creator: "@user",
-			members: "@user[]",
-		},
-	})
+// testOnModelDB("query reference values", async (t, openDB) => {
+// 	const db = await openDB(t, {
+// 		user: { address: "primary" },
+// 		room: {
+// 			id: "primary",
+// 			creator: "@user",
+// 			members: "@user[]",
+// 		},
+// 	})
 
-	await db.set("user", { address: "a" })
-	await db.set("user", { address: "b" })
-	await db.set("user", { address: "c" })
-	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
-	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
-	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
+// 	await db.set("user", { address: "a" })
+// 	await db.set("user", { address: "b" })
+// 	await db.set("user", { address: "c" })
+// 	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
+// 	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
+// 	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
 
-	t.deepEqual(await db.query("room", { where: { creator: "a" } }), [
-		{ id: "x", creator: "a", members: ["a", "b"] },
-		{ id: "z", creator: "a", members: ["a", "c"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { creator: "a" } }), [
+// 		{ id: "x", creator: "a", members: ["a", "b"] },
+// 		{ id: "z", creator: "a", members: ["a", "c"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { creator: "b" } }), [{ id: "y", creator: "b", members: ["b", "c"] }])
-	t.deepEqual(await db.query("room", { where: { creator: "c" } }), [])
-	t.deepEqual(await db.query("room", { where: { creator: { neq: "a" } } }), [
-		{ id: "y", creator: "b", members: ["b", "c"] },
-	])
-})
+// 	t.deepEqual(await db.query("room", { where: { creator: "b" } }), [{ id: "y", creator: "b", members: ["b", "c"] }])
+// 	t.deepEqual(await db.query("room", { where: { creator: "c" } }), [])
+// 	t.deepEqual(await db.query("room", { where: { creator: { neq: "a" } } }), [
+// 		{ id: "y", creator: "b", members: ["b", "c"] },
+// 	])
+// })
 
-testOnModelDB("query filtering on relation values", async (t, openDB) => {
-	const db = await openDB(t, {
-		user: { address: "primary" },
-		room: {
-			id: "primary",
-			creator: "@user",
-			members: "@user[]",
-		},
-	})
+// testOnModelDB("query filtering on relation values", async (t, openDB) => {
+// 	const db = await openDB(t, {
+// 		user: { address: "primary" },
+// 		room: {
+// 			id: "primary",
+// 			creator: "@user",
+// 			members: "@user[]",
+// 		},
+// 	})
 
-	await db.set("user", { address: "a" })
-	await db.set("user", { address: "b" })
-	await db.set("user", { address: "c" })
-	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
-	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
-	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
+// 	await db.set("user", { address: "a" })
+// 	await db.set("user", { address: "b" })
+// 	await db.set("user", { address: "c" })
+// 	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
+// 	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
+// 	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
 
-	t.deepEqual(await db.query("room", { where: { members: ["a"] } }), [
-		{ id: "x", creator: "a", members: ["a", "b"] },
-		{ id: "z", creator: "a", members: ["a", "c"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: ["a"] } }), [
+// 		{ id: "x", creator: "a", members: ["a", "b"] },
+// 		{ id: "z", creator: "a", members: ["a", "c"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: ["b"] } }), [
-		{ id: "x", creator: "a", members: ["a", "b"] },
-		{ id: "y", creator: "b", members: ["b", "c"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: ["b"] } }), [
+// 		{ id: "x", creator: "a", members: ["a", "b"] },
+// 		{ id: "y", creator: "b", members: ["b", "c"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: ["c"] } }), [
-		{ id: "y", creator: "b", members: ["b", "c"] },
-		{ id: "z", creator: "a", members: ["a", "c"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: ["c"] } }), [
+// 		{ id: "y", creator: "b", members: ["b", "c"] },
+// 		{ id: "z", creator: "a", members: ["a", "c"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: ["a", "b"] } }), [
-		{ id: "x", creator: "a", members: ["a", "b"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: ["a", "b"] } }), [
+// 		{ id: "x", creator: "a", members: ["a", "b"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: ["b", "a"] } }), [
-		{ id: "x", creator: "a", members: ["a", "b"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: ["b", "a"] } }), [
+// 		{ id: "x", creator: "a", members: ["a", "b"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: ["b", "c"] } }), [
-		{ id: "y", creator: "b", members: ["b", "c"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: ["b", "c"] } }), [
+// 		{ id: "y", creator: "b", members: ["b", "c"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: ["c", "b"] } }), [
-		{ id: "y", creator: "b", members: ["b", "c"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: ["c", "b"] } }), [
+// 		{ id: "y", creator: "b", members: ["b", "c"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: ["a", "c"] } }), [
-		{ id: "z", creator: "a", members: ["a", "c"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: ["a", "c"] } }), [
+// 		{ id: "z", creator: "a", members: ["a", "c"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: ["c", "a"] } }), [
-		{ id: "z", creator: "a", members: ["a", "c"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: ["c", "a"] } }), [
+// 		{ id: "z", creator: "a", members: ["a", "c"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: ["a", "b", "c"] } }), [])
+// 	t.deepEqual(await db.query("room", { where: { members: ["a", "b", "c"] } }), [])
 
-	t.deepEqual(await db.query("room", { where: { members: { neq: ["a"] } } }), [
-		{ id: "y", creator: "b", members: ["b", "c"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["a"] } } }), [
+// 		{ id: "y", creator: "b", members: ["b", "c"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: { neq: ["b"] } } }), [
-		{ id: "z", creator: "a", members: ["a", "c"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["b"] } } }), [
+// 		{ id: "z", creator: "a", members: ["a", "c"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: { neq: ["c"] } } }), [
-		{ id: "x", creator: "a", members: ["a", "b"] },
-	])
+// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["c"] } } }), [
+// 		{ id: "x", creator: "a", members: ["a", "b"] },
+// 	])
 
-	t.deepEqual(await db.query("room", { where: { members: { neq: ["a", "b"] } } }), [])
-	t.deepEqual(await db.query("room", { where: { members: { neq: ["b", "c"] } } }), [])
-	t.deepEqual(await db.query("room", { where: { members: { neq: ["a", "c"] } } }), [])
-})
+// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["a", "b"] } } }), [])
+// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["b", "c"] } } }), [])
+// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["a", "c"] } } }), [])
+// })
 
-testOnModelDB("select nested reference and relation values", async (t, openDB) => {
-	const db = await openDB(t, {
-		game: { id: "primary", player: "@player[]", city: "@city[]", unit: "@unit[]" },
-		player: { id: "primary", game: "@game", city: "@city[]", unit: "@unit[]" },
-		city: { id: "primary", player: "@player" },
-		unit: { id: "primary", player: "@player" },
-	})
+// testOnModelDB(
+// 	"select nested reference and relation values (without include)",
+// 	async (t, openDB) => {
+// 		const db = await openDB(t, {
+// 			game: { id: "primary", player: "@player[]", city: "@city[]", unit: "@unit[]" },
+// 			player: { id: "primary", game: "@game", city: "@city[]", unit: "@unit[]" },
+// 			city: { id: "primary", player: "@player" },
+// 			unit: { id: "primary", player: "@player" },
+// 		})
 
-	await db.set("game", { id: "game", player: [], city: [], unit: [] })
+// 		await db.set("game", { id: "game", player: [], city: [], unit: [] })
 
-	await db.set("player", { id: "alice", game: "game", city: [], unit: [] })
-	await db.set("player", { id: "bob", game: "game", city: [], unit: [] })
-	await db.update("game", { id: "game", player: ["alice", "bob"], city: [], unit: [] })
+// 		await db.set("player", { id: "alice", game: "game", city: [], unit: [] })
+// 		await db.set("player", { id: "bob", game: "game", city: [], unit: [] })
+// 		await db.update("game", { id: "game", player: ["alice", "bob"], city: [], unit: [] })
 
-	await db.set("city", { id: "london", game: "game", player: "alice" })
-	await db.set("city", { id: "paris", game: "game", player: "bob" })
-	await db.update("game", { id: "game", city: ["london", "paris"] })
-	await db.update("player", { id: "alice", city: ["london"] })
-	await db.update("player", { id: "bob", city: ["paris"] })
+// 		await db.set("city", { id: "london", game: "game", player: "alice" })
+// 		await db.set("city", { id: "paris", game: "game", player: "bob" })
+// 		await db.update("game", { id: "game", city: ["london", "paris"] })
+// 		await db.update("player", { id: "alice", city: ["london"] })
+// 		await db.update("player", { id: "bob", city: ["paris"] })
 
-	await db.set("unit", { id: "unit1", game: "game", city: "london", player: "alice" })
-	await db.set("unit", { id: "unit2", game: "game", city: "london", player: "alice" })
-	await db.set("unit", { id: "unit3", game: "game", city: "paris", player: "bob" })
-	await db.set("unit", { id: "unit4", game: "game", city: "paris", player: "bob" })
-	await db.set("unit", { id: "unit5", game: "game", city: null, player: "bob" })
-	await db.update("player", { id: "alice", unit: ["unit1", "unit2"] })
-	await db.update("player", { id: "bob", unit: ["unit3", "unit4", "unit5"] })
-	await db.update("city", { id: "london", unit: ["unit1", "unit2"] })
-	await db.update("city", { id: "paris", unit: ["unit3", "unit4"] })
-	await db.update("game", { id: "game", unit: ["unit1", "unit2", "unit3", "unit4", "unit5"] })
+// 		await db.set("unit", { id: "unit1", game: "game", city: "london", player: "alice" })
+// 		await db.set("unit", { id: "unit2", game: "game", city: "london", player: "alice" })
+// 		await db.set("unit", { id: "unit3", game: "game", city: "paris", player: "bob" })
+// 		await db.set("unit", { id: "unit4", game: "game", city: "paris", player: "bob" })
+// 		await db.set("unit", { id: "unit5", game: "game", city: null, player: "bob" })
+// 		await db.update("player", { id: "alice", unit: ["unit1", "unit2"] })
+// 		await db.update("player", { id: "bob", unit: ["unit3", "unit4", "unit5"] })
+// 		await db.update("city", { id: "london", unit: ["unit1", "unit2"] })
+// 		await db.update("city", { id: "paris", unit: ["unit3", "unit4"] })
+// 		await db.update("game", { id: "game", unit: ["unit1", "unit2", "unit3", "unit4", "unit5"] })
 
-	t.deepEqual(await db.query("game", { select: { id: true, player: true, city: true, unit: true } }), [
-		{
-			id: 'game',
-			player: [ 'alice', 'bob' ],
-			city: [ 'london', 'paris' ],
-			unit: [ 'unit1', 'unit2', 'unit3', 'unit4', 'unit5' ]
-		}
-	])
-})
+// 		t.deepEqual(await db.query("game", { select: { id: true, player: true, city: true, unit: true } }), [
+// 			{
+// 				id: "game",
+// 				player: ["alice", "bob"],
+// 				city: ["london", "paris"],
+// 				unit: ["unit1", "unit2", "unit3", "unit4", "unit5"],
+// 			},
+// 		])
+
+// 		await t.throwsAsync(async () => {
+// 			await db.query("game", {
+// 				include: {
+// 					player: {
+// 						unit: {
+// 							player: {},
+// 						},
+// 					},
+// 					city: {
+// 						player: {},
+// 					},
+// 				},
+// 				where: { id: "game" },
+// 			})
+// 		})
+// 	},
+// 	{ sqliteWasm: true, sqlite: true, idb: false, pg: true, do: true },
+// )
+
+testOnModelDB(
+	"select nested reference and relation values (with include)",
+	async (t, openDB) => {
+		const db = await openDB(t, {
+			game: { id: "primary", player: "@player[]", city: "@city[]", unit: "@unit[]" },
+			player: { id: "primary", game: "@game", city: "@city[]", unit: "@unit[]" },
+			city: { id: "primary", player: "@player" },
+			unit: { id: "primary", player: "@player" },
+		})
+
+		await db.set("game", { id: "game", player: [], city: [], unit: [] })
+
+		await db.set("player", { id: "alice", game: "game", city: [], unit: [] })
+		await db.set("player", { id: "bob", game: "game", city: [], unit: [] })
+		await db.update("game", { id: "game", player: ["alice", "bob"], city: [], unit: [] })
+
+		await db.set("city", { id: "london", game: "game", player: "alice" })
+		await db.set("city", { id: "paris", game: "game", player: "bob" })
+		await db.update("game", { id: "game", city: ["london", "paris"] })
+		await db.update("player", { id: "alice", city: ["london"] })
+		await db.update("player", { id: "bob", city: ["paris"] })
+
+		await db.set("unit", { id: "unit1", game: "game", city: "london", player: "alice" })
+		await db.set("unit", { id: "unit2", game: "game", city: "london", player: "alice" })
+		await db.set("unit", { id: "unit3", game: "game", city: "paris", player: "bob" })
+		await db.set("unit", { id: "unit4", game: "game", city: "paris", player: "bob" })
+		await db.set("unit", { id: "unit5", game: "game", city: null, player: "bob" })
+		await db.update("player", { id: "alice", unit: ["unit1", "unit2"] })
+		await db.update("player", { id: "bob", unit: ["unit3", "unit4", "unit5"] })
+		await db.update("city", { id: "london", unit: ["unit1", "unit2"] })
+		await db.update("city", { id: "paris", unit: ["unit3", "unit4"] })
+		await db.update("game", { id: "game", unit: ["unit1", "unit2", "unit3", "unit4", "unit5"] })
+
+		t.deepEqual(
+			await db.query("game", {
+				include: {
+					player: {
+						unit: {
+							player: {},
+						},
+					},
+					city: {
+						player: {},
+					},
+				},
+				where: { id: "game" },
+			}),
+			[
+				{
+					id: "game",
+					player: [
+						{ id: "alice", unit: [{ id: "unit1" }, { id: "unit2" }] },
+						{ id: "bob", unit: [{ id: "unit3" }, { id: "unit4" }, { id: "unit5" }] },
+					],
+					city: [
+						{ id: "london", unit: [{ id: "unit1" }, { id: "unit2" }] },
+						{ id: "paris", unit: [{ id: "unit3" }, { id: "unit4" }] },
+					],
+				},
+			],
+		)
+	},
+	{ sqliteWasm: false, sqlite: false, idb: true, pg: false, do: false },
+)

--- a/packages/modeldb/test/relations.test.ts
+++ b/packages/modeldb/test/relations.test.ts
@@ -278,8 +278,8 @@ testOnModelDB(
 							game: "game",
 							city: ["london"],
 							unit: [
-								{ id: "unit1", player: "alice" },
-								{ id: "unit2", player: "alice" },
+								{ id: "unit1", player: { id: "alice", game: "game", city: ["london"], unit: ["unit1", "unit2"] } },
+								{ id: "unit2", player: { id: "alice", game: "game", city: ["london"], unit: ["unit1", "unit2"] } },
 							],
 						},
 						{
@@ -287,9 +287,18 @@ testOnModelDB(
 							game: "game",
 							city: ["paris"],
 							unit: [
-								{ id: "unit3", player: "bob" },
-								{ id: "unit4", player: "bob" },
-								{ id: "unit5", player: "bob" },
+								{
+									id: "unit3",
+									player: { id: "bob", game: "game", city: ["paris"], unit: ["unit3", "unit4", "unit5"] },
+								},
+								{
+									id: "unit4",
+									player: { id: "bob", game: "game", city: ["paris"], unit: ["unit3", "unit4", "unit5"] },
+								},
+								{
+									id: "unit5",
+									player: { id: "bob", game: "game", city: ["paris"], unit: ["unit3", "unit4", "unit5"] },
+								},
 							],
 						},
 					],

--- a/packages/modeldb/test/relations.test.ts
+++ b/packages/modeldb/test/relations.test.ts
@@ -229,7 +229,7 @@ testOnModelDB(
 			game: { id: "primary", player: "@player[]", city: "@city[]", unit: "@unit[]" },
 			player: { id: "primary", game: "@game", city: "@city[]", unit: "@unit[]" },
 			city: { id: "primary", player: "@player" },
-			unit: { id: "primary", player: "@player" },
+			unit: { id: "primary", player: "@player", city: "@city?" },
 		})
 
 		await db.set("game", { id: "game", player: [], city: [], unit: [] })
@@ -278,8 +278,8 @@ testOnModelDB(
 							game: "game",
 							city: ["london"],
 							unit: [
-								{ id: "unit1", player: { id: "alice", game: "game", city: ["london"], unit: ["unit1", "unit2"] } },
-								{ id: "unit2", player: { id: "alice", game: "game", city: ["london"], unit: ["unit1", "unit2"] } },
+								{ id: "unit1", city: "london", player: { id: "alice", game: "game", city: ["london"], unit: ["unit1", "unit2"] } },
+								{ id: "unit2", city: "london", player: { id: "alice", game: "game", city: ["london"], unit: ["unit1", "unit2"] } },
 							],
 						},
 						{
@@ -289,14 +289,17 @@ testOnModelDB(
 							unit: [
 								{
 									id: "unit3",
+									city: "paris",
 									player: { id: "bob", game: "game", city: ["paris"], unit: ["unit3", "unit4", "unit5"] },
 								},
 								{
 									id: "unit4",
+									city: "paris",
 									player: { id: "bob", game: "game", city: ["paris"], unit: ["unit3", "unit4", "unit5"] },
 								},
 								{
 									id: "unit5",
+									city: null,
 									player: { id: "bob", game: "game", city: ["paris"], unit: ["unit3", "unit4", "unit5"] },
 								},
 							],
@@ -318,7 +321,7 @@ testOnModelDB(
 								id: "bob",
 								game: "game",
 								city: ["paris"],
-								unit: ["unit3", "unit4"],
+								unit: ["unit3", "unit4", "unit5"],
 							},
 						},
 					],

--- a/packages/modeldb/test/relations.test.ts
+++ b/packages/modeldb/test/relations.test.ts
@@ -1,226 +1,226 @@
 import { nanoid } from "nanoid"
 import { testOnModelDB } from "./utils.js"
 
-// testOnModelDB("set and get reference and relation values", async (t, openDB) => {
-// 	const db = await openDB(t, {
-// 		user: { address: "primary" },
-// 		room: {
-// 			id: "primary",
-// 			creator: "@user",
-// 			members: "@user[]",
-// 		},
-// 	})
+testOnModelDB("set and get reference and relation values", async (t, openDB) => {
+	const db = await openDB(t, {
+		user: { address: "primary" },
+		room: {
+			id: "primary",
+			creator: "@user",
+			members: "@user[]",
+		},
+	})
 
-// 	await db.set("user", { address: "a" })
-// 	await db.set("user", { address: "b" })
+	await db.set("user", { address: "a" })
+	await db.set("user", { address: "b" })
 
-// 	t.is(await db.count("user"), 2)
+	t.is(await db.count("user"), 2)
 
-// 	const roomId = nanoid()
-// 	await db.set("room", { id: roomId, creator: "a", members: ["a", "b"] })
-// 	t.deepEqual(await db.get("room", roomId), { id: roomId, creator: "a", members: ["a", "b"] })
-// })
+	const roomId = nanoid()
+	await db.set("room", { id: roomId, creator: "a", members: ["a", "b"] })
+	t.deepEqual(await db.get("room", roomId), { id: roomId, creator: "a", members: ["a", "b"] })
+})
 
-// testOnModelDB("select reference and relation values", async (t, openDB) => {
-// 	const db = await openDB(t, {
-// 		user: { address: "primary" },
-// 		room: {
-// 			id: "primary",
-// 			creator: "@user",
-// 			members: "@user[]",
-// 		},
-// 	})
+testOnModelDB("select reference and relation values", async (t, openDB) => {
+	const db = await openDB(t, {
+		user: { address: "primary" },
+		room: {
+			id: "primary",
+			creator: "@user",
+			members: "@user[]",
+		},
+	})
 
-// 	await db.set("user", { address: "a" })
-// 	await db.set("user", { address: "b" })
-// 	await db.set("user", { address: "c" })
-// 	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
-// 	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
-// 	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
+	await db.set("user", { address: "a" })
+	await db.set("user", { address: "b" })
+	await db.set("user", { address: "c" })
+	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
+	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
+	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
 
-// 	t.deepEqual(await db.query("room", { select: { id: true, creator: true } }), [
-// 		{ id: "x", creator: "a" },
-// 		{ id: "y", creator: "b" },
-// 		{ id: "z", creator: "a" },
-// 	])
+	t.deepEqual(await db.query("room", { select: { id: true, creator: true } }), [
+		{ id: "x", creator: "a" },
+		{ id: "y", creator: "b" },
+		{ id: "z", creator: "a" },
+	])
 
-// 	t.deepEqual(await db.query("room", { select: { id: true, members: true } }), [
-// 		{ id: "x", members: ["a", "b"] },
-// 		{ id: "y", members: ["b", "c"] },
-// 		{ id: "z", members: ["a", "c"] },
-// 	])
+	t.deepEqual(await db.query("room", { select: { id: true, members: true } }), [
+		{ id: "x", members: ["a", "b"] },
+		{ id: "y", members: ["b", "c"] },
+		{ id: "z", members: ["a", "c"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { select: { id: true, creator: true, members: true } }), [
-// 		{ id: "x", creator: "a", members: ["a", "b"] },
-// 		{ id: "y", creator: "b", members: ["b", "c"] },
-// 		{ id: "z", creator: "a", members: ["a", "c"] },
-// 	])
-// })
+	t.deepEqual(await db.query("room", { select: { id: true, creator: true, members: true } }), [
+		{ id: "x", creator: "a", members: ["a", "b"] },
+		{ id: "y", creator: "b", members: ["b", "c"] },
+		{ id: "z", creator: "a", members: ["a", "c"] },
+	])
+})
 
-// testOnModelDB("query reference values", async (t, openDB) => {
-// 	const db = await openDB(t, {
-// 		user: { address: "primary" },
-// 		room: {
-// 			id: "primary",
-// 			creator: "@user",
-// 			members: "@user[]",
-// 		},
-// 	})
+testOnModelDB("query reference values", async (t, openDB) => {
+	const db = await openDB(t, {
+		user: { address: "primary" },
+		room: {
+			id: "primary",
+			creator: "@user",
+			members: "@user[]",
+		},
+	})
 
-// 	await db.set("user", { address: "a" })
-// 	await db.set("user", { address: "b" })
-// 	await db.set("user", { address: "c" })
-// 	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
-// 	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
-// 	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
+	await db.set("user", { address: "a" })
+	await db.set("user", { address: "b" })
+	await db.set("user", { address: "c" })
+	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
+	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
+	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
 
-// 	t.deepEqual(await db.query("room", { where: { creator: "a" } }), [
-// 		{ id: "x", creator: "a", members: ["a", "b"] },
-// 		{ id: "z", creator: "a", members: ["a", "c"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { creator: "a" } }), [
+		{ id: "x", creator: "a", members: ["a", "b"] },
+		{ id: "z", creator: "a", members: ["a", "c"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { creator: "b" } }), [{ id: "y", creator: "b", members: ["b", "c"] }])
-// 	t.deepEqual(await db.query("room", { where: { creator: "c" } }), [])
-// 	t.deepEqual(await db.query("room", { where: { creator: { neq: "a" } } }), [
-// 		{ id: "y", creator: "b", members: ["b", "c"] },
-// 	])
-// })
+	t.deepEqual(await db.query("room", { where: { creator: "b" } }), [{ id: "y", creator: "b", members: ["b", "c"] }])
+	t.deepEqual(await db.query("room", { where: { creator: "c" } }), [])
+	t.deepEqual(await db.query("room", { where: { creator: { neq: "a" } } }), [
+		{ id: "y", creator: "b", members: ["b", "c"] },
+	])
+})
 
-// testOnModelDB("query filtering on relation values", async (t, openDB) => {
-// 	const db = await openDB(t, {
-// 		user: { address: "primary" },
-// 		room: {
-// 			id: "primary",
-// 			creator: "@user",
-// 			members: "@user[]",
-// 		},
-// 	})
+testOnModelDB("query filtering on relation values", async (t, openDB) => {
+	const db = await openDB(t, {
+		user: { address: "primary" },
+		room: {
+			id: "primary",
+			creator: "@user",
+			members: "@user[]",
+		},
+	})
 
-// 	await db.set("user", { address: "a" })
-// 	await db.set("user", { address: "b" })
-// 	await db.set("user", { address: "c" })
-// 	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
-// 	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
-// 	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
+	await db.set("user", { address: "a" })
+	await db.set("user", { address: "b" })
+	await db.set("user", { address: "c" })
+	await db.set("room", { id: "x", creator: "a", members: ["a", "b"] })
+	await db.set("room", { id: "y", creator: "b", members: ["b", "c"] })
+	await db.set("room", { id: "z", creator: "a", members: ["a", "c"] })
 
-// 	t.deepEqual(await db.query("room", { where: { members: ["a"] } }), [
-// 		{ id: "x", creator: "a", members: ["a", "b"] },
-// 		{ id: "z", creator: "a", members: ["a", "c"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: ["a"] } }), [
+		{ id: "x", creator: "a", members: ["a", "b"] },
+		{ id: "z", creator: "a", members: ["a", "c"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: ["b"] } }), [
-// 		{ id: "x", creator: "a", members: ["a", "b"] },
-// 		{ id: "y", creator: "b", members: ["b", "c"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: ["b"] } }), [
+		{ id: "x", creator: "a", members: ["a", "b"] },
+		{ id: "y", creator: "b", members: ["b", "c"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: ["c"] } }), [
-// 		{ id: "y", creator: "b", members: ["b", "c"] },
-// 		{ id: "z", creator: "a", members: ["a", "c"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: ["c"] } }), [
+		{ id: "y", creator: "b", members: ["b", "c"] },
+		{ id: "z", creator: "a", members: ["a", "c"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: ["a", "b"] } }), [
-// 		{ id: "x", creator: "a", members: ["a", "b"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: ["a", "b"] } }), [
+		{ id: "x", creator: "a", members: ["a", "b"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: ["b", "a"] } }), [
-// 		{ id: "x", creator: "a", members: ["a", "b"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: ["b", "a"] } }), [
+		{ id: "x", creator: "a", members: ["a", "b"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: ["b", "c"] } }), [
-// 		{ id: "y", creator: "b", members: ["b", "c"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: ["b", "c"] } }), [
+		{ id: "y", creator: "b", members: ["b", "c"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: ["c", "b"] } }), [
-// 		{ id: "y", creator: "b", members: ["b", "c"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: ["c", "b"] } }), [
+		{ id: "y", creator: "b", members: ["b", "c"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: ["a", "c"] } }), [
-// 		{ id: "z", creator: "a", members: ["a", "c"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: ["a", "c"] } }), [
+		{ id: "z", creator: "a", members: ["a", "c"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: ["c", "a"] } }), [
-// 		{ id: "z", creator: "a", members: ["a", "c"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: ["c", "a"] } }), [
+		{ id: "z", creator: "a", members: ["a", "c"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: ["a", "b", "c"] } }), [])
+	t.deepEqual(await db.query("room", { where: { members: ["a", "b", "c"] } }), [])
 
-// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["a"] } } }), [
-// 		{ id: "y", creator: "b", members: ["b", "c"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: { neq: ["a"] } } }), [
+		{ id: "y", creator: "b", members: ["b", "c"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["b"] } } }), [
-// 		{ id: "z", creator: "a", members: ["a", "c"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: { neq: ["b"] } } }), [
+		{ id: "z", creator: "a", members: ["a", "c"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["c"] } } }), [
-// 		{ id: "x", creator: "a", members: ["a", "b"] },
-// 	])
+	t.deepEqual(await db.query("room", { where: { members: { neq: ["c"] } } }), [
+		{ id: "x", creator: "a", members: ["a", "b"] },
+	])
 
-// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["a", "b"] } } }), [])
-// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["b", "c"] } } }), [])
-// 	t.deepEqual(await db.query("room", { where: { members: { neq: ["a", "c"] } } }), [])
-// })
+	t.deepEqual(await db.query("room", { where: { members: { neq: ["a", "b"] } } }), [])
+	t.deepEqual(await db.query("room", { where: { members: { neq: ["b", "c"] } } }), [])
+	t.deepEqual(await db.query("room", { where: { members: { neq: ["a", "c"] } } }), [])
+})
 
-// testOnModelDB(
-// 	"select nested reference and relation values (without include)",
-// 	async (t, openDB) => {
-// 		const db = await openDB(t, {
-// 			game: { id: "primary", player: "@player[]", city: "@city[]", unit: "@unit[]" },
-// 			player: { id: "primary", game: "@game", city: "@city[]", unit: "@unit[]" },
-// 			city: { id: "primary", player: "@player" },
-// 			unit: { id: "primary", player: "@player" },
-// 		})
+testOnModelDB(
+	"select nested reference and relation values (without include)",
+	async (t, openDB) => {
+		const db = await openDB(t, {
+			game: { id: "primary", player: "@player[]", city: "@city[]", unit: "@unit[]" },
+			player: { id: "primary", game: "@game", city: "@city[]", unit: "@unit[]" },
+			city: { id: "primary", player: "@player" },
+			unit: { id: "primary", player: "@player" },
+		})
 
-// 		await db.set("game", { id: "game", player: [], city: [], unit: [] })
+		await db.set("game", { id: "game", player: [], city: [], unit: [] })
 
-// 		await db.set("player", { id: "alice", game: "game", city: [], unit: [] })
-// 		await db.set("player", { id: "bob", game: "game", city: [], unit: [] })
-// 		await db.update("game", { id: "game", player: ["alice", "bob"], city: [], unit: [] })
+		await db.set("player", { id: "alice", game: "game", city: [], unit: [] })
+		await db.set("player", { id: "bob", game: "game", city: [], unit: [] })
+		await db.update("game", { id: "game", player: ["alice", "bob"], city: [], unit: [] })
 
-// 		await db.set("city", { id: "london", game: "game", player: "alice" })
-// 		await db.set("city", { id: "paris", game: "game", player: "bob" })
-// 		await db.update("game", { id: "game", city: ["london", "paris"] })
-// 		await db.update("player", { id: "alice", city: ["london"] })
-// 		await db.update("player", { id: "bob", city: ["paris"] })
+		await db.set("city", { id: "london", game: "game", player: "alice" })
+		await db.set("city", { id: "paris", game: "game", player: "bob" })
+		await db.update("game", { id: "game", city: ["london", "paris"] })
+		await db.update("player", { id: "alice", city: ["london"] })
+		await db.update("player", { id: "bob", city: ["paris"] })
 
-// 		await db.set("unit", { id: "unit1", game: "game", city: "london", player: "alice" })
-// 		await db.set("unit", { id: "unit2", game: "game", city: "london", player: "alice" })
-// 		await db.set("unit", { id: "unit3", game: "game", city: "paris", player: "bob" })
-// 		await db.set("unit", { id: "unit4", game: "game", city: "paris", player: "bob" })
-// 		await db.set("unit", { id: "unit5", game: "game", city: null, player: "bob" })
-// 		await db.update("player", { id: "alice", unit: ["unit1", "unit2"] })
-// 		await db.update("player", { id: "bob", unit: ["unit3", "unit4", "unit5"] })
-// 		await db.update("city", { id: "london", unit: ["unit1", "unit2"] })
-// 		await db.update("city", { id: "paris", unit: ["unit3", "unit4"] })
-// 		await db.update("game", { id: "game", unit: ["unit1", "unit2", "unit3", "unit4", "unit5"] })
+		await db.set("unit", { id: "unit1", game: "game", city: "london", player: "alice" })
+		await db.set("unit", { id: "unit2", game: "game", city: "london", player: "alice" })
+		await db.set("unit", { id: "unit3", game: "game", city: "paris", player: "bob" })
+		await db.set("unit", { id: "unit4", game: "game", city: "paris", player: "bob" })
+		await db.set("unit", { id: "unit5", game: "game", city: null, player: "bob" })
+		await db.update("player", { id: "alice", unit: ["unit1", "unit2"] })
+		await db.update("player", { id: "bob", unit: ["unit3", "unit4", "unit5"] })
+		await db.update("city", { id: "london", unit: ["unit1", "unit2"] })
+		await db.update("city", { id: "paris", unit: ["unit3", "unit4"] })
+		await db.update("game", { id: "game", unit: ["unit1", "unit2", "unit3", "unit4", "unit5"] })
 
-// 		t.deepEqual(await db.query("game", { select: { id: true, player: true, city: true, unit: true } }), [
-// 			{
-// 				id: "game",
-// 				player: ["alice", "bob"],
-// 				city: ["london", "paris"],
-// 				unit: ["unit1", "unit2", "unit3", "unit4", "unit5"],
-// 			},
-// 		])
+		t.deepEqual(await db.query("game", { select: { id: true, player: true, city: true, unit: true } }), [
+			{
+				id: "game",
+				player: ["alice", "bob"],
+				city: ["london", "paris"],
+				unit: ["unit1", "unit2", "unit3", "unit4", "unit5"],
+			},
+		])
 
-// 		await t.throwsAsync(async () => {
-// 			await db.query("game", {
-// 				include: {
-// 					player: {
-// 						unit: {
-// 							player: {},
-// 						},
-// 					},
-// 					city: {
-// 						player: {},
-// 					},
-// 				},
-// 				where: { id: "game" },
-// 			})
-// 		})
-// 	},
-// 	{ sqliteWasm: true, sqlite: true, idb: false, pg: true, do: true },
-// )
+		await t.throwsAsync(async () => {
+			await db.query("game", {
+				include: {
+					player: {
+						unit: {
+							player: {},
+						},
+					},
+					city: {
+						player: {},
+					},
+				},
+				where: { id: "game" },
+			})
+		})
+	},
+	{ sqliteWasm: true, sqlite: true, idb: false, pg: true, do: true },
+)
 
 testOnModelDB(
 	"select nested reference and relation values (with include)",

--- a/packages/modeldb/test/relations.test.ts
+++ b/packages/modeldb/test/relations.test.ts
@@ -273,13 +273,47 @@ testOnModelDB(
 				{
 					id: "game",
 					player: [
-						{ id: "alice", unit: [{ id: "unit1" }, { id: "unit2" }] },
-						{ id: "bob", unit: [{ id: "unit3" }, { id: "unit4" }, { id: "unit5" }] },
+						{
+							id: "alice",
+							game: "game",
+							city: ["london"],
+							unit: [
+								{ id: "unit1", player: "alice" },
+								{ id: "unit2", player: "alice" },
+							],
+						},
+						{
+							id: "bob",
+							game: "game",
+							city: ["paris"],
+							unit: [
+								{ id: "unit3", player: "bob" },
+								{ id: "unit4", player: "bob" },
+								{ id: "unit5", player: "bob" },
+							],
+						},
 					],
 					city: [
-						{ id: "london", unit: [{ id: "unit1" }, { id: "unit2" }] },
-						{ id: "paris", unit: [{ id: "unit3" }, { id: "unit4" }] },
+						{
+							id: "london",
+							player: {
+								id: "alice",
+								game: "game",
+								city: ["london"],
+								unit: ["unit1", "unit2"],
+							},
+						},
+						{
+							id: "paris",
+							player: {
+								id: "bob",
+								game: "game",
+								city: ["paris"],
+								unit: ["unit3", "unit4"],
+							},
+						},
 					],
+					unit: ["unit1", "unit2", "unit3", "unit4", "unit5"],
 				},
 			],
 		)


### PR DESCRIPTION
Allows making queries with joins over references or relations:

```
await db.query("room", {
  where: { id: gameId },
  include: {
    members: { profile: {} },
    messages: {},
  }
})
```

Lighter syntax than Prisma (no nested `{ foo: { include: { bar: true } } }`). Only supported in IndexedDB. Other database backends should throw an error.

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
