### PR TITLE
`packages/network-explorer` - add a landing page showing actions and sessions

### DIFF
--- a/packages/network-explorer/src/ActionsTable.tsx
+++ b/packages/network-explorer/src/ActionsTable.tsx
@@ -1,3 +1,4 @@
+import { ColumnDef } from "@tanstack/react-table"
 import { Table } from "./components/Table.js"
 import { useApplicationData } from "./hooks/useApplicationData.js"
 
@@ -15,11 +16,11 @@ export const ActionsTable = ({
 	const defaultSortColumn = "message_id"
 	const defaultSortDirection = "desc"
 
-	const columns = [
+	const columns: ColumnDef<any>[] = [
 		{
 			header: "did",
 			accessorKey: "did",
-			size: 320,
+			size: 400,
 			enableSorting: false,
 			enableColumnFilter: true,
 			meta: {
@@ -38,7 +39,8 @@ export const ActionsTable = ({
 		},
 		{
 			header: "timestamp",
-			accessorKey: "timestamp",
+			accessorFn: (row) => new Date(row.timestamp).toLocaleString(),
+			size: 200,
 			enableSorting: false,
 			enableColumnFilter: false,
 		},

--- a/packages/network-explorer/src/App.tsx
+++ b/packages/network-explorer/src/App.tsx
@@ -1,11 +1,12 @@
 import { Flex } from "@radix-ui/themes"
 import { Sidebar } from "./components/Sidebar.js"
 import { Table } from "./components/Table.js"
-import { Navigate, Route, Routes } from "react-router-dom"
+import { Route, Routes } from "react-router-dom"
 import { tables } from "./tables.js"
 import { Suspense, useState } from "react"
 import { ModelTable } from "./ModelTable.js"
 import { ActionsTable } from "./ActionsTable.js"
+import { LandingPage } from "./LandingPage.js"
 
 export const App = () => {
 	const [showSidebar, setShowSidebar] = useState(true)
@@ -14,7 +15,7 @@ export const App = () => {
 		<Flex height="calc(100vh - 1px)" direction="row">
 			{showSidebar && <Sidebar tables={tables} />}
 			<Routes>
-				<Route path="*" element={<Navigate to="/$actions" replace />} />
+				<Route path="/" element={<LandingPage />} />
 
 				<Route
 					key={"$actions"}

--- a/packages/network-explorer/src/LandingPage.tsx
+++ b/packages/network-explorer/src/LandingPage.tsx
@@ -1,0 +1,107 @@
+import { Box, Container, Flex, Heading, Link, Text } from "@radix-ui/themes"
+import useSWR from "swr"
+import { stringifyRequestParams } from "./components/Table.js"
+import { fetchAndIpldParseJson } from "./utils.js"
+import { ReactNode } from "react"
+
+const Th = ({ children }: { children: ReactNode }) => (
+	<th style={{ padding: "10px", textAlign: "left" }}>
+		<Text size="2">{children}</Text>
+	</th>
+)
+const Td = ({ children }: { children: ReactNode }) => (
+	<td style={{ padding: "10px" }}>
+		<Text size="2">{children}</Text>
+	</td>
+)
+
+export const LandingPage = () => {
+	const { data: actionData } = useSWR(
+		`/api/models/$actions?${stringifyRequestParams({
+			limit: 3,
+		})}`,
+		fetchAndIpldParseJson<{
+			totalCount: number
+			results: { message_id: string; name: string; timestamp: string; did: string }[]
+		}>,
+		{
+			refreshInterval: 1000,
+		},
+	)
+	const actions = actionData && actionData.content.results
+
+	const { data: sessionData } = useSWR(
+		`/api/models/$sessions?${stringifyRequestParams({
+			limit: 3,
+		})}`,
+		fetchAndIpldParseJson<{
+			totalCount: number
+			results: { did: string; public_key: string }[]
+		}>,
+		{
+			refreshInterval: 1000,
+		},
+	)
+	const sessions = sessionData && sessionData.content.results
+
+	return (
+		<Container size="2">
+			<Flex direction="column" gap="4" pt="9">
+				<Heading>Recent actions</Heading>
+
+				<Box style={{ border: "solid var(--gray-6) 1px" }} mb="4">
+					<table style={{ borderCollapse: "collapse", width: "100%" }}>
+						<thead style={{ backgroundColor: "white" }}>
+							<tr style={{ width: "100%", borderBottom: "solid var(--gray-6) 1px" }}>
+								<Th>id</Th>
+								<Th>name</Th>
+								<Th>timestamp</Th>
+								<Th>user</Th>
+							</tr>
+						</thead>
+						<tbody style={{ backgroundColor: "white" }}>
+							{(actions || []).map((action, index) => (
+								<tr key={index}>
+									<Td>{action.message_id.slice(0, 10)}</Td>
+									<Td>{action.name}</Td>
+									<Td>{action.timestamp}</Td>
+									<Td>{action.did.slice(0, 30)}...</Td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+					<Flex direction="row" justify="center" py="2" style={{ borderTop: "solid var(--gray-6) 1px" }}>
+						<Link href="#/$actions" color="gray">
+							See more
+						</Link>
+					</Flex>
+				</Box>
+
+				<Heading>Recent sessions</Heading>
+				<Box style={{ border: "solid var(--gray-6) 1px" }} mb="4">
+					<table style={{ borderCollapse: "collapse", width: "100%" }}>
+						<thead style={{ backgroundColor: "white" }}>
+							<tr style={{ width: "100%", borderBottom: "solid var(--gray-6) 1px" }}>
+								<Th>did</Th>
+								<Th>public_key</Th>
+							</tr>
+						</thead>
+						<tbody style={{ backgroundColor: "white" }}>
+							{(sessions || []).map((session, index) => (
+								<tr key={index}>
+									<Td>{session.did.slice(0, 30)}...</Td>
+									<Td>{session.public_key.slice(0, 30)}...</Td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+					<Flex direction="row" justify="center" py="2" style={{ borderTop: "solid var(--gray-6) 1px" }}>
+						<Link href="#/$sessions" color="gray">
+							See more
+						</Link>
+					</Flex>
+				</Box>
+			</Flex>
+		</Container>
+	)
+}

--- a/packages/network-explorer/src/LandingPage.tsx
+++ b/packages/network-explorer/src/LandingPage.tsx
@@ -22,7 +22,7 @@ export const LandingPage = () => {
 		})}`,
 		fetchAndIpldParseJson<{
 			totalCount: number
-			results: { message_id: string; name: string; timestamp: string; did: string }[]
+			results: { message_id: string; name: string; timestamp: number; did: string }[]
 		}>,
 		{
 			refreshInterval: 1000,
@@ -64,7 +64,7 @@ export const LandingPage = () => {
 								<tr key={index}>
 									<Td>{action.message_id.slice(0, 10)}</Td>
 									<Td>{action.name}</Td>
-									<Td>{action.timestamp}</Td>
+									<Td>{new Date(action.timestamp).toLocaleString()}</Td>
 									<Td>{action.did.slice(0, 30)}...</Td>
 								</tr>
 							))}

--- a/packages/network-explorer/src/components/Sidebar.tsx
+++ b/packages/network-explorer/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Heading, Box, Flex, TextField } from "@radix-ui/themes"
+import { Box, Flex, TextField, Link } from "@radix-ui/themes"
 import { TableSelector } from "./TableSelector.js"
 import { LuTable2 } from "react-icons/lu"
 import { ApplicationDataBox } from "../ApplicationDataBox.js"
@@ -26,9 +26,9 @@ export const Sidebar = ({ tables }: { tables: TableDef[] }) => {
 			style={{ borderRight: "1px solid var(--gray-3)" }}
 		>
 			<Box px="2" pt="10px" pb="9px">
-				<Heading size="3">
+				<Link href="#/" size="3" highContrast color="gray" underline="none" weight="bold">
 					Network Explorer
-				</Heading>
+				</Link>
 			</Box>
 			<Box px="2" py="0.5" pb="2">
 				<TextField.Root

--- a/packages/network-explorer/src/components/Table.tsx
+++ b/packages/network-explorer/src/components/Table.tsx
@@ -25,18 +25,21 @@ type SortDirection = "desc" | "asc"
 
 type RequestParams = {
 	limit: number
-	orderBy: {
+	orderBy?: {
 		[sortColumn: string]: SortDirection
 	}
-	where: WhereCondition
+	where?: WhereCondition
 }
 
-const stringifyRequestParams = ({ limit, orderBy, where }: RequestParams) => {
-	const params: Record<string, string> = {
-		limit: limit.toString(),
-		orderBy: JSON.stringify(orderBy),
+export const stringifyRequestParams = ({ limit, orderBy, where }: RequestParams) => {
+	const params: Record<string, string> = {}
+	if (limit) {
+		params.limit = limit.toString()
 	}
-	if (Object.keys(where).length > 0) {
+	if (orderBy) {
+		params.orderBy = JSON.stringify(orderBy)
+	}
+	if (where && Object.keys(where).length > 0) {
 		params.where = JSON.stringify(where)
 	}
 	return new URLSearchParams(params).toString()


### PR DESCRIPTION
Issue: https://github.com/canvasxyz/canvas/issues/434

Changes:

- Add a landing page showing the latest actions and sessions, with links to their respective pages. Timestamps are formatted with `new Date(timestamp).toLocaleString()`.
- Update the `$actions` table view to display the timestamp as a locale string.
- Make the "Network Explorer" heading in the sidebar link to the landing page.

![Screenshot 2025-01-14 at 2 03 47 PM](https://github.com/user-attachments/assets/15a6a558-9582-494c-a3ab-181eb821aa40)


## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
