### PR TITLE
Misc Network Explorer Fixes

### DIFF
--- a/packages/network-explorer/src/ModelTable.tsx
+++ b/packages/network-explorer/src/ModelTable.tsx
@@ -16,16 +16,18 @@ export const ModelTable = ({
 	if (applicationData !== null) {
 		const modelDefinition = applicationData.models[params.model as string]
 		if (modelDefinition) {
-			const primaryProperty = modelDefinition.properties.filter((p) => p.kind === "primary")[0]
-			// use the property with type "primary" if it exists, otherwise just assume the first column is
-			// the sorting/index column
-			const defaultSortColumn = primaryProperty ? primaryProperty.name : modelDefinition.properties[0].name
+			// the primary property has kind 'primary' or is the first property in the model definition
+			const primaryProperty =
+				modelDefinition.properties.filter((p) => p.kind === "primary")[0] || modelDefinition.properties[0]
+			// use the primary property as the sorting column
+			const defaultSortColumn = primaryProperty.name
 			const defaultSortDirection = "asc"
 
 			const defaultColumns = modelDefinition.properties.map((property) => ({
 				header: property.name,
 				accessorKey: property.name,
-				enableSorting: false,
+				// enable sorting on the primary property
+				enableSorting: property.name === primaryProperty.name,
 				enableColumnFilter: false,
 				size: 400,
 			}))

--- a/packages/network-explorer/src/components/Table.tsx
+++ b/packages/network-explorer/src/components/Table.tsx
@@ -142,7 +142,7 @@ export const Table = <T,>({
 				setEntriesPerPage={setEntriesPerPage}
 				responseTime={data ? data.responseTime : undefined}
 				doRefresh={doRefresh}
-				columnFilters={columnFilters}
+				columnFilters={columnFilters || []}
 				setColumnFilters={setColumnFilters}
 				hasPrevPage={currentCursor !== null}
 				prevPage={() => popCursor()}
@@ -173,7 +173,9 @@ export const Table = <T,>({
 										>
 											<Flex width="100%" gap="2" p="1">
 												<Text weight="medium">
-													{header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+													{header.isPlaceholder
+														? null
+														: flexRender(header.column.columnDef.header, header.getContext())}
 												</Text>
 												{header.column.getCanSort() && (
 													<Flex ml="auto" align="center">

--- a/packages/network-explorer/src/components/Table.tsx
+++ b/packages/network-explorer/src/components/Table.tsx
@@ -149,7 +149,7 @@ export const Table = <T,>({
 				hasNextPage={endCursor !== null}
 				nextPage={() => pushCursor(endCursor)}
 			/>
-			<Box overflowX="scroll">
+			<Box overflowX="scroll" flexGrow="1">
 				<Text size="2">
 					<table style={{ borderCollapse: "collapse", display: "grid" }}>
 						<thead style={{ display: "grid", position: "sticky", top: 0, zIndex: 1, backgroundColor: "white" }}>

--- a/packages/network-explorer/src/components/TableToolbar.tsx
+++ b/packages/network-explorer/src/components/TableToolbar.tsx
@@ -29,7 +29,7 @@ export const TableToolbar = ({
 	responseTime?: number
 	entriesPerPage: number
 	setEntriesPerPage: (entriesPerPage: number) => void
-	columnFilters?: ColumnFiltersState
+	columnFilters: ColumnFiltersState
 	setColumnFilters?: OnChangeFn<ColumnFiltersState>
 	hasPrevPage: boolean
 	prevPage: () => void
@@ -49,7 +49,7 @@ export const TableToolbar = ({
 					<DropdownMenu.Trigger>
 						<Button color="gray" variant="outline">
 							<BiFilter />
-							Filters
+							Filters {columnFilters && columnFilters.length > 0 && `(${columnFilters.length})`}
 						</Button>
 					</DropdownMenu.Trigger>
 					<DropdownMenu.Content>
@@ -63,7 +63,7 @@ export const TableToolbar = ({
 										{column.columnDef.meta?.textFilter && setColumnFilters && (
 											<TextFilterMenu
 												column={column}
-												columnFilters={columnFilters || []}
+												columnFilters={columnFilters}
 												setColumnFilters={setColumnFilters}
 											/>
 										)}
@@ -73,20 +73,17 @@ export const TableToolbar = ({
 												<ClickableChecklistItem
 													key={filterOption}
 													checked={
-														(columnFilters || []).filter((f) => f.id === column.id && f.value === filterOption).length >
-														0
+														columnFilters.filter((f) => f.id === column.id && f.value === filterOption).length > 0
 													}
 													onCheckedChange={(checked) => {
 														if (checked) {
 															if (setColumnFilters) {
-																setColumnFilters((columnFilters || []).concat({ id: column.id, value: filterOption }))
+																setColumnFilters(columnFilters.concat({ id: column.id, value: filterOption }))
 															}
 														} else {
 															if (setColumnFilters) {
 																setColumnFilters(
-																	(columnFilters || []).filter(
-																		(f) => !(f.id === column.id && f.value === filterOption),
-																	),
+																	columnFilters.filter((f) => !(f.id === column.id && f.value === filterOption)),
 																)
 															}
 														}

--- a/packages/network-explorer/src/components/TextFilterMenu.tsx
+++ b/packages/network-explorer/src/components/TextFilterMenu.tsx
@@ -13,7 +13,7 @@ export const TextFilterMenu = ({
 }) => {
 	const [newFilterText, setNewFilterText] = useState("")
 
-	const existingFilter = columnFilters.filter((f) => (f.id = column.id))[0]
+	const existingFilter = columnFilters.filter((f) => f.id === column.id)[0]
 
 	return existingFilter ? (
 		<Flex

--- a/packages/network-explorer/src/tables.ts
+++ b/packages/network-explorer/src/tables.ts
@@ -191,11 +191,21 @@ export const tables: (TableDef & SortDef)[] = [
 		defaultSortDirection: "desc",
 		defaultColumns: [
 			{
+				header: "message_id",
+				accessorKey: "message_id",
+				size: 580,
+				enableSorting: true,
+				enableColumnFilter: false,
+			},
+			{
 				header: "did",
 				accessorKey: "did",
 				size: 580,
 				enableSorting: false,
-				enableColumnFilter: false,
+				enableColumnFilter: true,
+				meta: {
+					textFilter: true,
+				},
 			},
 			{
 				header: "public_key",

--- a/packages/network-explorer/src/tables.ts
+++ b/packages/network-explorer/src/tables.ts
@@ -45,7 +45,7 @@ export const tables: (TableDef & SortDef)[] = [
 				header: "id",
 				accessorKey: "id",
 				size: 150,
-				enableSorting: false,
+				enableSorting: true,
 				enableColumnFilter: false,
 			},
 			{


### PR DESCRIPTION
Issue: https://github.com/canvasxyz/canvas/issues/424

This PR includes some fixes to filters, adds filtering/sorting to more table columns and improves the table scrolling UX on the X axis.

- [x] Add the number of filters to the Filters button, e.g. "Filters (1)", if there are any active filters
- [x] Fix bug where filters are reset if more than one filter is applied
- [x] Add sorting by `id` to `$branch_merges`
- [x] Add `message_id` column to `$sessions`
- [x] Add sorting by `message_id` to `$sessions`
- [x] Add filtering by `did` to `$sessions`
- [x] Add sorting on the primary key for model tables
- [x] If a table's height does not cover the entire table area, make the leftover area scrollable on the X axis

<!--- Provide a general summary of your changes in the title above, and a description here -->

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
