### PR TITLE
packages/hooks: Use remote contracts in hook

### DIFF
--- a/examples/chat/src/App.tsx
+++ b/examples/chat/src/App.tsx
@@ -46,8 +46,8 @@ export const App: React.FC<{}> = ({}) => {
 	const topicRef = useRef(topic)
 
 	const { app, ws } = useCanvas(wsURL, {
-		// topic: topicRef.current,
-		// contract,
+		topic: topicRef.current,
+		contract,
 		signers: [
 			new SIWESigner(),
 			new Eip712Signer(),

--- a/examples/chat/src/App.tsx
+++ b/examples/chat/src/App.tsx
@@ -46,8 +46,8 @@ export const App: React.FC<{}> = ({}) => {
 	const topicRef = useRef(topic)
 
 	const { app, ws } = useCanvas(wsURL, {
-		topic: topicRef.current,
-		contract,
+		// topic: topicRef.current,
+		// contract,
 		signers: [
 			new SIWESigner(),
 			new Eip712Signer(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -36955,6 +36955,7 @@
 				"@canvas-js/interfaces": "0.14.0-next.1",
 				"@canvas-js/modeldb": "0.14.0-next.1",
 				"@canvas-js/modeldb-idb": "0.14.0-next.1",
+				"@ipld/dag-cbor": "^9.2.2",
 				"@noble/hashes": "^1.7.1"
 			},
 			"devDependencies": {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,7 +1,8 @@
 import process from "node:process"
+import crypto from "node:crypto"
+import * as cbor from "@ipld/dag-cbor"
 import type { Argv } from "yargs"
 import dotenv from "dotenv"
-import crypto from "node:crypto"
 import { SiweMessage } from "siwe"
 import { verifyMessage } from "ethers"
 
@@ -147,9 +148,8 @@ export async function handler(args: Args) {
 		})
 
 		instance.api.get("/api/snapshot", async (_req, res) => {
-			res.json({
-				snapshot: updatedSnapshot,
-			})
+			res.writeHead(200, { 'Content-Type': 'application/cbor' });
+			res.end(cbor.encode(updatedSnapshot))
 		})
 
 		if (args.admin) {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -20,6 +20,7 @@
 		"@canvas-js/interfaces": "0.14.0-next.1",
 		"@canvas-js/modeldb": "0.14.0-next.1",
 		"@canvas-js/modeldb-idb": "0.14.0-next.1",
+		"@ipld/dag-cbor": "^9.2.2",
     "@noble/hashes": "^1.7.1"
 	},
 	"devDependencies": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -21,7 +21,7 @@
 		"@canvas-js/modeldb": "0.14.0-next.1",
 		"@canvas-js/modeldb-idb": "0.14.0-next.1",
 		"@ipld/dag-cbor": "^9.2.2",
-    "@noble/hashes": "^1.7.1"
+		"@noble/hashes": "^1.7.1"
 	},
 	"devDependencies": {
 		"@types/react": "^18.3.9",

--- a/packages/hooks/src/useCanvas.ts
+++ b/packages/hooks/src/useCanvas.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react"
+import * as cbor from "@ipld/dag-cbor"
 import { Canvas, NetworkClient, ModelSchema, Config, Snapshot, Actions, hashContract } from "@canvas-js/core"
 
 /**
@@ -70,7 +71,11 @@ export const useCanvas = <
 				const remoteContractHash = hashContract(contractInfo.contract)
 
 				const snapshot = contractInfo.snapshotHash
-					? ((await (await fetch(snapshotApi)).json()).snapshot as Snapshot)
+					? await (async () => {
+						const response = await fetch(snapshotApi)
+						const buffer = await response.arrayBuffer()
+						return cbor.decode<Snapshot>(new Uint8Array(buffer))
+					})()
 					: null
 
 				let reset: boolean

--- a/packages/hooks/src/useCanvas.ts
+++ b/packages/hooks/src/useCanvas.ts
@@ -1,61 +1,133 @@
 import { useState, useEffect, useRef } from "react"
-import { Canvas, NetworkClient, ModelSchema as Models, Config, Snapshot, Actions, hashContract } from "@canvas-js/core"
+import { Canvas, NetworkClient, ModelSchema, Config, Snapshot, Actions, hashContract } from "@canvas-js/core"
 
-export const useCanvas = <ModelsT extends Models = Models, ActionsT extends Actions<ModelsT> = Actions<ModelsT>>(
+/**
+ * React hook for Canvas applications, using client-to-server sync.
+ *
+ * @param url The wss:// endpoint to connect to.
+ * @param config The application to run inside the hook. If `topic` and `contract` are left empty, this will fetch the application from the URL, and the local application will live-update when the server side application is changed.
+ * @returns
+ */
+export const useCanvas = <
+	ModelsT extends ModelSchema = ModelSchema,
+	ActionsT extends Actions<ModelsT> = Actions<ModelsT>,
+>(
 	url: string | null,
-	config: Config<ModelsT, ActionsT>,
+	config: Config<ModelsT, ActionsT> | Omit<Config<ModelsT, ActionsT>, "topic" | "contract">,
 ) => {
 	const [app, setApp] = useState<Canvas<ModelsT, ActionsT>>()
 	const [networkClient, setNetworkClient] = useState<NetworkClient<any>>()
 	const [error, setError] = useState<Error>()
 
-	// TODO: ensure effect hook re-runs on signer change
-	const hashRef = useRef<string>()
-	const snapshotRef = useRef<Snapshot>()
-	const renderedRef = useRef(false) // skip second render in React.StrictMode
+	// TODO: Ensure effect hook re-runs when signers are changed.
+	const localContractHashRef = useRef<string>() // Ref for last-rendered contractHash of a local application.
+	const remoteContractHashRef = useRef<Record<string, string>>({}) // Ref for last-rendered contractHash for remote applications.
+	const snapshotRef = useRef<Snapshot>() // Ref for caching a local application's snapshot.
+	const renderedRef = useRef(false) // Ref for skipping extra render in React.StrictMode.
 
-	const contractHash = hashContract(config.contract)
+	const contractHash = config && "contract" in config ? hashContract(config.contract) : null
 
 	useEffect(() => {
 		if (renderedRef.current) return
 		renderedRef.current = true
 
-		function setupApp(appUrl: string | null, app: Canvas<ModelsT, ActionsT>) {
+		// Assign a new application to the hook's state vars.
+		function assign(appUrl: string | null, app: Canvas<ModelsT, ActionsT>) {
 			if (url) {
-				app.connect(url).then((networkClient) => {
-					setApp(app)
-					setNetworkClient(networkClient)
-				}).catch((err) => {
-					setApp(app)
-					setTimeout(() => setupApp(appUrl, app), 2000)
-				})
+				app
+					.connect(url)
+					.then((networkClient) => {
+						setApp(app)
+						setNetworkClient(networkClient)
+					})
+					.catch((err) => {
+						setApp(app)
+						setTimeout(() => assign(appUrl, app), 2000)
+					})
 			} else {
 				setApp(app)
 			}
 		}
 
-		async function updateSnapshot() {
-			if (!app || contractHash === hashRef.current) {
-				// app just initialized, or contract remains unchanged
-				await Canvas.initialize<ModelsT, ActionsT>(config).then(setupApp.bind(null, url))
-			} else if ((await app.db.count("$messages")) > 1 && snapshotRef.current) {
-				// contract changed, reuse the old snapshot
-				const snapshot = snapshotRef.current
-				await Canvas.initialize<ModelsT, ActionsT>({ ...config, reset: true, snapshot }).then(setupApp.bind(null, url))
-			} else {
-				// contract changed, make a new snapshot
-				const snapshot = await app.createSnapshot()
-				await Canvas.initialize<ModelsT, ActionsT>({ ...config, reset: true, snapshot }).then(setupApp.bind(null, url))
-				snapshotRef.current = snapshot
+		if (contractHash === null) {
+			// Set up a remotely fetched application.
+			async function setupRemoteApplication([info, contractInfo]: [{ topic: string }, { contract: string }]) {
+				if (config === undefined || "topic" in config || "contract" in config) {
+					console.error("Unexpected: Internal error (remote application)")
+					return
+				}
+
+				const topic = info.topic
+				const contract = contractInfo.contract
+				const remoteContractHash = hashContract(contractInfo.contract)
+				let reset: boolean
+
+				// TODO: Maybe the contract is already in IndexedDB?
+				// We should store the contract in ModelDB, and/or always include contractHash in the topic.
+				if (remoteContractHashRef.current[topic] === undefined) {
+					reset = false
+				} else if (contractInfo.contract === remoteContractHashRef.current[topic]) {
+					reset = false
+				} else {
+					reset = true
+				}
+
+				// TODO: Add a remote snapshot.
+				await Canvas.initialize<ModelsT, ActionsT>({
+					topic,
+					contract,
+					reset,
+					...config,
+				})
+					.then(assign.bind(null, url))
+					.finally(() => {
+						remoteContractHashRef.current[topic] = remoteContractHash
+					})
 			}
+
+			const httpRoot = url?.replace("ws://", "http://").replace("wss://", "https://")
+			const baseApi = `${httpRoot}/api`
+			const contractApi = `${httpRoot}/api/contract`
+
+			Promise.all([
+				fetch(baseApi).then((response) => response.json()),
+				fetch(contractApi).then((response) => response.json()),
+			])
+				.then(setupRemoteApplication)
+				.catch((error) => {
+					console.error(error)
+					setError(error)
+				})
+		} else {
+			// Set up the application from a local `config`.
+			// Snapshot, reset, and restart the application from a snapshot if the contract changed.
+			async function setupLocalApplicationBySnapshot() {
+				if (config === undefined || !("topic" in config) || !("contract" in config)) {
+					console.error("Unexpected: Internal error (local application)")
+					return
+				}
+				if (!app || contractHash === localContractHashRef.current) {
+					// Application just initialized, or contract remains unchanged
+					await Canvas.initialize<ModelsT, ActionsT>(config).then(assign.bind(null, url))
+				} else if ((await app.db.count("$messages")) > 1 && snapshotRef.current) {
+					// Contract changed, reuse the old snapshot
+					const snapshot = snapshotRef.current
+					await Canvas.initialize<ModelsT, ActionsT>({ ...config, reset: true, snapshot }).then(assign.bind(null, url))
+				} else {
+					// Contract changed, make a new snapshot
+					const snapshot = await app.createSnapshot()
+					await Canvas.initialize<ModelsT, ActionsT>({ ...config, reset: true, snapshot }).then(assign.bind(null, url))
+					snapshotRef.current = snapshot
+				}
+			}
+
+			setupLocalApplicationBySnapshot().catch((error) => {
+				console.error(error)
+				setError(error)
+			})
+
+			localContractHashRef.current = contractHash
 		}
-
-		updateSnapshot().catch((error) => {
-			console.error(error)
-			setError(error)
-		})
-
-		hashRef.current = contractHash
 	}, [url, contractHash])
 
 	return { app, ws: networkClient, error }

--- a/packages/hooks/src/useCanvas.ts
+++ b/packages/hooks/src/useCanvas.ts
@@ -3,12 +3,12 @@ import * as cbor from "@ipld/dag-cbor"
 import { Canvas, NetworkClient, ModelSchema, Config, Snapshot, Actions, hashContract } from "@canvas-js/core"
 
 /**
- * React hook for Canvas applications, using client-to-server sync.
+ * React hook for Canvas applications using client-to-server sync.
  *
  * @param url The wss:// endpoint to connect to.
  * @param config The application to run inside the hook. If `topic` and
  * `contract` are empty, this will fetch the application contract from
- * the URL, and live-update when the server contract is changed.
+ * `url`, and live-update the local app when the server contract changes.
  */
 export const useCanvas = <
 	ModelsT extends ModelSchema = ModelSchema,
@@ -23,8 +23,8 @@ export const useCanvas = <
 
 	// TODO: Ensure effect hook re-runs when signers are changed.
 	const localContractHashRef = useRef<string>() // Ref for last-rendered contractHash of a local application.
-	const remoteContractHashRef = useRef<Record<string, string>>({}) // Ref for last-rendered contractHash for remote applications.
 	const snapshotRef = useRef<Snapshot>() // Ref for caching a local application's snapshot.
+	const remoteContractHashRef = useRef<Record<string, string>>({}) // Ref for last-rendered contractHash for remote applications.
 	const renderedRef = useRef(false) // Ref for skipping extra render in React.StrictMode.
 
 	const contractHash = config && "contract" in config ? hashContract(config.contract) : null
@@ -72,10 +72,10 @@ export const useCanvas = <
 
 				const snapshot = contractInfo.snapshotHash
 					? await (async () => {
-						const response = await fetch(snapshotApi)
-						const buffer = await response.arrayBuffer()
-						return cbor.decode<Snapshot>(new Uint8Array(buffer))
-					})()
+							const response = await fetch(snapshotApi)
+							const buffer = await response.arrayBuffer()
+							return cbor.decode<Snapshot>(new Uint8Array(buffer))
+						})()
 					: null
 
 				let reset: boolean


### PR DESCRIPTION
Closes #450. 

The `useCanvas` hook can now be instantiated with just a URL, at which point it will fetch a contract and optionally a snapshot from the remote URL and run that.