### PR TITLE
`packages/network-explorer` - fix bug when changing tables

### DIFF
--- a/packages/network-explorer/src/components/Table.tsx
+++ b/packages/network-explorer/src/components/Table.tsx
@@ -96,15 +96,18 @@ export const Table = <T,>({
 		},
 	)
 
+	let rows: T[] | undefined = undefined
+	let endCursor: any
+	if (data) {
+		rows = data.content.results
+		endCursor = (rows?.length || 0) > entriesPerPage ? (rows[rows.length - 1] as any)[sortColumn] : null
+	}
+
 	const [columnVisibility, setColumnVisibility] = useState({})
-
-	const rows = data ? data.content.results : []
-
-	const endCursor = (rows?.length || 0) > entriesPerPage ? (rows[rows.length - 1] as any)[sortColumn] : null
 
 	const tanStackTable = useReactTable<T>({
 		columns: defaultColumns,
-		data: rows,
+		data: rows || [],
 		getCoreRowModel: getCoreRowModel(),
 		manualPagination: true,
 		manualSorting: true,


### PR DESCRIPTION
Fixes part of https://github.com/canvasxyz/canvas/issues/427

If we have a table that has a healthy API endpoint and a table that has a broken API endpoint then if we switch from the healthy table to the broken table, the rows persist. I think this happens because of optimisations that Tanstack Table makes when data partially changes, but I am not sure.

## Bug example

1. We navigate to the unhealthy table (threads) ![Screenshot 2025-01-13 at 4 12 21 PM](https://github.com/user-attachments/assets/c81097ab-36dc-4194-a331-ec667abac9a6)

2. Then we navigate to a healthy table (comments) ![Screenshot 2025-01-13 at 4 12 25 PM](https://github.com/user-attachments/assets/5911c11b-8d5e-49e3-8f01-e09e361a82fd)

3. Now we navigate back to the unhealthy table. We can see that the rows from the healthy table are still visible. ![Screenshot 2025-01-13 at 4 12 32 PM](https://github.com/user-attachments/assets/3a03a476-ef39-40a3-8483-ae1c8bb2b13a)

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
