### PR TITLE
`packages/modeldb-pg` - fix returning float columns 

### DIFF
--- a/packages/modeldb-pg/src/encoding.ts
+++ b/packages/modeldb-pg/src/encoding.ts
@@ -183,6 +183,8 @@ export function decodePrimitiveValue(modelName: string, property: PrimitivePrope
 	} else if (property.type === "number" || property.type === "float") {
 		if (typeof value === "string") {
 			return parseFloat(value)
+		} else if (typeof value === "number") {
+			return value
 		} else {
 			console.error("expected float, got", value)
 			throw new Error(`internal error - invalid ${modelName}/${property.name} value (expected float)`)


### PR DESCRIPTION
Issue: https://github.com/canvasxyz/canvas/issues/427

This originated in the Network Explorer `/api/models/:model` endpoint for the `threads` table in Common returning the following error: `{"error":"Error: internal error - invalid threads/topic value (expected float)"}`. In this situation, we had a table `threads` with a column `topic` with the type `number`. It looks like the `decodePrimitiveValue` function in `packages/modeldb-pg/src/encoding.ts` assumes that this value is stored in the database as a string. The `decodePrimitiveValue` functions in the other modeldb versions don't make this assumption - I'm not sure what is going on here. @raykyri ?

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
