### PR TITLE
packages/network-explorer: add download button to $messages

### DIFF
--- a/packages/network-explorer/src/ActionsTable.tsx
+++ b/packages/network-explorer/src/ActionsTable.tsx
@@ -50,6 +50,7 @@ export const ActionsTable = ({
 			defaultSortDirection={defaultSortDirection}
 			showSidebar={showSidebar}
 			setShowSidebar={setShowSidebar}
+			enableDownload={false}
 			tableName={tableName}
 			defaultColumns={columns}
 		/>

--- a/packages/network-explorer/src/App.tsx
+++ b/packages/network-explorer/src/App.tsx
@@ -26,7 +26,7 @@ export const App = () => {
 					}
 				/>
 
-				{tables.map(({ tableName, defaultColumns, defaultSortColumn, defaultSortDirection }, key) => (
+				{tables.map(({ tableName, defaultColumns, enableDownload, defaultSortColumn, defaultSortDirection }, key) => (
 					<Route
 						key={key}
 						path={`/${tableName}`}
@@ -37,6 +37,7 @@ export const App = () => {
 									defaultSortDirection={defaultSortDirection}
 									showSidebar={showSidebar}
 									setShowSidebar={setShowSidebar}
+									enableDownload={enableDownload || false}
 									tableName={tableName}
 									defaultColumns={defaultColumns}
 								/>

--- a/packages/network-explorer/src/ModelTable.tsx
+++ b/packages/network-explorer/src/ModelTable.tsx
@@ -33,6 +33,7 @@ export const ModelTable = ({
 				<Table
 					defaultSortColumn={defaultSortColumn}
 					defaultSortDirection={defaultSortDirection}
+					enableDownload={false}
 					showSidebar={showSidebar}
 					setShowSidebar={setShowSidebar}
 					tableName={params.model as string}

--- a/packages/network-explorer/src/components/TableToolbar.tsx
+++ b/packages/network-explorer/src/components/TableToolbar.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, DropdownMenu, Flex, Text, TextField } from "@radix-ui/themes"
 import { ColumnFiltersState, OnChangeFn, Table as TanStackTable } from "@tanstack/react-table"
 import { BiChevronLeft, BiChevronRight, BiFilter, BiSidebar } from "react-icons/bi"
-import { LuRefreshCw, LuSlidersHorizontal } from "react-icons/lu"
+import { LuDownload, LuRefreshCw, LuSlidersHorizontal } from "react-icons/lu"
 import { ClickableChecklistItem } from "./ClickableChecklistItem.js"
 import { TextFilterMenu } from "./TextFilterMenu.js"
 
@@ -20,6 +20,8 @@ export const TableToolbar = ({
 	prevPage,
 	hasNextPage,
 	nextPage,
+	enableDownload,
+	downloadTable,
 }: {
 	totalCount?: number
 	showSidebar: boolean
@@ -35,6 +37,8 @@ export const TableToolbar = ({
 	prevPage: () => void
 	hasNextPage: boolean
 	nextPage: () => void
+	enableDownload: boolean
+	downloadTable: () => void
 }) => {
 	const tableHasFilters = tanStackTable.getAllLeafColumns().filter((column) => column.getCanFilter()).length > 0
 
@@ -166,6 +170,11 @@ export const TableToolbar = ({
 			<Button color="gray" variant="outline" onClick={() => doRefresh()}>
 				<LuRefreshCw />
 			</Button>
+			{enableDownload && (
+				<Button color="gray" variant="outline" onClick={() => downloadTable()}>
+					<LuDownload />
+				</Button>
+			)}
 		</Flex>
 	)
 }

--- a/packages/network-explorer/src/tables.ts
+++ b/packages/network-explorer/src/tables.ts
@@ -4,14 +4,12 @@ import { BinaryCellData } from "./components/BinaryCellData.js"
 export type TableDef = {
 	tableName: string
 	defaultColumns: ColumnDef<any>[]
-}
-
-type SortDef = {
 	defaultSortColumn: string
 	defaultSortDirection: "desc" | "asc"
+	enableDownload?: boolean
 }
 
-export const tables: (TableDef & SortDef)[] = [
+export const tables: TableDef[] = [
 	{
 		tableName: "$ancestors",
 		defaultSortColumn: "id",
@@ -161,6 +159,7 @@ export const tables: (TableDef & SortDef)[] = [
 		tableName: "$messages",
 		defaultSortColumn: "id",
 		defaultSortDirection: "desc",
+		enableDownload: true,
 		defaultColumns: [
 			{
 				header: "id",

--- a/packages/network-explorer/src/utils.ts
+++ b/packages/network-explorer/src/utils.ts
@@ -4,6 +4,11 @@ import { parse } from "@ipld/dag-json"
 
 export const BASE_URL = import.meta.env.VITE_API_BASE_URL || ""
 
+export const fetchAsString = async (path: string) => {
+	const response = await fetch(`${BASE_URL}${path}`)
+	return await response.text()
+}
+
 export const fetchAndIpldParseJson = async <T>(path: string) => {
 	const startTime = Date.now()
 	const response = await fetch(`${BASE_URL}${path}`)


### PR DESCRIPTION
Issue: https://github.com/canvasxyz/canvas/issues/422

This PR adds a download button to Network Explorer. Currently it is only enabled for the `$messages` table but it can be enabled for other by modifying `tables.ts`. The button appears on the right side of the toolbar. It requests the full table contents from the API and then creates a file download in the browser.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
