### PR TITLE
return bootstrap, listen, announce in application info api

### DIFF
--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -64,6 +64,11 @@ export type CanvasLogEvent = CustomEvent<{
 }>
 
 export type ApplicationData = {
+	networkConfig: {
+		bootstrapList?: string[]
+		listen?: string[]
+		announce?: string[]
+	}
 	topic: string
 	models: Record<string, Model>
 	actions: string[]
@@ -180,6 +185,8 @@ export class Canvas<
 	private readonly controller = new AbortController()
 	private readonly log = logger("canvas:core")
 
+	private networkConfig: NetworkConfig | null = null
+
 	private constructor(
 		public readonly signers: SignerCache,
 		public readonly messageLog: AbstractGossipLog<Action | Session | Snapshot>,
@@ -254,6 +261,7 @@ export class Canvas<
 	}
 
 	public async startLibp2p(config: NetworkConfig): Promise<Libp2p<ServiceMap<Action | Session | Snapshot>>> {
+		this.networkConfig = config
 		return await this.messageLog.startLibp2p(config)
 	}
 
@@ -311,6 +319,11 @@ export class Canvas<
 	public getApplicationData(): ApplicationData {
 		const models = Object.fromEntries(Object.entries(this.db.models).filter(([name]) => !name.startsWith("$")))
 		return {
+			networkConfig: {
+				bootstrapList: this.networkConfig?.bootstrapList,
+				listen: this.networkConfig?.listen,
+				announce: this.networkConfig?.announce,
+			},
 			topic: this.topic,
 			models: models,
 			actions: Object.keys(this.actions),


### PR DESCRIPTION
Fixes https://github.com/canvasxyz/canvas/issues/386

This PR updates the `Canvas` class so that when we call `getApplicationData`, it returns libp2p config fields if they are known (ie if libp2p is running). Currently it just returns bootstrapList, listen and announce. These values just return whatever was passed into the libp2p config, there isn't any "live" information in here.

Screenshot:

![Screenshot 2024-11-18 at 3 35 04 PM](https://github.com/user-attachments/assets/5d680bdb-dafd-4625-a0f3-996bd58f8122)


## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
