### PR TITLE
Rework snapshots on log

### DIFF
--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -21,6 +21,7 @@ import { ActionRecord } from "./runtime/AbstractRuntime.js"
 import { validatePayload } from "./schema.js"
 import { createSnapshot, hashSnapshot, Change } from "./snapshot.js"
 import { initialUpgradeSchema, topicPattern } from "./utils.js"
+import { SnapshotSignatureScheme } from "@canvas-js/signatures"
 
 export type { Model } from "@canvas-js/modeldb"
 export type { PeerId } from "@libp2p/interface"
@@ -104,9 +105,13 @@ export class Canvas<
 		const signers = new SignerCache(initSigners.length === 0 ? [new SIWESigner()] : initSigners)
 
 		const verifySignature = (signature: Signature, message: Message<MessageType>) => {
-			const signer = signers.getAll().find((signer) => signer.scheme.codecs.includes(signature.codec))
-			assert(signer !== undefined, "no matching signer found")
-			return signer.scheme.verify(signature, message)
+			if (message.payload.type === "snapshot") {
+				SnapshotSignatureScheme.verify(signature, message)
+			} else {
+				const signer = signers.getAll().find((signer) => signer.scheme.codecs.includes(signature.codec))
+				assert(signer !== undefined, "no matching signer found")
+				return signer.scheme.verify(signature, message)
+			}
 		}
 
 		const runtime = await createRuntime(topic, signers, contract, { runtimeMemoryLimit })
@@ -159,14 +164,20 @@ export class Canvas<
 			}
 		}
 
-		if (config.snapshot) {
-			const [clock, heads] = await messageLog.getClock()
-			if (clock === 1 && heads.length === 0) {
-				await messageLog.append(config.snapshot)
-			}
-		}
-
 		const app = new Canvas<ModelsT, ActionsT>(signers, messageLog, runtime)
+
+		if (config.snapshot) {
+			assert(topic.endsWith(`#${hashSnapshot(config.snapshot)}`), "invalid snapshot")
+			const message: Message<Snapshot> = {
+				topic,
+				clock: 0,
+				parents: [],
+				payload: config.snapshot,
+			}
+			const signature = await SnapshotSignatureScheme.create().sign(message)
+			const signedMessage: SignedMessage<Snapshot> = app.messageLog.encode(signature, message)
+			await app.messageLog.insert(signedMessage)
+		}
 
 		// Check to see if the $actions table is empty and populate it if necessary
 		const messagesCount = await messageLog.db.count("$messages")

--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -110,6 +110,7 @@ export class Canvas<
 			} else {
 				const signer = signers.getAll().find((signer) => signer.scheme.codecs.includes(signature.codec))
 				assert(signer !== undefined, "no matching signer found")
+				assert(message.clock > 0, "invalid clock")
 				return signer.scheme.verify(signature, message)
 			}
 		}

