### PR TITLE
packages/core: Add db.link() for updating bidirectional relations

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -19,13 +19,21 @@ export type ActionImplementation<ModelsT extends ModelSchema = ModelSchema, Args
 	context: ActionContext,
 ) => Awaitable<Result>
 
+export type Chainable<ModelTypes extends Record<string, ModelValue>> = Promise<void> & {
+	link: <T extends keyof ModelTypes & string>(
+		model: T,
+		primaryKey: string,
+		through?: { through: string },
+	) => Promise<void>
+}
+
 export type ModelAPI<ModelTypes extends Record<string, ModelValue>> = {
-	get: <T extends keyof ModelTypes & string>(model: T, key: string) => Awaitable<ModelTypes[T] | null>
-	set: <T extends keyof ModelTypes & string>(model: T, value: ModelTypes[T]) => Awaitable<void>
-	create: <T extends keyof ModelTypes & string>(model: T, value: ModelTypes[T]) => Awaitable<void>
-	update: <T extends keyof ModelTypes & string>(model: T, value: Partial<ModelTypes[T]>) => Awaitable<void>
-	merge: <T extends keyof ModelTypes & string>(model: T, value: Partial<ModelTypes[T]>) => Awaitable<void>
-	delete: <T extends keyof ModelTypes & string>(model: T, key: string) => Awaitable<void>
+	get: <T extends keyof ModelTypes & string>(model: T, key: string) => Promise<ModelTypes[T] | null>
+	set: <T extends keyof ModelTypes & string>(model: T, value: ModelTypes[T]) => Chainable<ModelTypes>
+	create: <T extends keyof ModelTypes & string>(model: T, value: ModelTypes[T]) => Chainable<ModelTypes>
+	update: <T extends keyof ModelTypes & string>(model: T, value: Partial<ModelTypes[T]>) => Chainable<ModelTypes>
+	merge: <T extends keyof ModelTypes & string>(model: T, value: Partial<ModelTypes[T]>) => Chainable<ModelTypes>
+	delete: <T extends keyof ModelTypes & string>(model: T, key: string) => Promise<void>
 }
 
 export type ActionContext = {

--- a/packages/core/test/link.test.ts
+++ b/packages/core/test/link.test.ts
@@ -10,15 +10,16 @@ test("link database items", async (t) => {
 		topic: "com.example.app",
 		contract: {
 			models: {
-				game: { id: "primary", player: "@players[]", status: "json" },
+				game: { id: "primary", player: "@players[]", manager: "@player?", observers: "@player[]", status: "json" },
 				player: { id: "primary", game: "@game", status: "json" },
 			},
 			actions: {
 				async createGame(db: any) {
 					const gameId = "0"
-					const playerId = "1"
-					db.create("game", { id: gameId, player: [], status: "GAME_START" })
-					db.create("player", { id: playerId, game: gameId, status: "ALIVE" }).link("game", gameId)
+					db.create("game", { id: gameId, player: [], manager: null, observers: [], status: "GAME_START" })
+					db.create("player", { id: "1", game: gameId, status: "ALIVE" }).link("game", gameId)
+					db.create("player", { id: "2", game: gameId, status: "ALIVE" }).link("game", gameId, { through: "manager" })
+					db.create("player", { id: "3", game: gameId, status: "ALIVE" }).link("game", gameId, { through: "observers" })
 				},
 			},
 		},
@@ -31,6 +32,8 @@ test("link database items", async (t) => {
 	t.deepEqual(await app.db.get("game", "0"), {
 		id: "0",
 		player: ["1"],
+		manager: "2",
+		observers: ["3"],
 		status: "GAME_START",
 	})
 	t.deepEqual(await app.db.get("player", "1"), {

--- a/packages/core/test/link.test.ts
+++ b/packages/core/test/link.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert"
+import test from "ava"
+
+import { Canvas } from "@canvas-js/core"
+
+const id = () => Math.random().toString().slice(2, 10)
+
+test("link database items", async (t) => {
+	const app = await Canvas.initialize({
+		topic: "com.example.app",
+		contract: {
+			models: {
+				game: { id: "primary", player: "@players[]", status: "json" },
+				player: { id: "primary", game: "@game", status: "json" },
+			},
+			actions: {
+				async createGame(db: any) {
+					const gameId = "0"
+					const playerId = "1"
+					db.create("game", { id: gameId, player: [], status: "GAME_START" })
+					db.create("player", { id: playerId, game: gameId, status: "ALIVE" }).link("game", gameId)
+				},
+			},
+		},
+	})
+
+	t.teardown(() => app.stop())
+
+	await app.actions.createGame()
+
+	t.deepEqual(await app.db.get("game", "0"), {
+		id: "0",
+		player: ["1"],
+		status: "GAME_START",
+	})
+	t.deepEqual(await app.db.get("player", "1"), {
+		id: "1",
+		game: "0",
+		status: "ALIVE",
+	})
+})


### PR DESCRIPTION
Closes #379.

Makes bidirectional relations easier. Changes the return value of db.set() and other create/update functions a chainable object, which can be used with shorthand to link another object to point to the created/updated object.

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
