### PR TITLE
add DATABASE_URL environment variable to common/chat explorer

### DIFF
--- a/examples/chat-explorer/server/server.ts
+++ b/examples/chat-explorer/server/server.ts
@@ -15,6 +15,7 @@ const dev = process.env.NODE_ENV !== "production"
 const PORT = parseInt(process.env.PORT || "3333", 10)
 const HTTP_ADDR = "0.0.0.0"
 
+const DATABASE_URL = process.env.DATABASE_URL
 const LIBP2P_PORT = parseInt(process.env.LIBP2P_PORT || "3334", 10)
 const LIBP2P_ANNOUNCE_HOST = process.env.LIBP2P_ANNOUNCE_HOST || "my-example.p2p.app"
 const LIBP2P_ANNOUNCE_PORT = parseInt(process.env.LIBP2P_ANNOUNCE_PORT || "80", 10)
@@ -22,6 +23,7 @@ const BOOTSTRAP_LIST = process.env.BOOTSTRAP_LIST || [
 	"/dns4/canvas-chat-example-libp2p.p2p.app/tcp/443/wss/p2p/12D3KooWNCqJHo8BNdjTUmq51xudtrDPFTCKCD2Pf87FXHGXcSXD",
 ]
 
+console.log(`DATABASE_URL: ${DATABASE_URL}`)
 console.log(`dev: ${dev}`)
 console.log(`PORT: ${PORT}`)
 console.log(`HTTP_ADDR: ${HTTP_ADDR}`)
@@ -41,6 +43,7 @@ expressApp.use(
 console.log(`initializing canvas for topic ${topic}`)
 
 const canvasApp = await Canvas.initialize({
+	path: DATABASE_URL,
 	contract: {
 		models: {},
 		actions: {

--- a/examples/common-explorer/server/server.ts
+++ b/examples/common-explorer/server/server.ts
@@ -16,11 +16,13 @@ const dev = process.env.NODE_ENV !== "production"
 const PORT = parseInt(process.env.PORT || "3333", 10)
 const HTTP_ADDR = "0.0.0.0"
 
+const DATABASE_URL = process.env.DATABASE_URL
 const LIBP2P_PORT = parseInt(process.env.LIBP2P_PORT || "3334", 10)
 const LIBP2P_ANNOUNCE_HOST = process.env.LIBP2P_ANNOUNCE_HOST || "my-example.p2p.app"
 const LIBP2P_ANNOUNCE_PORT = parseInt(process.env.LIBP2P_ANNOUNCE_PORT || "80", 10)
 const BOOTSTRAP_LIST = process.env.BOOTSTRAP_LIST || []
 
+console.log(`DATABASE_URL: ${DATABASE_URL}`)
 console.log(`dev: ${dev}`)
 console.log(`PORT: ${PORT}`)
 console.log(`HTTP_ADDR: ${HTTP_ADDR}`)
@@ -40,6 +42,7 @@ expressApp.use(
 console.log(`initializing canvas for topic ${contractTopic}`)
 
 const canvasApp = await Canvas.initialize({
+	path: DATABASE_URL,
 	contract,
 	signers: [new SIWESigner(), new ATPSigner(), new CosmosSigner(), new SubstrateSigner({}), new SolanaSigner()],
 	topic: contractTopic,


### PR DESCRIPTION
Add support for the `DATABASE_URL` environment variable to chat-explorer and common-explorer. This passed to the `Canvas.initialize` function as the `path` parameter. If the env var is not set, we act as if `path` is undefined, i.e. an ephemeral database is run in memory.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