--- a/packages/core/test/snapshot.test.ts
+++ b/packages/core/test/snapshot.test.ts
@@ -63,7 +63,7 @@ test("snapshot persists data across apps", async (t) => {
 	await app2.actions.createPost({ id: "f", content: "4" })
 
 	const [clock2, parents2] = await app2.messageLog.getClock()
-	t.is(clock2, 7) // one snapshot, one session, four actions
+	t.is(clock2, 6) // one snapshot, one session, four actions
 	t.is(parents2.length, 1)
 
 	t.is((await app2.db.get("posts", "a"))?.content, "1")
@@ -91,6 +91,6 @@ test("snapshot persists data across apps", async (t) => {
 	t.is(await app3.db.get("posts", "g"), null)
 
 	const [clock3] = await app3.messageLog.getClock()
-	t.is(clock3, 2) // one snapshot
+	t.is(clock3, 1) // one snapshot
 	t.is(parents2.length, 1)
 })

--- a/packages/gossiplog/src/migrations.ts
+++ b/packages/gossiplog/src/migrations.ts
@@ -5,7 +5,7 @@ import * as json from "@ipld/dag-json"
 import { hashEntry } from "@canvas-js/okra"
 
 import { Config, DatabaseUpgradeAPI, ModelSchema, RangeExpression } from "@canvas-js/modeldb"
-import { Message, Signature } from "@canvas-js/interfaces"
+import { Message, MessageType, Signature } from "@canvas-js/interfaces"
 import { assert, JSONValue } from "@canvas-js/utils"
 
 import { SignedMessage } from "./SignedMessage.js"
@@ -15,7 +15,7 @@ export const version = 5
 
 export const baseVersion = { [namespace]: version }
 
-export async function upgrade(
+export async function upgrade<Payload extends MessageType>(
 	upgradeAPI: DatabaseUpgradeAPI,
 	oldConfig: Config,
 	oldVersion: Record<string, number>,
@@ -92,7 +92,7 @@ export async function upgrade(
 				const messageBytes: Uint8Array = json.encode(message)
 				const signedMessage = SignedMessage.encode(
 					json.decode<Signature>(signatureBytes),
-					json.decode<Message>(messageBytes),
+					json.decode<Message<Payload>>(messageBytes),
 				)
 
 				assert(signedMessage.id === id, "internal error - expected signedMessage.id === id")

--- a/packages/gossiplog/src/schema.ts
+++ b/packages/gossiplog/src/schema.ts
@@ -40,13 +40,7 @@ function validateMessageTuple<Payload extends MessageType>(
 		assert(parent.length === KEY_LENGTH, "expected parent.length === KEY_LENGTH")
 	}
 
-	assert(payload !== null && payload !== undefined, "expected payload")
-	if (payload.type === "snapshot") {
-		assert(clock === 0, "expected clock === 0 for snapshot")
-		assert(parents.length === 0, "expected empty parent array for snapshot")
-	} else {
-		assert(clock === getNextClock(parents), "expected clock === getNextClock(parents)")
-	}
+	assert((clock === 0 && parents.length === 0) || clock === getNextClock(parents), "expected clock === getNextClock(parents)")
 }
 
 export function decodeSignedMessage(value: Uint8Array): { signature: Signature; message: Message } {
@@ -60,22 +54,12 @@ export function decodeSignedMessage(value: Uint8Array): { signature: Signature; 
 	}
 }
 
-function isValidPayload(payload: unknown): payload is MessageType {
-	return typeof payload === "object" && payload !== null && "type" in payload
-}
-
 export function encodeSignedMessage<Payload>(
 	{ codec, publicKey, signature }: Signature,
 	{ topic, clock, parents, payload }: Message<Payload>,
 ): Uint8Array {
 	const parentKeys = parents.map(encodeId)
-	assert(isValidPayload(payload), "invalid payload")
-	if (payload.type === "snapshot") {
-		assert(clock === 0, "expected clock === 0 for snapshot")
-		assert(parents.length === 0, "expected empty parent array of snapshot")
-	} else {
-		assert(clock === getNextClock(parentKeys), "expected clock === getNextClock(parentKeys)")
-	}
+	assert((clock === 0 && parentKeys.length === 0) || clock === getNextClock(parentKeys), "expected clock === getNextClock(parentKeys)")
 	return cbor.encode([[codec, publicKey, signature], topic, clock, parentKeys, payload])
 }
 

--- a/packages/gossiplog/src/utils.ts
+++ b/packages/gossiplog/src/utils.ts
@@ -2,12 +2,19 @@ import { Uint8ArrayList } from "uint8arraylist"
 import * as cbor from "@ipld/dag-cbor"
 
 import { Event } from "@canvas-js/gossiplog/protocols/events"
-import { ModelSchema } from "@canvas-js/modeldb"
+import { Snapshot } from "@canvas-js/interfaces"
+import { sha256 } from "@noble/hashes/sha256"
+import { bytesToHex } from "@noble/hashes/utils"
 
 export const cborNull: Uint8Array = cbor.encode(null)
 
 // eslint-disable-next-line no-useless-escape
 export const gossiplogTopicPattern = /^[a-zA-Z0-9\.\-]+(\#[a-zA-Z0-9]+)?$/
+
+export function hashSnapshot(snapshot: Snapshot): string {
+	const hash = sha256(cbor.encode(snapshot))
+	return bytesToHex(hash).slice(0, 16)
+}
 
 /** Logarithmic clock decay */
 export function* getAncestorClocks(clock: number): Iterable<number> {
@@ -21,8 +28,6 @@ export function* getAncestorClocks(clock: number): Iterable<number> {
 		}
 	}
 }
-
-export const formatTopic = (topic: string) => topic.replace("#", "_")
 
 export const getSyncProtocol = (topic: string) => `/canvas/v1/${topic}/sync`
 export const getPushProtocol = (topic: string) => `/canvas/v1/${topic}/push`

--- a/packages/interfaces/src/Signature.ts
+++ b/packages/interfaces/src/Signature.ts
@@ -1,5 +1,5 @@
 export type Signature = {
-	codec: string // "dag-cbor" | "dag-json" | "canvas-action-eip712" | "canvas-session-eip712"
-	publicKey: string // did:key URI
+	codec: string // "dag-cbor" | "dag-json" | "canvas-action-eip712" | "canvas-session-eip712" | "canvas-snapshot"
+	publicKey: string // did:key URI, or empty string if snapshot
 	signature: Uint8Array
 }

--- a/packages/signatures/src/index.ts
+++ b/packages/signatures/src/index.ts
@@ -1,4 +1,5 @@
 export { Ed25519SignatureScheme as ed25519 } from "./ed25519.js"
+export { SnapshotSignatureScheme, SnapshotSigner } from "./snapshot.js"
 export * from "./AbstractSessionSigner.js"
 
 export { encodeURI, decodeURI, prepareMessage } from "./utils.js"

--- a/packages/signatures/src/snapshot.ts
+++ b/packages/signatures/src/snapshot.ts
@@ -1,0 +1,45 @@
+import type { Action, Session, Snapshot, Message, Signature, SignatureScheme, Signer } from "@canvas-js/interfaces"
+import { assert } from "@canvas-js/utils"
+
+const codecs = { snapshot: "canvas-snapshot" }
+
+/**
+ * SnapshotSigner returns an empty signature, and supports the following codecs:
+ * - snapshot
+ */
+export class SnapshotSigner<Payload extends { type: string }> implements Signer<Payload> {
+	public readonly publicKey: string = ""
+	public readonly scheme: SignatureScheme<any> = SnapshotSignatureScheme
+
+	public constructor() {}
+
+	public sign(message: Message<Payload>): Signature {
+		assert(message.payload.type === "snapshot", "SnapshotSigner only supports messages of type 'snapshot'")
+		assert(message.clock === 0)
+		assert(message.parents.length === 0)
+		return {
+			codec: "canvas-snapshot",
+			publicKey: "",
+			signature: new Uint8Array(0),
+		}
+	}
+
+	public export(): { type: string; privateKey: Uint8Array } {
+		throw new Error("unimplemented")
+	}
+}
+
+export const SnapshotSignatureScheme = {
+	type: "canvas-snapshot",
+	codecs: [codecs.snapshot],
+
+	verify: (signature: Signature, message: Message<any>) => {
+		assert(signature.publicKey === "")
+		assert(signature.signature instanceof Uint8Array && signature.signature.length === 0)
+		assert(message.clock === 0)
+		assert(message.parents.length === 0)
+		assert("type" in message.payload && message.payload.type === "snapshot")
+	},
+
+	create: <Payload extends { type: string }>() => new SnapshotSigner<Payload>(),
+} satisfies SignatureScheme<any>


### PR DESCRIPTION
Previously we put snapshots on the log at clock = 1, but it was possible to have multiple snapshots on the same log because they could be signed by different publicKeys.

This reworks snapshots to be at clock = 0, by adding some special casing:
- Creates a snapshot scheme in @canvas-js/signatures, which always fills in an empty signature using the canvas-snapshot codec.
- Inside the Canvas.ts verifyMessage() call, use the snapshot scheme to "verify" the snapshot signature, if the added message is a snapshot.
- The scheme's verify() method enforces that parents = [] and clock = 0.
- Topics must include a snapshot's hash, so applications are locked to the snapshot they're started with, and it's safe to have an empty signature for the snapshot. Also, this means that actions and sessions are signed with that snapshot's hash inside the topic.

GossipLog message validation has been relaxed slightly, to allow messages to be added with clock = 0 and parents = [], that are not subject to getNextClock() checking.

Snapshots do not affect $heads, so I think this shouldn't impact messages at clock = 1, 2, etc.

## How has this been tested?

- [x] CI tests pass
- [x] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [x] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
