### PR TITLE
fix action and session pagination in chat,common-explorer

### DIFF
--- a/examples/chat-explorer/src/ActionsTable.tsx
+++ b/examples/chat-explorer/src/ActionsTable.tsx
@@ -36,7 +36,7 @@ function ActionsTable() {
 		limit: (entriesPerPage + 1).toString(),
 	})
 	if (currentCursor) {
-		params.append("before", currentCursor)
+		params.append("gt", currentCursor)
 	}
 
 	const { data: actions, error } = useSWR(
@@ -103,7 +103,7 @@ function ActionsTable() {
 				<PaginationButton
 					text="Next"
 					enabled={hasMore}
-					onClick={() => pushCursor(actionsToDisplay[entriesPerPage].id)}
+					onClick={() => pushCursor(actionsToDisplay[actionsToDisplay.length - 1].id)}
 				/>
 			</Flex>
 		</Flex>

--- a/examples/chat-explorer/src/SessionsTable.tsx
+++ b/examples/chat-explorer/src/SessionsTable.tsx
@@ -16,7 +16,7 @@ function SessionsTable() {
 	// if the length of the result is n + 1, then there is another page
 	const params = new URLSearchParams({ type: "session", limit: (entriesPerPage + 1).toString() })
 	if (currentCursor) {
-		params.append("before", currentCursor)
+		params.append("gt", currentCursor)
 	}
 
 	const { data: sessions, error } = useSWR(
@@ -70,7 +70,7 @@ function SessionsTable() {
 				<PaginationButton
 					text="Next"
 					enabled={hasMore}
-					onClick={() => pushCursor(sessionsToDisplay[entriesPerPage].id)}
+					onClick={() => pushCursor(sessionsToDisplay[sessionsToDisplay.length - 1].id)}
 				/>
 			</Flex>
 		</Flex>

--- a/examples/common-explorer/src/ActionsTable.tsx
+++ b/examples/common-explorer/src/ActionsTable.tsx
@@ -36,7 +36,7 @@ function ActionsTable() {
 		limit: (entriesPerPage + 1).toString(),
 	})
 	if (currentCursor) {
-		params.append("before", currentCursor)
+		params.append("gt", currentCursor)
 	}
 
 	const { data: actions, error } = useSWR(
@@ -103,7 +103,7 @@ function ActionsTable() {
 				<PaginationButton
 					text="Next"
 					enabled={hasMore}
-					onClick={() => pushCursor(actionsToDisplay[entriesPerPage].id)}
+					onClick={() => pushCursor(actionsToDisplay[actionsToDisplay.length - 1].id)}
 				/>
 			</Flex>
 		</Flex>

--- a/examples/common-explorer/src/SessionsTable.tsx
+++ b/examples/common-explorer/src/SessionsTable.tsx
@@ -16,7 +16,7 @@ function SessionsTable() {
 	// if the length of the result is n + 1, then there is another page
 	const params = new URLSearchParams({ type: "session", limit: (entriesPerPage + 1).toString() })
 	if (currentCursor) {
-		params.append("before", currentCursor)
+		params.append("gt", currentCursor)
 	}
 
 	const { data: sessions, error } = useSWR(
@@ -70,7 +70,7 @@ function SessionsTable() {
 				<PaginationButton
 					text="Next"
 					enabled={hasMore}
-					onClick={() => pushCursor(sessionsToDisplay[entriesPerPage].id)}
+					onClick={() => pushCursor(sessionsToDisplay[sessionsToDisplay.length - 1].id)}
 				/>
 			</Flex>
 		</Flex>


### PR DESCRIPTION
The code for paginating sessions and actions in chat/common-explorer was broken - looks like we just didn't update the changes correctly when the `/api/sessions` and `/api/actions` endpoints last got updated.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
