### PR TITLE
Add `--connect` argument to CLI run command

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -119,6 +119,10 @@ export const builder = (yargs: Argv) =>
 			type: "boolean",
 			desc: "Serve the network explorer web interface",
 		})
+		.option("ws-url", {
+			type: "string",
+			desc: "WebSocket URL for GossipLog to connect to directly",
+		})
 
 type Args = ReturnType<typeof builder> extends Argv<infer T> ? T : never
 
@@ -337,5 +341,9 @@ export async function handler(args: Args) {
 	if (args["repl"]) {
 		console.log("")
 		startActionPrompt(app)
+	}
+
+	if (args["ws-url"]) {
+		await app.connect(args["ws-url"])
 	}
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -119,9 +119,9 @@ export const builder = (yargs: Argv) =>
 			type: "boolean",
 			desc: "Serve the network explorer web interface",
 		})
-		.option("ws-url", {
+		.option("connect", {
 			type: "string",
-			desc: "WebSocket URL for GossipLog to connect to directly",
+			desc: "Connect GossipLog directly to this WebSocket URL. If this is enabled, libp2p is disabled.",
 		})
 
 type Args = ReturnType<typeof builder> extends Argv<infer T> ? T : never
@@ -183,7 +183,9 @@ export async function handler(args: Args) {
 		)
 	})
 
-	if (!args.offline) {
+	if (args["connect"]) {
+		await app.connect(args["connect"])
+	} else if (!args.offline) {
 		let bootstrapList = defaultBootstrapList
 		if (args.offline) {
 			bootstrapList = []
@@ -341,9 +343,5 @@ export async function handler(args: Args) {
 	if (args["repl"]) {
 		console.log("")
 		startActionPrompt(app)
-	}
-
-	if (args["ws-url"]) {
-		await app.connect(args["ws-url"])
 	}
 }


### PR DESCRIPTION
This PR adds a new `--connect` argument to the CLI run command. 

```
  --connect           Connect GossipLog directly to this WebSocket URL. If this
                      is enabled, libp2p is disabled.                   [string]
```

This is useful when we need to run a Canvas node (e.g. when working on Network Explorer) but we are on a network that has no public-facing IP address, e.g. a home computer. 

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
