### PR TITLE
`packages/network-explorer` - add filter for single values

### DIFF
--- a/packages/network-explorer/src/ActionsTable.tsx
+++ b/packages/network-explorer/src/ActionsTable.tsx
@@ -1,5 +1,4 @@
 import { Table } from "./components/Table.js"
-import { actionsTable } from "./tables.js"
 import { useApplicationData } from "./hooks/useApplicationData.js"
 
 // special case of Table where the name field options are based on data from the API
@@ -12,13 +11,20 @@ export const ActionsTable = ({
 }) => {
 	const applicationData = useApplicationData()
 
+	const tableName = "$actions"
+	const defaultSortColumn = "message_id"
+	const defaultSortDirection = "desc"
+
 	const columns = [
 		{
 			header: "did",
 			accessorKey: "did",
 			size: 580,
 			enableSorting: false,
-			enableColumnFilter: false,
+			enableColumnFilter: true,
+			meta: {
+				textFilter: true,
+			},
 		},
 		{
 			header: "name",
@@ -40,11 +46,11 @@ export const ActionsTable = ({
 
 	return (
 		<Table
-			defaultSortColumn={actionsTable.defaultSortColumn}
-			defaultSortDirection={actionsTable.defaultSortDirection}
+			defaultSortColumn={defaultSortColumn}
+			defaultSortDirection={defaultSortDirection}
 			showSidebar={showSidebar}
 			setShowSidebar={setShowSidebar}
-			tableName={actionsTable.tableName}
+			tableName={tableName}
 			defaultColumns={columns}
 		/>
 	)

--- a/packages/network-explorer/src/columndefMeta.d.ts
+++ b/packages/network-explorer/src/columndefMeta.d.ts
@@ -2,6 +2,7 @@ import "@tanstack/react-table" //or vue, svelte, solid, qwik, etc.
 
 declare module "@tanstack/react-table" {
 	interface ColumnMeta<TData extends RowData, TValue> {
+		textFilter?: boolean
 		filterOptions?: string[]
 	}
 }

--- a/packages/network-explorer/src/components/Table.tsx
+++ b/packages/network-explorer/src/components/Table.tsx
@@ -74,6 +74,10 @@ export const Table = <T,>({
 		}
 	}
 
+	for (const f of columnFilters) {
+		where[f.id] = f.value as string | number
+	}
+
 	const { data, mutate: doRefresh } = useSWR(
 		`/api/models/${tableName}?${stringifyRequestParams({
 			limit: entriesPerPage + 1,

--- a/packages/network-explorer/src/components/TableToolbar.tsx
+++ b/packages/network-explorer/src/components/TableToolbar.tsx
@@ -3,6 +3,7 @@ import { ColumnFiltersState, OnChangeFn, Table as TanStackTable } from "@tanstac
 import { BiChevronLeft, BiChevronRight, BiFilter, BiSidebar } from "react-icons/bi"
 import { LuRefreshCw, LuSlidersHorizontal } from "react-icons/lu"
 import { ClickableChecklistItem } from "./ClickableChecklistItem.js"
+import { TextFilterMenu } from "./TextFilterMenu.js"
 
 export const TableToolbar = ({
 	totalCount,
@@ -59,29 +60,41 @@ export const TableToolbar = ({
 								<DropdownMenu.Sub key={column.id}>
 									<DropdownMenu.SubTrigger>{column.columnDef.header?.toString()}</DropdownMenu.SubTrigger>
 									<DropdownMenu.SubContent>
-										{(column.columnDef.meta?.filterOptions || []).map((filterOption) => (
-											<ClickableChecklistItem
-												key={filterOption}
-												checked={
-													(columnFilters || []).filter((f) => f.id === column.id && f.value === filterOption).length > 0
-												}
-												onCheckedChange={(checked) => {
-													if (checked) {
-														if (setColumnFilters) {
-															setColumnFilters((columnFilters || []).concat({ id: column.id, value: filterOption }))
-														}
-													} else {
-														if (setColumnFilters) {
-															setColumnFilters(
-																(columnFilters || []).filter((f) => !(f.id === column.id && f.value === filterOption)),
-															)
-														}
+										{column.columnDef.meta?.textFilter && columnFilters && setColumnFilters && (
+											<TextFilterMenu
+												column={column}
+												columnFilters={columnFilters}
+												setColumnFilters={setColumnFilters}
+											/>
+										)}
+
+										{column.columnDef.meta?.filterOptions &&
+											column.columnDef.meta?.filterOptions.map((filterOption) => (
+												<ClickableChecklistItem
+													key={filterOption}
+													checked={
+														(columnFilters || []).filter((f) => f.id === column.id && f.value === filterOption).length >
+														0
 													}
-												}}
-											>
-												{filterOption}
-											</ClickableChecklistItem>
-										))}
+													onCheckedChange={(checked) => {
+														if (checked) {
+															if (setColumnFilters) {
+																setColumnFilters((columnFilters || []).concat({ id: column.id, value: filterOption }))
+															}
+														} else {
+															if (setColumnFilters) {
+																setColumnFilters(
+																	(columnFilters || []).filter(
+																		(f) => !(f.id === column.id && f.value === filterOption),
+																	),
+																)
+															}
+														}
+													}}
+												>
+													{filterOption}
+												</ClickableChecklistItem>
+											))}
 									</DropdownMenu.SubContent>
 								</DropdownMenu.Sub>
 							))}{" "}

--- a/packages/network-explorer/src/components/TableToolbar.tsx
+++ b/packages/network-explorer/src/components/TableToolbar.tsx
@@ -60,10 +60,10 @@ export const TableToolbar = ({
 								<DropdownMenu.Sub key={column.id}>
 									<DropdownMenu.SubTrigger>{column.columnDef.header?.toString()}</DropdownMenu.SubTrigger>
 									<DropdownMenu.SubContent>
-										{column.columnDef.meta?.textFilter && columnFilters && setColumnFilters && (
+										{column.columnDef.meta?.textFilter && setColumnFilters && (
 											<TextFilterMenu
 												column={column}
-												columnFilters={columnFilters}
+												columnFilters={columnFilters || []}
 												setColumnFilters={setColumnFilters}
 											/>
 										)}

--- a/packages/network-explorer/src/components/TextFilterMenu.tsx
+++ b/packages/network-explorer/src/components/TextFilterMenu.tsx
@@ -1,0 +1,58 @@
+import { Button, Flex, TextField } from "@radix-ui/themes"
+import { Column, ColumnFiltersState, OnChangeFn } from "@tanstack/react-table"
+import { useState } from "react"
+
+export const TextFilterMenu = ({
+	column,
+	columnFilters,
+	setColumnFilters,
+}: {
+	column: Column<any, unknown>
+	columnFilters: ColumnFiltersState
+	setColumnFilters: OnChangeFn<ColumnFiltersState>
+}) => {
+	const [newFilterText, setNewFilterText] = useState("")
+
+	const existingFilter = columnFilters.filter((f) => (f.id = column.id))[0]
+
+	return existingFilter ? (
+		<Flex
+			direction="row"
+			gap="2"
+			onClick={(e) => {
+				e.preventDefault()
+			}}
+			align="center"
+		>
+			{existingFilter.value as string}
+			<Button
+				ml="auto"
+				color="red"
+				onClick={() => {
+					setColumnFilters(columnFilters.filter((f2) => f2.id !== column.id || f2.value !== existingFilter.value))
+				}}
+			>
+				Remove
+			</Button>
+		</Flex>
+	) : (
+		<Flex direction="row" gap="2">
+			<TextField.Root
+				value={newFilterText}
+				onChange={(e) => setNewFilterText(e.target.value)}
+				placeholder="filter value"
+			></TextField.Root>
+			<Button
+				disabled={newFilterText.length === 0}
+				onClick={() => {
+					const otherFilters = columnFilters.filter((f) => f.id !== column.id)
+
+					setColumnFilters(() => [...otherFilters, { id: column.id, value: newFilterText }])
+					setNewFilterText("")
+				}}
+			>
+				Add
+			</Button>
+		</Flex>
+	)
+}

--- a/packages/network-explorer/src/tables.ts
+++ b/packages/network-explorer/src/tables.ts
@@ -50,7 +50,10 @@ export const tables: (TableDef & SortDef)[] = [
 				accessorKey: "id",
 				size: 350,
 				enableSorting: true,
-				enableColumnFilter: false,
+				enableColumnFilter: true,
+				meta: {
+					textFilter: true,
+				},
 			},
 			{
 				header: "links",

--- a/packages/network-explorer/src/tables.ts
+++ b/packages/network-explorer/src/tables.ts
@@ -11,34 +11,6 @@ type SortDef = {
 	defaultSortDirection: "desc" | "asc"
 }
 
-export const actionsTable = {
-	tableName: "$actions",
-	defaultSortColumn: "message_id",
-	defaultSortDirection: "desc" as const,
-	defaultColumns: [
-		{
-			header: "did",
-			accessorKey: "did",
-			size: 580,
-			enableSorting: false,
-			enableColumnFilter: false,
-		},
-		{
-			header: "name",
-			accessorKey: "name",
-			size: 200,
-			enableSorting: false,
-			enableColumnFilter: true,
-		},
-		{
-			header: "timestamp",
-			accessorKey: "timestamp",
-			enableSorting: false,
-			enableColumnFilter: false,
-		},
-	],
-}
-
 export const tables: (TableDef & SortDef)[] = [
 	{
 		tableName: "$ancestors",


### PR DESCRIPTION

This PR adds a UI widget for filtering tables on single values. Currently ModelDB just lets us query with a `where` condition matching individual values or ranges, so we can't query for something like `id = X OR id = Y`. So this PR just adds a feature to filter on a single value.

Screenshots:

Empty text field:
![Screenshot 2025-01-08 at 4 28 35 PM](https://github.com/user-attachments/assets/91d240ce-6097-4c21-a1bc-330b2387b197)

Text field with query string:
![Screenshot 2025-01-08 at 4 28 44 PM](https://github.com/user-attachments/assets/85e14cb8-44c9-47e9-9819-4a793c62c8b0)

Applied filter with "Remove" button:
![Screenshot 2025-01-08 at 4 28 47 PM](https://github.com/user-attachments/assets/884e6706-db52-40fb-b339-a3b8a611b580)

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
