### PR TITLE
fix /actions endpoint in core api, which sometimes doesn't return anything

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -65,7 +65,6 @@ export function createAPI(app: Canvas): express.Express {
 				select: { id: true, signature: true, message: true },
 				where: { id: range },
 				orderBy: { id: order },
-				limit,
 			})) {
 				if (isAction(message)) {
 					const count = results.push({ id, signature, message })

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -39,40 +39,23 @@ export function createAPI(app: Canvas): express.Express {
 		type MessageRecord = { id: string; signature: Signature; message: Message<Action> }
 		const results: MessageRecord[] = []
 
-		if (did !== undefined || name !== undefined) {
-			const messageIds: string[] = []
+		const where = did !== undefined || name !== undefined ? { did, name } : { id: range }
 
-			for await (const { message_id } of app.db.iterate("$actions", { where: { did, name } })) {
-				const count = messageIds.push(message_id)
-				if (count >= limit) {
-					break
-				}
-			}
+		const messageIds: string[] = []
 
-			const signedMessages = await app.db.getMany<SignedMessage<Action>>("$messages", messageIds)
+		for await (const { message_id } of app.db.iterate("$actions", { where })) {
+			const count = messageIds.push(message_id)
+			if (count >= limit) {
+				break
+			}
+		}
 
-			for (const signedMessage of signedMessages) {
-				assert(signedMessage !== null, "internal error - missing record in $messages")
-				const { signature, message } = signedMessage
-				results.push({ id: signedMessage.id, signature, message })
-			}
-		} else {
-			for await (const { id, signature, message } of app.db.iterate<{
-				id: string
-				signature: Signature
-				message: Message<Action | Session>
-			}>("$messages", {
-				select: { id: true, signature: true, message: true },
-				where: { id: range },
-				orderBy: { id: order },
-			})) {
-				if (isAction(message)) {
-					const count = results.push({ id, signature, message })
-					if (count >= limit) {
-						break
-					}
-				}
-			}
+		const signedMessages = await app.db.getMany<SignedMessage<Action>>("$messages", messageIds)
+
+		for (const signedMessage of signedMessages) {
+			assert(signedMessage !== null, "internal error - missing record in $messages")
+			const { signature, message } = signedMessage
+			results.push({ id: signedMessage.id, signature, message })
 		}
 
 		res.writeHead(StatusCodes.OK, { "content-type": "application/json" })


### PR DESCRIPTION
Fixes: https://github.com/canvasxyz/canvas/issues/396

When the `GET /api/actions` core api endpoint is requested with no query parameters (or with just the `limit` query parameter), it is meant to return an array of N (where N = the limit parameter or the default limit value) actions. The current implementation iterates over the rows in the `$messages` table, then checks if the row is an action and if it is, adds it to the result, until we have `limit` number of actions. The bug here is that when we call `iterate` we also pass in the `limit` parameter, so if there aren't any actions in the first N messages then the API endpoint doesn't return anything.


## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
