### PR TITLE
`packages/core` - fix inconsistent handling of args object in `ContractRuntime`

### DIFF
--- a/packages/core/src/runtime/ContractRuntime.ts
+++ b/packages/core/src/runtime/ContractRuntime.ts
@@ -229,7 +229,9 @@ export class ContractRuntime extends AbstractRuntime {
 			blockhash: blockhash ?? null,
 			timestamp,
 		})
-		const argHandles = args.map(this.vm.wrapValue)
+
+		const argHandles = Array.isArray(args) ? args.map(this.vm.wrapValue) : [this.vm.wrapValue(args)]
+
 		try {
 			const result = await this.vm.callAsync(actionHandle, ctxHandle, [this.#databaseAPI, ...argHandles])
 


### PR DESCRIPTION
Issue: https://github.com/canvasxyz/canvas/issues/432

Fixes the bug where `ContractRuntime` expects the args value to be an array, while `FunctionRuntime` can accept either an object or an array.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
