### PR TITLE
generic result values: provide Actions type for record of action implementations

### DIFF
--- a/examples/chat/src/contract.ts
+++ b/examples/chat/src/contract.ts
@@ -1,4 +1,4 @@
-import type { ActionSchema, ModelSchema } from "@canvas-js/core"
+import type { Actions, ModelSchema } from "@canvas-js/core"
 
 const models = {
 	message: {
@@ -14,6 +14,6 @@ export const actions = {
 	async createMessage(db, { content }, { id, address, timestamp }) {
 		await db.set("message", { id, address, content, timestamp })
 	},
-} satisfies ActionSchema<typeof models>
+} satisfies Actions<typeof models>
 
 export const contract = { models, actions }

--- a/examples/chat/src/contract.ts
+++ b/examples/chat/src/contract.ts
@@ -1,4 +1,4 @@
-import type { Contract, ModelSchema } from "@canvas-js/core"
+import type { ActionSchema, ModelSchema } from "@canvas-js/core"
 
 const models = {
 	message: {
@@ -10,11 +10,10 @@ const models = {
 	},
 } satisfies ModelSchema
 
-export const contract = {
-	models,
-	actions: {
-		async createMessage(db, { content }, { id, address, timestamp }) {
-			await db.set("message", { id, address, content, timestamp })
-		},
+export const actions = {
+	async createMessage(db, { content }, { id, address, timestamp }) {
+		await db.set("message", { id, address, content, timestamp })
 	},
-} satisfies Contract<typeof models>
+} satisfies ActionSchema<typeof models>
+
+export const contract = { models, actions }

--- a/examples/common-explorer/server/contract.ts
+++ b/examples/common-explorer/server/contract.ts
@@ -1,4 +1,4 @@
-import type { ModelSchema, ActionSchema } from "@canvas-js/core"
+import type { ModelSchema, Actions } from "@canvas-js/core"
 
 export const contractTopic = "common.xyz"
 
@@ -140,6 +140,6 @@ export const actions = {
 		if (!r || !r.id) throw new Error("reaction does not exist")
 		await db.delete("comment_reactions", `${comment_id}/${did}`)
 	},
-} satisfies ActionSchema<typeof models>
+} satisfies Actions<typeof models>
 
 export const contract = { models, actions }

--- a/examples/common-explorer/server/contract.ts
+++ b/examples/common-explorer/server/contract.ts
@@ -1,4 +1,4 @@
-import type { Contract, ModelSchema } from "@canvas-js/core"
+import type { ModelSchema, ActionSchema } from "@canvas-js/core"
 
 export const contractTopic = "common.xyz"
 
@@ -41,106 +41,105 @@ export const models = {
 	},
 } satisfies ModelSchema
 
