### PR TITLE
replace browser router with hash router in network explorer

### DIFF
--- a/examples/chat-explorer/src/HomePage.tsx
+++ b/examples/chat-explorer/src/HomePage.tsx
@@ -62,7 +62,7 @@ function HomePage() {
 			</TabNav.Root>
 
 			<Routes>
-				<Route path="/" element={<Navigate to="./actions" replace={true} />} />
+				<Route path="/" element={<Navigate to="actions" replace={true} />} />
 				<Route path="network" element={<NetworkPlot />} />
 				<Route path="actions" element={<ActionsTable />} />
 				<Route path="sessions" element={<SessionsTable />} />

--- a/examples/chat-explorer/src/main.tsx
+++ b/examples/chat-explorer/src/main.tsx
@@ -2,13 +2,13 @@ import { Container, Separator, Theme } from "@radix-ui/themes"
 import "@radix-ui/themes/styles.css"
 import React from "react"
 import ReactDOM from "react-dom/client"
-import { createBrowserRouter, Route, RouterProvider, Routes } from "react-router-dom"
+import { createHashRouter, Route, RouterProvider, Routes } from "react-router-dom"
 
 import "./index.css"
 import HomePage from "./HomePage.js"
 import Navbar from "./components/Navbar.js"
 
-const router = createBrowserRouter([
+const router = createHashRouter([
 	{
 		path: "/*",
 		element: (

--- a/examples/common-explorer/src/HomePage.tsx
+++ b/examples/common-explorer/src/HomePage.tsx
@@ -62,7 +62,7 @@ function HomePage() {
 			</TabNav.Root>
 
 			<Routes>
-				<Route path="/" element={<Navigate to="./actions" replace={true} />} />
+				<Route path="/" element={<Navigate to="actions" replace={true} />} />
 				<Route path="network" element={<NetworkPlot />} />
 				<Route path="actions" element={<ActionsTable />} />
 				<Route path="sessions" element={<SessionsTable />} />

--- a/examples/common-explorer/src/main.tsx
+++ b/examples/common-explorer/src/main.tsx
@@ -2,13 +2,13 @@ import { Container, Separator, Theme } from "@radix-ui/themes"
 import "@radix-ui/themes/styles.css"
 import React from "react"
 import ReactDOM from "react-dom/client"
-import { createBrowserRouter, Route, RouterProvider, Routes } from "react-router-dom"
+import { createHashRouter, Route, RouterProvider, Routes } from "react-router-dom"
 
 import "./index.css"
 import HomePage from "./HomePage.js"
 import Navbar from "./components/Navbar.js"
 
-const router = createBrowserRouter([
+const router = createHashRouter([
 	{
 		path: "/*",
 		element: (


### PR DESCRIPTION
Navigating to paths like `https://common-explorer.canvas.xyz/actions`  and `https://common-explorer.canvas.xyz/sessions` currently fails because the server isn't configured with a rewrite rule so that all paths route to `index.html`. We can save us from having to edit server config by using hash router, which encodes the particular page as a client-side fragment. Our paths will now look like `https://common-explorer.canvas.xyz/#/actions`.

This change has been made for both `common-explorer` and `chat-explorer`. This has been tested locally.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
