### PR TITLE
packages/signatures: remove privkeyseed, creating signers now defaults to a random key

### DIFF
--- a/packages/chain-ethereum/src/siwe/SIWESigner.ts
+++ b/packages/chain-ethereum/src/siwe/SIWESigner.ts
@@ -36,7 +36,7 @@ export class SIWESigner extends AbstractSessionSigner<SIWESessionData> {
 	public constructor({ sessionDuration, ...init }: SIWESignerInit = { sessionDuration: 14 * DAYS }) {
 		super("chain-ethereum", ed25519, { sessionDuration })
 
-		this._signer = init.signer ?? new Wallet(this.privkeySeed) // Wallet.createRandom()
+		this._signer = init.signer ?? Wallet.createRandom()
 		this.chainId = init.chainId ?? 1
 		this.key = `chain-ethereum${init.signer ? "-signer" : ""}`
 	}

--- a/packages/signatures/src/AbstractSessionSigner.ts
+++ b/packages/signatures/src/AbstractSessionSigner.ts
@@ -29,7 +29,6 @@ export abstract class AbstractSessionSigner<
 	public readonly sessionDuration: number | null
 
 	protected readonly log: Logger
-	protected readonly privkeySeed: string
 
 	#cache = new Map<string, { session: Session; signer: Signer<MessageType<AuthorizationData>> }>()
 
@@ -40,13 +39,6 @@ export abstract class AbstractSessionSigner<
 	) {
 		this.log = logger(`canvas:signer:${key}`)
 		this.sessionDuration = options.sessionDuration ?? null
-
-		let seed = target.get(`canvas:signers/${key}/seed`)
-		if (seed === null || seed.length !== 64 || !seed.match(/^[0-9a-f]+$/i)) {
-			seed = bytesToHex(randomBytes(32))
-			target.set(`canvas:signers/${key}/seed`, seed)
-		}
-		this.privkeySeed = seed
 	}
 
 	public abstract match: (address: string) => boolean


### PR DESCRIPTION
Closes #417.

<!--- Provide a general summary of your changes in the title above, and a description here -->

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