-export const contract = {
-	models,
-	actions: {
-		async thread(db, { community, title, body, link, topic }, { did, id, timestamp }) {
-			await db.set("threads", {
-				id: id,
-				author: did,
-				community,
-				title,
-				body,
-				link,
-				topic,
-				updated_at: timestamp,
-			})
-		},
-		// TODO: not implemented (packages/commonwealth/server/routes/threads/update_thread_handler.ts)
-		async updateThread(db, { thread_id, title, body, link, topic }, { did, timestamp }) {
-			const t = await db.get("threads", thread_id)
-			if (!t || !t.id) throw new Error("invalid thread")
-			if (t.author !== did) throw new Error("invalid thread")
-			await db.set("threads", {
-				id: t.id as string,
-				author: t.author,
-				community: t.community,
-				title,
-				body,
-				link,
-				topic,
-				updated_at: timestamp,
-			})
-		},
-		async deleteThread(db, { thread_id }, { did }) {
-			const t = await db.get("threads", thread_id)
-			if (!t || !t.id) throw new Error("invalid thread")
-			if (t.author !== did) throw new Error("invalid thread")
-			await db.delete("threads", t.id as string)
-		},
-		async comment(db, { thread_id, body, parent_comment_id }, { did, id, timestamp }) {
-			await db.set("comments", {
-				id: id,
-				author: did,
-				thread_id,
-				body,
-				parent_comment_id,
-				updated_at: timestamp,
-			})
-		},
-		// TODO: not implemented (packages/commonwealth/server/routes/comments/update_comment_handler.ts)
-		async updateComment(db, { comment_id, body }, { did, timestamp }) {
-			const c = await db.get("comments", comment_id)
-			if (!c || !c.id) throw new Error("invalid comment")
-			if (c.author !== did) throw new Error("invalid comment")
-			await db.set("comments", {
-				id: c.id,
-				author: c.author,
-				thread_id: c.thread_id,
-				body,
-				parent_comment_id: c.parent_comment_id,
-				updated_at: timestamp,
-			})
-		},
-		async deleteComment(db, { comment_id }, { did }) {
-			const c = await db.get("comments", comment_id)
-			if (!c || !c.id) throw new Error("invalid comment")
-			if (c.author !== did) throw new Error("invalid comment")
-			await db.delete("comments", c.id as string)
-		},
-		async reactThread(db, { thread_id, value }, { did, timestamp }) {
-			if (value !== "like" && value !== "dislike") {
-				throw new Error("Invalid reaction")
-			}
-			await db.set("thread_reactions", {
-				id: `${thread_id}/${did}`,
-				author: did,
-				thread_id,
-				value,
-				updated_at: timestamp,
-			})
-		},
-		async unreactThread(db, { thread_id }, { did }) {
-			const r = await db.get("thread_reactions", `${thread_id}/${did}`)
-			if (!r || !r.id) throw new Error("reaction does not exist")
-			await db.delete("thread_reactions", `${thread_id}/${did}`)
-		},
-		async reactComment(db, { comment_id, value }, { did, timestamp }) {
-			if (value !== "like" && value !== "dislike") {
-				throw new Error("Invalid reaction")
-			}
-			await db.set("comment_reactions", {
-				id: `${comment_id}/${did}`,
-				author: did,
-				comment_id,
-				value,
-				updated_at: timestamp,
-			})
-		},
-		async unreactComment(db, { comment_id }, { did }) {
-			const r = await db.get("comment_reactions", `${comment_id}/${did}`)
-			if (!r || !r.id) throw new Error("reaction does not exist")
-			await db.delete("comment_reactions", `${comment_id}/${did}`)
-		},
+export const actions = {
+	async thread(db, { community, title, body, link, topic }, { did, id, timestamp }) {
+		await db.set("threads", {
+			id: id,
+			author: did,
+			community,
+			title,
+			body,
+			link,
+			topic,
+			updated_at: timestamp,
+		})
 	},
-} satisfies Contract<typeof models>
+	// TODO: not implemented (packages/commonwealth/server/routes/threads/update_thread_handler.ts)
+	async updateThread(db, { thread_id, title, body, link, topic }, { did, timestamp }) {
+		const t = await db.get("threads", thread_id)
+		if (!t || !t.id) throw new Error("invalid thread")
+		if (t.author !== did) throw new Error("invalid thread")
+		await db.set("threads", {
+			id: t.id as string,
+			author: t.author,
+			community: t.community,
+			title,
+			body,
+			link,
+			topic,
+			updated_at: timestamp,
+		})
+	},
+	async deleteThread(db, { thread_id }, { did }) {
+		const t = await db.get("threads", thread_id)
+		if (!t || !t.id) throw new Error("invalid thread")
+		if (t.author !== did) throw new Error("invalid thread")
+		await db.delete("threads", t.id as string)
+	},
+	async comment(db, { thread_id, body, parent_comment_id }, { did, id, timestamp }) {
+		await db.set("comments", {
+			id: id,
+			author: did,
+			thread_id,
+			body,
+			parent_comment_id,
+			updated_at: timestamp,
+		})
+	},
+	// TODO: not implemented (packages/commonwealth/server/routes/comments/update_comment_handler.ts)
+	async updateComment(db, { comment_id, body }, { did, timestamp }) {
+		const c = await db.get("comments", comment_id)
+		if (!c || !c.id) throw new Error("invalid comment")
+		if (c.author !== did) throw new Error("invalid comment")
+		await db.set("comments", {
+			id: c.id,
+			author: c.author,
+			thread_id: c.thread_id,
+			body,
+			parent_comment_id: c.parent_comment_id,
+			updated_at: timestamp,
+		})
+	},
+	async deleteComment(db, { comment_id }, { did }) {
+		const c = await db.get("comments", comment_id)
+		if (!c || !c.id) throw new Error("invalid comment")
+		if (c.author !== did) throw new Error("invalid comment")
+		await db.delete("comments", c.id as string)
+	},
+	async reactThread(db, { thread_id, value }, { did, timestamp }) {
+		if (value !== "like" && value !== "dislike") {
+			throw new Error("Invalid reaction")
+		}
+		await db.set("thread_reactions", {
+			id: `${thread_id}/${did}`,
+			author: did,
+			thread_id,
+			value,
+			updated_at: timestamp,
+		})
+	},
+	async unreactThread(db, { thread_id }, { did }) {
+		const r = await db.get("thread_reactions", `${thread_id}/${did}`)
+		if (!r || !r.id) throw new Error("reaction does not exist")
+		await db.delete("thread_reactions", `${thread_id}/${did}`)
+	},
+	async reactComment(db, { comment_id, value }, { did, timestamp }) {
+		if (value !== "like" && value !== "dislike") {
+			throw new Error("Invalid reaction")
+		}
+		await db.set("comment_reactions", {
+			id: `${comment_id}/${did}`,
+			author: did,
+			comment_id,
+			value,
+			updated_at: timestamp,
+		})
+	},
+	async unreactComment(db, { comment_id }, { did }) {
+		const r = await db.get("comment_reactions", `${comment_id}/${did}`)
+		if (!r || !r.id) throw new Error("reaction does not exist")
+		await db.delete("comment_reactions", `${comment_id}/${did}`)
+	},
+} satisfies ActionSchema<typeof models>
+
+export const contract = { models, actions }

--- a/examples/encrypted-chat/src/contract.ts
+++ b/examples/encrypted-chat/src/contract.ts
@@ -1,4 +1,4 @@
-import type { ActionSchema, ModelSchema } from "@canvas-js/core"
+import type { ModelSchema, Actions } from "@canvas-js/core"
 
 const models = {
 	encryptionKeys: {
@@ -38,6 +38,6 @@ export const actions = {
 		// TODO: check address is in group
 		db.set("privateMessages", { id, ciphertext, group, timestamp })
 	},
-} satisfies ActionSchema<typeof models>
+} satisfies Actions<typeof models>
 
 export const contract = { models, actions }

--- a/examples/encrypted-chat/src/contract.ts
+++ b/examples/encrypted-chat/src/contract.ts
@@ -1,4 +1,4 @@
-import type { Contract, ModelSchema } from "@canvas-js/core"
+import type { ActionSchema, ModelSchema } from "@canvas-js/core"
 
 const models = {
 	encryptionKeys: {
@@ -19,26 +19,25 @@ const models = {
 	},
 } satisfies ModelSchema
 
-export const contract = {
-	models,
-	actions: {
-		registerEncryptionKey: (db, { key }, { address }) => {
-			db.set("encryptionKeys", { address, key })
-		},
-		createEncryptionGroup: (db, { members, groupKeys, groupPublicKey }, { address }) => {
-			// TODO: enforce the encryption group is sorted correctly, and each groupKey is registered correctly
-			if (members.indexOf(address) === -1) throw new Error()
-			const id = members.join()
-
-			db.set("encryptionGroups", {
-				id,
-				groupKeys: JSON.stringify(groupKeys),
-				key: groupPublicKey,
-			})
-		},
-		sendPrivateMessage: (db, { group, ciphertext }, { timestamp, id }) => {
-			// TODO: check address is in group
-			db.set("privateMessages", { id, ciphertext, group, timestamp })
-		},
+export const actions = {
+	registerEncryptionKey: (db, { key }, { address }) => {
+		db.set("encryptionKeys", { address, key })
 	},
-} satisfies Contract<typeof models>
+	createEncryptionGroup: (db, { members, groupKeys, groupPublicKey }, { address }) => {
+		// TODO: enforce the encryption group is sorted correctly, and each groupKey is registered correctly
+		if (members.indexOf(address) === -1) throw new Error()
+		const id = members.join()
+
+		db.set("encryptionGroups", {
+			id,
+			groupKeys: JSON.stringify(groupKeys),
+			key: groupPublicKey,
+		})
+	},
+	sendPrivateMessage: (db, { group, ciphertext }, { timestamp, id }) => {
+		// TODO: check address is in group
+		db.set("privateMessages", { id, ciphertext, group, timestamp })
+	},
+} satisfies ActionSchema<typeof models>
+
+export const contract = { models, actions }

--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -14,7 +14,7 @@ import { assert } from "@canvas-js/utils"
 
 import target from "#target"
 
-import type { Contract, ActionImpls, ActionImpl } from "./types.js"
+import type { Contract, ActionSchema, ActionImplementation } from "./types.js"
 import { Runtime, createRuntime } from "./runtime/index.js"
 import { ActionRecord } from "./runtime/AbstractRuntime.js"
 import { validatePayload } from "./schema.js"
@@ -24,7 +24,7 @@ import { topicPattern } from "./utils.js"
 export type { Model } from "@canvas-js/modeldb"
 export type { PeerId } from "@libp2p/interface"
 
-export type Config<Models extends ModelSchema = any, Actions extends ActionImpls<Models> = ActionImpls<Models>> = {
+export type Config<Models extends ModelSchema = any, Actions extends ActionSchema<Models> = ActionSchema<Models>> = {
 	topic: string
 	contract: string | Contract<Models, Actions>
 	signers?: SessionSigner[]
@@ -71,9 +71,9 @@ export type ApplicationData = {
 
 export class Canvas<
 	Models extends ModelSchema = ModelSchema,
-	Actions extends ActionImpls<Models> = ActionImpls<Models>,
+	Actions extends ActionSchema<Models> = ActionSchema<Models>,
 > extends TypedEventEmitter<CanvasEvents> {
-	public static async initialize<Models extends ModelSchema, Actions extends ActionImpls<Models> = ActionImpls<Models>>(
+	public static async initialize<Models extends ModelSchema, Actions extends ActionSchema<Models> = ActionSchema<Models>>(
 		config: Config<Models, Actions>,
 	): Promise<Canvas<Models, Actions>> {
 		const { topic, path = null, contract, signers: initSigners = [], runtimeMemoryLimit } = config
@@ -172,7 +172,7 @@ export class Canvas<
 
 	public readonly db: AbstractModelDB
 	public readonly actions = {} as {
-		[K in keyof Actions]: Actions[K] extends ActionImpl<Models, infer Args, infer Result>
+		[K in keyof Actions]: Actions[K] extends ActionImplementation<Models, infer Args, infer Result>
 			? ActionAPI<Args, Result>
 			: never
 	}

--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -14,7 +14,7 @@ import { assert } from "@canvas-js/utils"
 
 import target from "#target"
 
-import type { Contract, ActionSchema, ActionImplementation } from "./types.js"
+import type { Contract, Actions, ActionImplementation } from "./types.js"
 import { Runtime, createRuntime } from "./runtime/index.js"
 import { ActionRecord } from "./runtime/AbstractRuntime.js"
 import { validatePayload } from "./schema.js"
@@ -24,9 +24,9 @@ import { topicPattern } from "./utils.js"
 export type { Model } from "@canvas-js/modeldb"
 export type { PeerId } from "@libp2p/interface"
 
-export type Config<Models extends ModelSchema = any, Actions extends ActionSchema<Models> = ActionSchema<Models>> = {
+export type Config<ModelsT extends ModelSchema = any, ActionsT extends Actions<ModelsT> = Actions<ModelsT>> = {
 	topic: string
-	contract: string | Contract<Models, Actions>
+	contract: string | Contract<ModelsT, ActionsT>
 	signers?: SessionSigner[]
 
 	/** data directory path (NodeJS/sqlite), postgres connection config (NodeJS/pg), or storage backend (Cloudflare DO) */
@@ -70,12 +70,12 @@ export type ApplicationData = {
 }
 
 export class Canvas<
-	Models extends ModelSchema = ModelSchema,
-	Actions extends ActionSchema<Models> = ActionSchema<Models>,
+	ModelsT extends ModelSchema = ModelSchema,
+	ActionsT extends Actions<ModelsT> = Actions<ModelsT>,
 > extends TypedEventEmitter<CanvasEvents> {
-	public static async initialize<Models extends ModelSchema, Actions extends ActionSchema<Models> = ActionSchema<Models>>(
-		config: Config<Models, Actions>,
-	): Promise<Canvas<Models, Actions>> {
+	public static async initialize<ModelsT extends ModelSchema, ActionsT extends Actions<ModelsT> = Actions<ModelsT>>(
+		config: Config<ModelsT, ActionsT>,
+	): Promise<Canvas<ModelsT, ActionsT>> {
 		const { topic, path = null, contract, signers: initSigners = [], runtimeMemoryLimit } = config
 
 		assert(topicPattern.test(topic), "invalid topic (must match [a-zA-Z0-9\\.\\-])")
@@ -117,7 +117,7 @@ export class Canvas<
 			await messageLog.append(config.snapshot)
 		}
 
-		const app = new Canvas<Models, Actions>(signers, messageLog, runtime)
+		const app = new Canvas<ModelsT, ActionsT>(signers, messageLog, runtime)
 
 		// Check to see if the $actions table is empty and populate it if necessary
 		const messagesCount = await db.count("$messages")
@@ -172,7 +172,7 @@ export class Canvas<
 
 	public readonly db: AbstractModelDB
 	public readonly actions = {} as {
-		[K in keyof Actions]: Actions[K] extends ActionImplementation<Models, infer Args, infer Result>
+		[K in keyof ActionsT]: ActionsT[K] extends ActionImplementation<ModelsT, infer Args, infer Result>
 			? ActionAPI<Args, Result>
 			: never
 	}

--- a/packages/core/src/runtime/FunctionRuntime.ts
+++ b/packages/core/src/runtime/FunctionRuntime.ts
@@ -16,12 +16,12 @@ import { assert } from "@canvas-js/utils"
 import { ActionImplementation, Contract, ModelAPI } from "../types.js"
 import { AbstractRuntime, ExecutionContext } from "./AbstractRuntime.js"
 
-export class FunctionRuntime<M extends ModelSchema> extends AbstractRuntime {
-	public static async init<M extends ModelSchema>(
+export class FunctionRuntime<ModelsT extends ModelSchema> extends AbstractRuntime {
+	public static async init<ModelsT extends ModelSchema>(
 		topic: string,
 		signers: SignerCache,
-		contract: Contract<M>,
-	): Promise<FunctionRuntime<M>> {
+		contract: Contract<ModelsT>,
+	): Promise<FunctionRuntime<ModelsT>> {
 		assert(contract.actions !== undefined, "contract initialized without actions")
 		assert(contract.models !== undefined, "contract initialized without models")
 
@@ -30,7 +30,7 @@ export class FunctionRuntime<M extends ModelSchema> extends AbstractRuntime {
 	}
 
 	#context: ExecutionContext | null = null
-	readonly #db: ModelAPI<DeriveModelTypes<M>>
+	readonly #db: ModelAPI<DeriveModelTypes<ModelsT>>
 
 	#lock: DeferredPromise<void> | null = null
 	#concurrency: number = 0
@@ -55,17 +55,17 @@ export class FunctionRuntime<M extends ModelSchema> extends AbstractRuntime {
 		public readonly topic: string,
 		public readonly signers: SignerCache,
 		public readonly schema: ModelSchema,
-		public readonly actions: Record<string, ActionImplementation<M, any>>,
+		public readonly actions: Record<string, ActionImplementation<ModelsT, any>>,
 	) {
 		super()
 
 		this.#db = {
-			get: async <T extends keyof DeriveModelTypes<M> & string>(model: T, key: string) => {
+			get: async <T extends keyof DeriveModelTypes<ModelsT> & string>(model: T, key: string) => {
 				await this.acquireLock()
 				try {
 					assert(this.#context !== null, "expected this.#context !== null")
 					const result = await this.getModelValue(this.#context, model, key)
-					return result as DeriveModelTypes<M>[T]
+					return result as DeriveModelTypes<ModelsT>[T]
 				} finally {
 					this.releaseLock()
 				}

--- a/packages/core/src/runtime/FunctionRuntime.ts
+++ b/packages/core/src/runtime/FunctionRuntime.ts
@@ -13,7 +13,7 @@ import {
 } from "@canvas-js/modeldb"
 import { assert } from "@canvas-js/utils"
 
-import { ActionImpl, Contract, ModelAPI } from "../types.js"
+import { ActionImplementation, Contract, ModelAPI } from "../types.js"
 import { AbstractRuntime, ExecutionContext } from "./AbstractRuntime.js"
 
 export class FunctionRuntime<M extends ModelSchema> extends AbstractRuntime {
@@ -55,7 +55,7 @@ export class FunctionRuntime<M extends ModelSchema> extends AbstractRuntime {
 		public readonly topic: string,
 		public readonly signers: SignerCache,
 		public readonly schema: ModelSchema,
-		public readonly actions: Record<string, ActionImpl<M, any>>,
+		public readonly actions: Record<string, ActionImplementation<M, any>>,
 	) {
 		super()
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,17 +4,17 @@ import type { Awaitable } from "@canvas-js/interfaces"
 export type { ModelValue, ModelSchema, DeriveModelTypes } from "@canvas-js/modeldb"
 
 export type Contract<
-	Models extends ModelSchema = ModelSchema,
-	Actions extends ActionSchema<Models> = ActionSchema<Models>,
+	ModelsT extends ModelSchema = ModelSchema,
+	ActionsT extends Actions<ModelsT> = Actions<ModelsT>,
 > = {
-	models: Models
-	actions: Actions
+	models: ModelsT
+	actions: ActionsT
 }
 
-export type ActionSchema<Models extends ModelSchema> = Record<string, ActionImplementation<Models>>
+export type Actions<ModelsT extends ModelSchema> = Record<string, ActionImplementation<ModelsT>>
 
-export type ActionImplementation<Models extends ModelSchema = ModelSchema, Args = any, Result = any> = (
-	db: ModelAPI<DeriveModelTypes<Models>>,
+export type ActionImplementation<ModelsT extends ModelSchema = ModelSchema, Args = any, Result = any> = (
+	db: ModelAPI<DeriveModelTypes<ModelsT>>,
 	args: Args,
 	context: ActionContext,
 ) => Awaitable<Result>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,15 +5,15 @@ export type { ModelValue, ModelSchema, DeriveModelTypes } from "@canvas-js/model
 
 export type Contract<
 	Models extends ModelSchema = ModelSchema,
-	Actions extends ActionImpls<Models> = ActionImpls<Models>,
+	Actions extends ActionSchema<Models> = ActionSchema<Models>,
 > = {
 	models: Models
 	actions: Actions
 }
 
-export type ActionImpls<Models extends ModelSchema> = Record<string, ActionImpl<Models>>
+export type ActionSchema<Models extends ModelSchema> = Record<string, ActionImplementation<Models>>
 
-export type ActionImpl<Models extends ModelSchema = ModelSchema, Args = any, Result = any> = (
+export type ActionImplementation<Models extends ModelSchema = ModelSchema, Args = any, Result = any> = (
 	db: ModelAPI<DeriveModelTypes<Models>>,
 	args: Args,
 	context: ActionContext,

--- a/packages/hooks/src/useCanvas.ts
+++ b/packages/hooks/src/useCanvas.ts
@@ -6,12 +6,12 @@ import {
 	type Config,
 	type Snapshot,
 	hashContract,
-	ActionImpls,
+	ActionSchema,
 } from "@canvas-js/core"
 
 export const useCanvas = <
 	Models extends ModelSchema = ModelSchema,
-	Actions extends ActionImpls<Models> = ActionImpls<Models>,
+	Actions extends ActionSchema<Models> = ActionSchema<Models>,
 >(
 	url: string | null,
 	config: Config<Models, Actions>,

--- a/packages/hooks/src/useCanvas.ts
+++ b/packages/hooks/src/useCanvas.ts
@@ -2,21 +2,21 @@ import { useState, useEffect, useRef } from "react"
 import {
 	Canvas,
 	Contract,
-	type ModelSchema,
+	type ModelSchema as Models,
 	type Config,
 	type Snapshot,
 	hashContract,
-	ActionSchema,
+	Actions,
 } from "@canvas-js/core"
 
 export const useCanvas = <
-	Models extends ModelSchema = ModelSchema,
-	Actions extends ActionSchema<Models> = ActionSchema<Models>,
+	ModelsT extends Models = Models,
+	ActionsT extends Actions<ModelsT> = Actions<ModelsT>,
 >(
 	url: string | null,
-	config: Config<Models, Actions>,
+	config: Config<ModelsT, ActionsT>,
 ) => {
-	const [app, setApp] = useState<Canvas<Models, Actions>>()
+	const [app, setApp] = useState<Canvas<ModelsT, ActionsT>>()
 	const [error, setError] = useState<Error>()
 
 	// TODO: ensure effect hook re-runs on signer change
@@ -30,7 +30,7 @@ export const useCanvas = <
 
 		const contractHash = hashContract(config.contract)
 
-		function setupApp(appUrl: string | null, app: Canvas<Models, Actions>) {
+		function setupApp(appUrl: string | null, app: Canvas<ModelsT, ActionsT>) {
 			if (url) {
 				app.connect(url).then(() => setApp(app))
 			} else {
@@ -41,15 +41,15 @@ export const useCanvas = <
 		async function updateSnapshot() {
 			if (!app || contractHash === hashRef.current) {
 				// app just initialized, or contract remains unchanged
-				await Canvas.initialize<Models, Actions>(config).then(setupApp.bind(null, url))
+				await Canvas.initialize<ModelsT, ActionsT>(config).then(setupApp.bind(null, url))
 			} else if ((await app.db.count("$messages")) > 1 && snapshotRef.current) {
 				// contract changed, reuse the old snapshot
 				const snapshot = snapshotRef.current
-				await Canvas.initialize<Models, Actions>({ ...config, reset: true, snapshot }).then(setupApp.bind(null, url))
+				await Canvas.initialize<ModelsT, ActionsT>({ ...config, reset: true, snapshot }).then(setupApp.bind(null, url))
 			} else {
 				// contract changed, make a new snapshot
 				const snapshot = await app.createSnapshot()
-				await Canvas.initialize<Models, Actions>({ ...config, reset: true, snapshot }).then(setupApp.bind(null, url))
+				await Canvas.initialize<ModelsT, ActionsT>({ ...config, reset: true, snapshot }).then(setupApp.bind(null, url))
 				snapshotRef.current = snapshot
 			}
 		}


### PR DESCRIPTION
Same as #384 but with `Actions<typeof Models>`.

Other names considered:

- ActionFunctions
- ActionProcedures
- ActionImplementations (too long)
- ActionImpls (could be confusing?)
- Actions (runner up, but the generic is currently called Actions, that would have to change to `A` or `ActionsT`)

This steers developers towards either providing `export contract = { actions, models }` at the end of their contract.ts files, or exporting actions and models separately and then providing `contract: { actions, models }` when they call Canvas.initialize or useCanvas. Which seems okay - better to keep the Config types simple.

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
