### PR TITLE
examples/explorer: Don't use named import

### DIFF
--- a/examples/chat-explorer/src/HomePage.tsx
+++ b/examples/chat-explorer/src/HomePage.tsx
@@ -1,4 +1,4 @@
-import { version } from "../package.json"
+import * as pkg from "../package.json"
 import { BASE_URL, fetchAndIpldParseJson } from "./utils.js"
 import { Card, Flex, Grid, TabNav, Text } from "@radix-ui/themes"
 import ActionsTable from "./ActionsTable.js"
@@ -35,7 +35,7 @@ function HomePage() {
 					<Flex direction="column">
 						<Flex gap="2">
 							<Text weight="bold">Status:</Text>
-							<Text weight="medium">Online, running v{version}</Text>
+							<Text weight="medium">Online, running v{pkg.default.version}</Text>
 						</Flex>
 						<Flex gap="2">
 							<Text weight="bold">URL:</Text>

--- a/examples/chat-postgres/package.json
+++ b/examples/chat-postgres/package.json
@@ -32,6 +32,6 @@
 		"tailwindcss": "^3.4.4",
 		"ts-node": "^10.9.2",
 		"tsx": "^4.15.6",
-		"typescript": "^5.4.5"
+		"typescript": "^5.7.2"
 	}
 }

--- a/examples/chat/package.json
+++ b/examples/chat/package.json
@@ -49,7 +49,7 @@
 		"autoprefixer": "^10.4.19",
 		"postcss": "^8.4.38",
 		"tailwindcss": "^3.4.4",
-		"typescript": "^5.4.5",
+		"typescript": "^5.7.2",
 		"vite": "^5.4.8",
 		"vite-plugin-node-polyfills": "^0.22.0"
 	}

--- a/examples/common-explorer/src/HomePage.tsx
+++ b/examples/common-explorer/src/HomePage.tsx
@@ -1,4 +1,4 @@
-import { version } from "../package.json"
+import * as pkg from "../package.json"
 import { BASE_URL, fetchAndIpldParseJson } from "./utils.js"
 import { Card, Flex, Grid, TabNav, Text } from "@radix-ui/themes"
 import ActionsTable from "./ActionsTable.js"
@@ -35,7 +35,7 @@ function HomePage() {
 					<Flex direction="column">
 						<Flex gap="2">
 							<Text weight="bold">Status:</Text>
-							<Text weight="medium">Online, running v{version}</Text>
+							<Text weight="medium">Online, running v{pkg.default.version}</Text>
 						</Flex>
 						<Flex gap="2">
 							<Text weight="bold">URL:</Text>

--- a/examples/encrypted-chat/package.json
+++ b/examples/encrypted-chat/package.json
@@ -27,7 +27,7 @@
 		"eslint": "^8.57.0",
 		"eslint-plugin-react-hooks": "^4.6.2",
 		"eslint-plugin-react-refresh": "^0.4.7",
-		"typescript": "^5.4.5",
+		"typescript": "^5.7.2",
 		"vite": "^5.4.8",
 		"vite-plugin-node-polyfills": "^0.22.0"
 	}

--- a/examples/snake/package.json
+++ b/examples/snake/package.json
@@ -26,7 +26,7 @@
 		"eslint": "^8.57.0",
 		"eslint-plugin-react-hooks": "^4.6.2",
 		"eslint-plugin-react-refresh": "^0.4.7",
-		"typescript": "^5.4.5",
+		"typescript": "^5.7.2",
 		"vite": "^5.4.8",
 		"vite-plugin-node-polyfills": "^0.22.0"
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,9 +48,9 @@
 				"protons-runtime": "^5.5.0",
 				"react": "^18.3.1",
 				"react-chessboard": "^4.6.0",
-				"typescript": "^5.4.5",
+				"typescript": "^5.7.2",
 				"veaury": "^2.4.0",
-				"vite": "^5.3.3",
+				"vite": "^5.4.8",
 				"vitepress": "^1.5.0",
 				"vue": "^3.3.7",
 				"vue-markdown-render": "^2.2.1"
@@ -106,7 +106,7 @@
 				"autoprefixer": "^10.4.19",
 				"postcss": "^8.4.38",
 				"tailwindcss": "^3.4.4",
-				"typescript": "^5.4.5",
+				"typescript": "^5.7.2",
 				"vite": "^5.4.8",
 				"vite-plugin-node-polyfills": "^0.22.0"
 			}
@@ -182,7 +182,7 @@
 				"tailwindcss": "^3.4.4",
 				"ts-node": "^10.9.2",
 				"tsx": "^4.15.6",
-				"typescript": "^5.4.5"
+				"typescript": "^5.7.2"
 			}
 		},
 		"examples/chat/node_modules/@noble/hashes": {
@@ -262,7 +262,7 @@
 				"eslint": "^8.57.0",
 				"eslint-plugin-react-hooks": "^4.6.2",
 				"eslint-plugin-react-refresh": "^0.4.7",
-				"typescript": "^5.4.5",
+				"typescript": "^5.7.2",
 				"vite": "^5.4.8",
 				"vite-plugin-node-polyfills": "^0.22.0"
 			}
@@ -287,7 +287,7 @@
 				"eslint": "^8.57.0",
 				"eslint-plugin-react-hooks": "^4.6.2",
 				"eslint-plugin-react-refresh": "^0.4.7",
-				"typescript": "^5.4.5",
+				"typescript": "^5.7.2",
 				"vite": "^5.4.8",
 				"vite-plugin-node-polyfills": "^0.22.0"
 			}
@@ -31769,8 +31769,9 @@
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
-			"version": "5.5.3",
-			"license": "Apache-2.0",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+			"integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
 		"protons-runtime": "^5.5.0",
 		"react": "^18.3.1",
 		"react-chessboard": "^4.6.0",
-		"typescript": "^5.4.5",
+		"typescript": "^5.7.2",
 		"veaury": "^2.4.0",
-		"vite": "^5.3.3",
+		"vite": "^5.4.8",
 		"vitepress": "^1.5.0",
 		"vue": "^3.3.7",
 		"vue-markdown-render": "^2.2.1"


### PR DESCRIPTION
This should fix the module resolution error on typescript@5.7.0+ at #404, but it doesn't. 