### PR TITLE
`packages/network-explorer` - store filters in URL

### DIFF
--- a/packages/network-explorer/src/components/Table.tsx
+++ b/packages/network-explorer/src/components/Table.tsx
@@ -55,7 +55,9 @@ export const Table = <T,>({
 }) => {
 	const applicationData = useApplicationData()
 
-	const [columnFilters, setColumnFilters] = useSearchFilters([])
+	const [columnFilters, setColumnFilters] = useSearchFilters(
+		defaultColumns.filter((col) => col.enableColumnFilter).map((col) => col.header as string),
+	)
 
 	const { clearCursors, currentCursor, popCursor, pushCursor } = useCursorStack()
 

--- a/packages/network-explorer/src/components/Table.tsx
+++ b/packages/network-explorer/src/components/Table.tsx
@@ -2,19 +2,13 @@ import useSWR from "swr"
 import { Box, Button, Flex, Text } from "@radix-ui/themes"
 import { TableToolbar } from "./TableToolbar.js"
 import { LuChevronDown, LuChevronsUpDown, LuChevronUp } from "react-icons/lu"
-import {
-	ColumnDef,
-	ColumnFiltersState,
-	flexRender,
-	getCoreRowModel,
-	SortingState,
-	useReactTable,
-} from "@tanstack/react-table"
+import { ColumnDef, flexRender, getCoreRowModel, SortingState, useReactTable } from "@tanstack/react-table"
 import { useCallback, useEffect, useState } from "react"
 import { fetchAndIpldParseJson, fetchAsString } from "../utils.js"
 import useCursorStack from "../hooks/useCursorStack.js"
 import { WhereCondition } from "@canvas-js/modeldb"
 import { useApplicationData } from "../hooks/useApplicationData.js"
+import { useSearchFilters } from "../hooks/useSearchFilters.js"
 
 export type Column = {
 	name: string
@@ -60,7 +54,8 @@ export const Table = <T,>({
 	defaultSortDirection: "desc" | "asc"
 }) => {
 	const applicationData = useApplicationData()
-	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]) // can set initial column filter state here
+
+	const [columnFilters, setColumnFilters] = useSearchFilters([])
 
 	const { clearCursors, currentCursor, popCursor, pushCursor } = useCursorStack()
 

--- a/packages/network-explorer/src/hooks/useSearchFilters.ts
+++ b/packages/network-explorer/src/hooks/useSearchFilters.ts
@@ -2,32 +2,35 @@ import { ColumnFiltersState } from "@tanstack/react-table"
 import { Dispatch, SetStateAction } from "react"
 import { useSearchParams } from "react-router-dom"
 
-function read<O>(searchParams: URLSearchParams, defaultValue: O): O {
-	const searchParamsFilterString = searchParams.get("filter")
-	let value = defaultValue
-	if (searchParamsFilterString) {
-		try {
-			value = JSON.parse(searchParamsFilterString)
-		} catch {}
-	}
-	return value
-}
-
-function write<O>(newValue: O): URLSearchParams {
-	return new URLSearchParams({ filter: JSON.stringify(newValue) })
-}
-
-export const useSearchFilters = function (
+export const useSearchFilters = (
 	defaultValue: ColumnFiltersState,
-): [ColumnFiltersState, Dispatch<SetStateAction<ColumnFiltersState>>] {
+): [ColumnFiltersState, Dispatch<SetStateAction<ColumnFiltersState>>] => {
 	const [searchParams, setSearchParams] = useSearchParams()
 
-	const columnFilters = read(searchParams, defaultValue)
+	const searchParamsFilterString = searchParams.get("filter")
+	let columnFilters = defaultValue
+	if (searchParamsFilterString) {
+		try {
+			columnFilters = JSON.parse(searchParamsFilterString)
+		} catch {}
+	}
 
-	const setColumnFilters = (newColumnFilters: SetStateAction<ColumnFiltersState>) => {
-		const value = Array.isArray(newColumnFilters) ? newColumnFilters : newColumnFilters(columnFilters)
-		const processedValue = write(value)
-		setSearchParams(processedValue)
+	const setColumnFilters = (updater: SetStateAction<ColumnFiltersState>) => {
+		if (Array.isArray(updater)) {
+			setSearchParams(new URLSearchParams({ filter: JSON.stringify(updater) }))
+		} else {
+			setSearchParams((oldParams) => {
+				const searchParamsFilterString = oldParams.get("filter")
+				let columnFilters = defaultValue
+				if (searchParamsFilterString) {
+					try {
+						columnFilters = JSON.parse(searchParamsFilterString)
+					} catch {}
+				}
+
+				return { filter: JSON.stringify(updater(columnFilters)) }
+			})
+		}
 	}
 
 	return [columnFilters, setColumnFilters]

--- a/packages/network-explorer/src/hooks/useSearchFilters.ts
+++ b/packages/network-explorer/src/hooks/useSearchFilters.ts
@@ -1,0 +1,34 @@
+import { ColumnFiltersState } from "@tanstack/react-table"
+import { Dispatch, SetStateAction } from "react"
+import { useSearchParams } from "react-router-dom"
+
+function read<O>(searchParams: URLSearchParams, defaultValue: O): O {
+	const searchParamsFilterString = searchParams.get("filter")
+	let value = defaultValue
+	if (searchParamsFilterString) {
+		try {
+			value = JSON.parse(searchParamsFilterString)
+		} catch {}
+	}
+	return value
+}
+
+function write<O>(newValue: O): URLSearchParams {
+	return new URLSearchParams({ filter: JSON.stringify(newValue) })
+}
+
+export const useSearchFilters = function (
+	defaultValue: ColumnFiltersState,
+): [ColumnFiltersState, Dispatch<SetStateAction<ColumnFiltersState>>] {
+	const [searchParams, setSearchParams] = useSearchParams()
+
+	const columnFilters = read(searchParams, defaultValue)
+
+	const setColumnFilters = (newColumnFilters: SetStateAction<ColumnFiltersState>) => {
+		const value = Array.isArray(newColumnFilters) ? newColumnFilters : newColumnFilters(columnFilters)
+		const processedValue = write(value)
+		setSearchParams(processedValue)
+	}
+
+	return [columnFilters, setColumnFilters]
+}


### PR DESCRIPTION
This PR stores filters in the URL - it does this by using the `useSearchParams` provided by `react-router-dom` to store the set of active filters, instead of `useState`. We can filter on at most one value per column at a time.

Example URL:
```
http://localhost:5173/#/$actions?did=did%3Apkh%3Acosmos%3Acosmoshub-1%3Astars1vzrt2kd974tt2n67hv9n8axhuk56swtp6mdhj0&name=reactComment
```

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
