### PR TITLE
Model-only contracts

### DIFF
--- a/contracts/refs.ts
+++ b/contracts/refs.ts
@@ -1,0 +1,76 @@
+import type { ModelSchema, ModelInit } from "@canvas-js/core"
+
+const connection: ModelInit = {
+	id: "primary",
+	creator: "@user",
+	ref: "@ref",
+
+	image: "string?",
+	location: "string?",
+	url: "string?",
+	text: "string?",
+	children: "@connection[]",
+
+	list: "boolean?",
+	backlog: "boolean?",
+	order: "number?",
+
+	created: "string?",
+	deleted: "string?",
+	updated: "string?",
+
+	$indexes: ["id"],
+	$rules: {
+		create: "this.sender === creator && id === user + '/' + connection",
+		update: "this.sender === creator && id === user + '/' + connection",
+		delete: "this.sender === creator",
+	},
+}
+
+const profile: ModelInit = {
+	id: "primary",
+	userName: "string",
+
+	firstName: "string",
+	lastName: "string",
+	geolocation: "string?",
+	location: "string?",
+	image: "string?",
+
+	created: "string?",
+	updated: "string?",
+
+	$rules: {
+		create: "this.sender === id",
+		update: "this.sender === id",
+		delete: false,
+	},
+}
+
+const ref: ModelInit = {
+	id: "primary",
+	creator: "@user?",
+	type: "string?",
+
+	title: "string?",
+	image: "string?",
+	location: "string?",
+	url: "string?",
+	meta: "string?",
+
+	created: "string?",
+	updated: "string?",
+	deleted: "string?",
+
+	$rules: {
+		create: "this.sender === creator && ['place', 'artwork', 'other'].includes(type)",
+		update: "this.sender === creator && ['place', 'artwork', 'other'].includes(type)",
+		delete: false,
+	},
+}
+
+export const models = {
+	connection,
+	profile,
+	ref,
+} satisfies ModelSchema

--- a/contracts/refs.ts
+++ b/contracts/refs.ts
@@ -2,7 +2,7 @@ import type { ModelSchema, ModelInit } from "@canvas-js/core"
 
 const connection: ModelInit = {
 	id: "primary",
-	creator: "@user",
+	creator: "@profile",
 	ref: "@ref",
 
 	image: "string?",
@@ -21,8 +21,8 @@ const connection: ModelInit = {
 
 	$indexes: ["id"],
 	$rules: {
-		create: "this.sender === creator && id === user + '/' + connection",
-		update: "this.sender === creator && id === user + '/' + connection",
+		create: "this.sender === creator && id === creator + '/' + ref",
+		update: "this.sender === creator && id === creator + '/' + ref",
 		delete: "this.sender === creator",
 	},
 }
@@ -49,7 +49,7 @@ const profile: ModelInit = {
 
 const ref: ModelInit = {
 	id: "primary",
-	creator: "@user?",
+	creator: "@profile?",
 	type: "string?",
 
 	title: "string?",
@@ -63,8 +63,8 @@ const ref: ModelInit = {
 	deleted: "string?",
 
 	$rules: {
-		create: "this.sender === creator && ['place', 'artwork', 'other'].includes(type)",
-		update: "this.sender === creator && ['place', 'artwork', 'other'].includes(type)",
+		create: "this.id === txid && this.sender === creator && ['place', 'artwork', 'other'].includes(type)",
+		update: "this.id === txid && this.sender === creator && ['place', 'artwork', 'other'].includes(type)",
 		delete: false,
 	},
 }

--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -5,7 +5,7 @@ import type { SqlStorage } from "@cloudflare/workers-types"
 import { bytesToHex } from "@noble/hashes/utils"
 
 import { Signature, Action, Message, Snapshot, SessionSigner, SignerCache, MessageType } from "@canvas-js/interfaces"
-import { AbstractModelDB, Model, ModelSchema, Effect } from "@canvas-js/modeldb"
+import { AbstractModelDB, Model, Effect } from "@canvas-js/modeldb"
 import { SIWESigner } from "@canvas-js/signer-ethereum"
 import { AbstractGossipLog, GossipLogEvents, NetworkClient, SignedMessage } from "@canvas-js/gossiplog"
 import type { ServiceMap, NetworkConfig } from "@canvas-js/gossiplog/libp2p"
@@ -15,7 +15,7 @@ import { SnapshotSignatureScheme } from "@canvas-js/signatures"
 
 import target from "#target"
 
-import type { Contract, Actions, ActionImplementation, ModelAPI, DeriveModelTypes } from "./types.js"
+import type { Contract, Actions, ActionImplementation, ModelSchema, ModelAPI, DeriveModelTypes } from "./types.js"
 import { Runtime, createRuntime } from "./runtime/index.js"
 import { ActionRecord } from "./runtime/AbstractRuntime.js"
 import { validatePayload } from "./schema.js"
@@ -259,7 +259,6 @@ export class Canvas<
 	private readonly log = logger("canvas:core")
 	private lastMessage: number | null = null
 
-	private peerId: string | null = null
 	private libp2p: Libp2p | null = null
 	private networkConfig: NetworkConfig | null = null
 	private wsListen: { port: number } | null = null

--- a/packages/core/src/CanvasLoadable.ts
+++ b/packages/core/src/CanvasLoadable.ts
@@ -1,4 +1,4 @@
-import type { ModelSchema } from "@canvas-js/modeldb"
+import type { ModelSchema } from "@canvas-js/core"
 import { assert } from "@canvas-js/utils"
 
 import type { Actions } from "./types.js"

--- a/packages/core/src/migrations.ts
+++ b/packages/core/src/migrations.ts
@@ -1,5 +1,6 @@
 import { logger } from "@libp2p/logger"
-import { Config, DatabaseUpgradeAPI, ModelSchema } from "@canvas-js/modeldb"
+import { Config, DatabaseUpgradeAPI } from "@canvas-js/modeldb"
+import { ModelSchema } from "./types.js"
 
 export const namespace = "canvas"
 export const version = 4

--- a/packages/core/src/runtime/AbstractRuntime.ts
+++ b/packages/core/src/runtime/AbstractRuntime.ts
@@ -132,7 +132,7 @@ export abstract class AbstractRuntime {
 		const { schema, rules } = extractRulesFromModelSchema(models);
 
 		this.rules = rules
-		this.generatedActions = generateActions(rules)
+		this.generatedActions = generateActions(rules, models)
 
 		this.schema = {
 			...schema,

--- a/packages/core/src/runtime/AbstractRuntime.ts
+++ b/packages/core/src/runtime/AbstractRuntime.ts
@@ -12,7 +12,7 @@ import { assert } from "@canvas-js/utils"
 import { ExecutionContext } from "../ExecutionContext.js"
 
 import { View } from "../View.js"
-import { generateActions, extractRulesFromModelSchema } from "./utils.js"
+import { generateActionsFromRules, extractRulesFromModelSchema } from "./rules.js"
 import { encodeRecordKey, encodeRecordValue, getRecordId, isAction, isSession, isSnapshot } from "../utils.js"
 import { Actions, ModelSchema, RulesInit } from "../types.js"
 
@@ -132,7 +132,7 @@ export abstract class AbstractRuntime {
 		const { schema, rules } = extractRulesFromModelSchema(models);
 
 		this.rules = rules
-		this.generatedActions = generateActions(rules, models)
+		this.generatedActions = generateActionsFromRules(rules, models)
 
 		this.schema = {
 			...schema,

--- a/packages/core/src/runtime/ContractRuntime.ts
+++ b/packages/core/src/runtime/ContractRuntime.ts
@@ -87,8 +87,13 @@ export class ContractRuntime extends AbstractRuntime {
 	) {
 		super(modelSchema)
 
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const self = this
+
 		this.contract = contract
+
+		// Create a context for generated actions outside the runtime, if
+		// we're not using actions inside QuickJS for execution.
 		this.actions =
 			actions ??
 			mapValues(this.generatedActions, (action) => {
@@ -128,6 +133,7 @@ export class ContractRuntime extends AbstractRuntime {
 					await action.call(actionContext, ...args)
 				})
 			})
+
 		this.#databaseAPI = vm
 			.wrapObject({
 				get: vm.wrapFunction(async (model, key) => {

--- a/packages/core/src/runtime/ContractRuntime.ts
+++ b/packages/core/src/runtime/ContractRuntime.ts
@@ -1,11 +1,11 @@
 import { QuickJSHandle } from "quickjs-emscripten"
 
 import type { SignerCache } from "@canvas-js/interfaces"
-import { ModelValue, ModelSchema } from "@canvas-js/modeldb"
+import { ModelValue } from "@canvas-js/modeldb"
 import { VM } from "@canvas-js/vm"
 import { assert, mapValues } from "@canvas-js/utils"
 
-import { Contract } from "../types.js"
+import { Contract, ModelSchema } from "../types.js"
 import { ExecutionContext } from "../ExecutionContext.js"
 import { AbstractRuntime } from "./AbstractRuntime.js"
 

--- a/packages/core/src/runtime/rules.ts
+++ b/packages/core/src/runtime/rules.ts
@@ -22,7 +22,7 @@ export const extractRulesFromModelSchema = (models: ModelSchema) => {
 	return { schema, rules }
 }
 
-export const generateActions = <T extends ModelSchema>(rules: Record<string, RulesInit>, models: T) => {
+export const generateActionsFromRules = <T extends ModelSchema>(rules: Record<string, RulesInit>, models: T) => {
 	const actions: Actions<T> = {}
 
 	for (const [modelName, modelRules] of Object.entries(rules)) {

--- a/packages/core/src/runtime/utils.ts
+++ b/packages/core/src/runtime/utils.ts
@@ -28,117 +28,99 @@ export const generateActions = <T extends ModelSchema>(rules: Record<string, Rul
 	for (const [modelName, modelRules] of Object.entries(rules)) {
 		/**
 		 * Create rules run on the data that is being *written* to a database row.
-		 * Update/delete rules run on the data that is being *read from* a database row,
-		 * necessarily from a local perspective.
+		 * Update/delete rules run on the data that is being *read from* a database row.
 		 */
-		const createRule = modelRules["create"]
-		const updateRule = modelRules["update"]
-		const deleteRule = modelRules["delete"]
+		const createRule = modelRules["create"].toString()
+		const updateRule = modelRules["update"].toString()
+		const deleteRule = modelRules["delete"].toString()
 
-		const checkCreateRule = async (rule: string, context: ActionContext<DeriveModelTypes<T>>, newModel: any) => {
-			const ruleFunction = new Function("$model", `with ($model) { return (${rule}) }`)
-			const result = ruleFunction.call(context, newModel)
+		/**
+		 * These functions use outside variables from the closure:
+		 *
+		 * - createRule, updateRule, deleteRule: string
+		 * - modelName: string
+		 * - models: {} // used to access model schema information for pk lookups
+		 */
+
+		const createAction = async function proxiedCreateAction(
+			this: ActionContext<DeriveModelTypes<T>>,
+			newModel: DeriveModelTypes<T>[string],
+		) {
+			console.log("createAction", this, newModel)
+			const ruleFunction = new Function("$model", `with ($model) { return (${createRule}) }`)
+			const result = ruleFunction.call(this, newModel)
 			if (result !== true) {
-                const contextString = JSON.stringify({ ...newModel, this: context })
 				throw new Error(
-					`Create rule check failed: ${rule} returned ${result}, context: ${contextString}`,
+					`Create rule check failed: ${createRule} returned ${result}, context: ${JSON.stringify({ ...newModel, this: this })}`,
 				)
 			}
+
+			await this.db.set(modelName, newModel)
 		}
-		const checkUpdateDeleteRule = async (
-			rule: string,
-			context: ActionContext<DeriveModelTypes<T>>,
-			existingModel: any,
-			update?: boolean,
-		) => {
-			const ruleFunction = new Function("$model", `with ($model) { return (${rule}) }`)
-			const result = ruleFunction.call(context, existingModel)
-			if (result !== true) {
-                const contextString = JSON.stringify({ ...existingModel, this: context })
+
+		const updateAction = async function proxiedUpdateAction(
+			this: ActionContext<DeriveModelTypes<T>>,
+			newModel: Partial<DeriveModelTypes<T>[string]>,
+		) {
+			const findPrimaryKey = (m: ModelInit) => {
+				if (models[modelName]["$primary"] !== undefined) {
+					return models[modelName]["$primary"]
+				}
+				const tuple = Object.entries(m).find(([k, v]) => {
+					return v === "primary"
+				})
+				if (!tuple) {
+					throw new Error("Must provide model primary key")
+				}
+				return tuple[0]
+			}
+
+			const primaryKey = models[modelName]["$primary"] ?? findPrimaryKey(models[modelName])
+			assert(
+				primaryKey in newModel && typeof newModel[primaryKey as keyof typeof newModel] === "string",
+				"Must provide model primary key",
+			)
+			const existingModel = await this.db.get(modelName, newModel[primaryKey as keyof typeof newModel] as string)
+
+			// check update rule
+			const updateRuleFunction = new Function("$model", `with ($model) { return (${updateRule}) }`)
+			const updateResult = updateRuleFunction.call(this, existingModel)
+			if (updateResult !== true) {
 				throw new Error(
-					`${update ? "Update" : "Delete"} rule check failed: ${rule} returned ${result}, context: ${contextString}`,
+					`Update rule check failed: ${updateRule} returned ${updateResult}, context: ${JSON.stringify({ ...existingModel, this: this })}`,
 				)
 			}
-		}
 
-		const createAction = async function (
-			this: ActionContext<DeriveModelTypes<T>>,
-			createdModel: DeriveModelTypes<T>[string],
-		) {
-			if (createRule === false) {
-				throw new Error("Disallowed by $rules.create")
-			} else if (createRule === true) {
-				await this.db.set(modelName, createdModel)
-			} else {
-				await checkCreateRule(createRule, this, createdModel)
-				await this.db.set(modelName, createdModel)
+			// check create rule
+			const createRuleFunction = new Function("$model", `with ($model) { return (${createRule}) }`)
+			const createResult = createRuleFunction.call(this, newModel)
+			if (createResult !== true) {
+				throw new Error(
+					`Create rule check failed: ${createRule} returned ${createResult}, context: ${JSON.stringify({ ...newModel, this: this })}`,
+				)
 			}
+
+			await this.db.update(modelName, newModel)
 		}
-		const updateAction = async function (
-			this: ActionContext<DeriveModelTypes<T>>,
-			updatedModel: Partial<DeriveModelTypes<T>[string]>,
-		) {
-            const findPrimaryKey = (m: ModelInit) => {
-                if (models[modelName]["$primary"] !== undefined) {
-                    return models[modelName]["$primary"]
-                }
-                const tuple = Object.entries(m).find(([k, v]) => {
-                    return v === "primary"
-                })
-                if (!tuple) {
-                    throw new Error("Must provide model primary key")
-                }
-                return tuple[0]
-            }
+		const deleteAction = async function proxiedDeleteAction(this: ActionContext<DeriveModelTypes<T>>, pk: string) {
+			const existing = await this.db.get(modelName, pk)
 
-			if (updateRule === false) {
-				throw new Error("Disallowed by $rules.delete")
-			} else if (updateRule === true) {
-                const primaryKey = findPrimaryKey(models[modelName])
-				assert(primaryKey in updatedModel && typeof updatedModel[primaryKey as keyof typeof updatedModel] === "string", "Must provide model primary key")
-
-				if (createRule === false) {
-					throw new Error("Disallowed by $rules.create")
-				} else if (createRule !== true) {
-					await checkCreateRule(createRule, this, updatedModel)
-				}
-
-				await this.db.update(modelName, updatedModel)
-			} else {
-                const primaryKey = models[modelName]["$primary"] ?? findPrimaryKey(models[modelName])
-				assert(primaryKey in updatedModel && typeof updatedModel[primaryKey as keyof typeof updatedModel] === "string", "Must provide model primary key")
-				const existingModel = await this.db.get(modelName, updatedModel[primaryKey as keyof typeof updatedModel] as string)
-				await checkUpdateDeleteRule(updateRule, this, existingModel, true)
-
-				if (createRule === false) {
-					throw new Error("Disallowed by $rules.create")
-				} else if (createRule !== true) {
-					await checkCreateRule(createRule, this, updatedModel)
-				}
-
-				await this.db.update(modelName, updatedModel)
+			// check delete rule
+			const deleteRuleFunction = new Function("$model", `with ($model) { return (${deleteRule}) }`)
+			const deleteResult = deleteRuleFunction.call(this, existing)
+			if (deleteResult !== true) {
+				throw new Error(
+					`Delete rule check failed: ${deleteRule} returned ${deleteResult}, context: ${pk}, ${JSON.stringify({ this: this })}`,
+				)
 			}
-		}
-		const deleteAction = async function (this: ActionContext<DeriveModelTypes<T>>, pk: string) {
-			if (deleteRule === false) {
-				throw new Error("Disallowed by $rules.delete")
-			} else if (deleteRule === true) {
-				await this.db.delete(modelName, pk)
-			} else {
-				const existing = await this.db.get(modelName, pk)
-				checkUpdateDeleteRule(deleteRule, this, existing)
-				await this.db.delete(modelName, pk)
-			}
+
+			await this.db.delete(modelName, pk)
 		}
 
 		const action = capitalize(modelName)
-		const createActionName = `create${action}`
-		const updateActionName = `update${action}`
-		const deleteActionName = `delete${action}`
-
-		actions[createActionName] = createAction
-		actions[updateActionName] = updateAction
-		actions[deleteActionName] = deleteAction
+		actions[`create${action}`] = createAction
+		actions[`update${action}`] = updateAction
+		actions[`delete${action}`] = deleteAction
 	}
 
 	return actions

--- a/packages/core/src/runtime/utils.ts
+++ b/packages/core/src/runtime/utils.ts
@@ -1,0 +1,125 @@
+import { assert } from "@canvas-js/utils"
+import { ActionContext, Actions, DeriveModelTypes, ModelSchema, RulesInit } from "../types.js"
+import { capitalize } from "../utils.js"
+
+export const extractRulesFromModelSchema = (models: ModelSchema) => {
+	const rules: Record<string, RulesInit> = {}
+	const schema: ModelSchema = {}
+
+	for (const modelName of Object.keys(models)) {
+		const model = models[modelName]
+
+		if ("$rules" in model) {
+			rules[modelName] = model.$rules as RulesInit
+		}
+
+		schema[modelName] = { ...model }
+		if ("$rules" in schema[modelName]) {
+			delete schema[modelName].$rules
+		}
+	}
+
+	return { schema, rules }
+}
+
+export const generateActions = <T extends ModelSchema>(rules: Record<string, RulesInit>) => {
+	const actions: Actions<T> = {}
+
+	for (const [modelName, modelRules] of Object.entries(rules)) {
+		/**
+		 * Create rules run on the data that is being *written* a model.
+		 * Update/delete rules run on the data that is being *read from* in a model, from a local perspective.
+		 */
+		const createRule = modelRules["create"]
+		const updateRule = modelRules["update"]
+		const deleteRule = modelRules["delete"]
+
+		const checkCreateRule = async (rule: string, context: ActionContext<DeriveModelTypes<T>>, newModel: any) => {
+			const ruleFunction = new Function("$model", `with ($model) { return (${rule}) }`)
+			const result = ruleFunction.call(context, newModel)
+			assert(
+				result === true,
+				`Create rule check failed: ${rule} returned ${result}, context: ${JSON.stringify({ ...newModel, this: context })}`,
+			)
+		}
+		const checkUpdateDeleteRule = async (
+			rule: string,
+			context: ActionContext<DeriveModelTypes<T>>,
+			existingModel: any,
+			update?: boolean,
+		) => {
+			const ruleFunction = new Function("$model", `with ($model) { return (${rule}) }`)
+			const result = ruleFunction.call(context, existingModel)
+			assert(
+				result === true,
+				`${update ? "Update" : "Delete"} rule check failed: ${rule} returned ${result}, context: ${JSON.stringify({ ...existingModel, this: context })}`,
+			)
+		}
+
+		const createAction = async function (
+			this: ActionContext<DeriveModelTypes<T>>,
+			createdModel: DeriveModelTypes<T>[string],
+		) {
+			if (createRule === false) {
+				throw new Error("Disallowed by $rules.create")
+			} else if (createRule === true) {
+				await this.db.set(modelName, createdModel)
+			} else {
+				await checkCreateRule(createRule, this, createdModel)
+				await this.db.set(modelName, createdModel)
+			}
+		}
+		const updateAction = async function (
+			this: ActionContext<DeriveModelTypes<T>>,
+			updatedModel: Partial<DeriveModelTypes<T>[string]>,
+		) {
+			if (updateRule === false) {
+				throw new Error("Disallowed by $rules.delete")
+			} else if (updateRule === true) {
+				assert("id" in updatedModel && typeof updatedModel.id === "string", "Must provide model primary key") // TODO: support PKs other than `id`
+
+				if (createRule === false) {
+					throw new Error("Disallowed by $rules.create")
+				} else if (createRule !== true) {
+					await checkCreateRule(createRule, this, updatedModel)
+				}
+
+				await this.db.update(modelName, updatedModel)
+			} else {
+				assert("id" in updatedModel && typeof updatedModel.id === "string", "Must provide model primary key") // TODO: support PKs other than `id`
+				const existingModel = await this.db.get(modelName, updatedModel.id) // TODO: support PKs other than `id`
+				await checkUpdateDeleteRule(updateRule, this, existingModel, true)
+
+				if (createRule === false) {
+					throw new Error("Disallowed by $rules.create")
+				} else if (createRule !== true) {
+					await checkCreateRule(createRule, this, updatedModel)
+				}
+
+				await this.db.update(modelName, updatedModel)
+			}
+		}
+		const deleteAction = async function (this: ActionContext<DeriveModelTypes<T>>, pk: string) {
+			if (deleteRule === false) {
+				throw new Error("Disallowed by $rules.delete")
+			} else if (deleteRule === true) {
+				await this.db.delete(modelName, pk)
+			} else {
+				const existing = await this.db.get(modelName, pk)
+				checkUpdateDeleteRule(deleteRule, this, existing)
+				await this.db.delete(modelName, pk)
+			}
+		}
+
+		const action = capitalize(modelName)
+		const createActionName = `create${action}`
+		const updateActionName = `update${action}`
+		const deleteActionName = `delete${action}`
+
+		actions[createActionName] = createAction
+		actions[updateActionName] = updateAction
+		actions[deleteActionName] = deleteAction
+	}
+
+	return actions
+}

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -51,7 +51,7 @@ export function hashContract<T extends Contract<any>>(contract: T | string): str
 		return bytesToHex(hash)
 	} else {
 		const contractCodeMap: Record<string, string> = Object.fromEntries(
-			Object.entries(contract.actions).map(([name, fn]) => [name, fn.toString()]),
+			Object.entries(contract.actions ?? {}).map(([name, fn]) => [name, fn.toString()]),
 		)
 		const actionHash = sha256(cbor.encode(contractCodeMap))
 		const modelHash = sha256(cbor.encode(contract.models))

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,14 +1,19 @@
-import type { DeriveModelTypes, ModelSchema, ModelValue } from "@canvas-js/modeldb"
+import type { DeriveModelTypes, ModelValue } from "@canvas-js/modeldb"
 import type { Awaitable } from "@canvas-js/interfaces"
 
-export type { ModelValue, ModelSchema, DeriveModelTypes, DeriveModelType } from "@canvas-js/modeldb"
+export type { ModelValue, DeriveModelTypes, DeriveModelType } from "@canvas-js/modeldb"
+import type { ModelInit as DbModelInit, ModelSchema as DbModelSchema } from "@canvas-js/modeldb"
+
+export type RulesInit = { create: string | boolean; update: string | boolean; delete: string | boolean }
+export type ModelInit = DbModelInit<{ $rules?: RulesInit }>
+export type ModelSchema = DbModelSchema<{ $rules?: RulesInit }>
 
 export type Contract<
 	ModelsT extends ModelSchema = ModelSchema,
 	ActionsT extends Actions<ModelsT> = Actions<ModelsT>,
 > = {
 	models: ModelsT
-	actions: ActionsT
+	actions?: ActionsT
 }
 
 export type Actions<ModelsT extends ModelSchema> = Record<string, ActionImplementation<ModelsT>>
@@ -17,11 +22,7 @@ export type ActionImplementation<
 	ModelsT extends ModelSchema = ModelSchema,
 	Args extends Array<any> = any,
 	Result = any,
-> = (
-	this: ActionContext<DeriveModelTypes<ModelsT>>,
-	// db: ModelAPI<DeriveModelTypes<ModelsT>>,
-	...args: Args
-) => Awaitable<Result>
+> = (this: ActionContext<DeriveModelTypes<ModelsT>>, ...args: Args) => Awaitable<Result>
 
 export type ModelAPI<ModelTypes extends Record<string, ModelValue>> = {
 	get: <T extends keyof ModelTypes & string>(model: T, key: string) => Promise<ModelTypes[T] | null>

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -158,3 +158,7 @@ function writeArgument(majorType: number, argument: number): Uint8Array {
 		return arrays[4]
 	}
 }
+
+export const capitalize = (str: string) => {
+	return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/packages/core/test/modelContract.test.ts
+++ b/packages/core/test/modelContract.test.ts
@@ -5,7 +5,7 @@ import { ethers } from "ethers"
 import { SIWESigner } from "@canvas-js/signer-ethereum"
 import { Canvas } from "@canvas-js/core"
 
-test("create, update, and delete in a contract permissioned by model $rules", async (t) => {
+test("create, update, and delete in an inline contract with $rules", async (t) => {
 	const wallet = ethers.Wallet.createRandom()
 
 	const app = await Canvas.initialize({
@@ -21,13 +21,57 @@ test("create, update, and delete in a contract permissioned by model $rules", as
 						update: "address === this.did",
 						delete: false,
 					},
-					$primary: "pk"
+					$primary: "pk",
 				},
 			},
 		},
 		signers: [new SIWESigner({ signer: wallet })],
 	})
 	t.teardown(() => app.stop())
+
+	await app.create("posts", { pk: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Hello world" })
+	await t.throwsAsync(async () => {
+		await app.create("posts", { pk: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
+	})
+
+	const value = await app.db.get("posts", "foo")
+	t.is(value?.address, `did:pkh:eip155:1:${wallet.address}`)
+	t.is(value?.content, "Hello world")
+
+	await t.throwsAsync(async () => {
+		await app.update("posts", { pk: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
+	})
+	await app.update("posts", { pk: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Bonk!" })
+	const value2 = await app.db.get("posts", "foo")
+	t.is(value2?.content, "Bonk!")
+
+	await t.throwsAsync(async () => {
+		await app.delete("posts", "foo")
+	})
+})
+
+test("create, update, and delete in a string contract with $rules", async (t) => {
+	const wallet = ethers.Wallet.createRandom()
+
+	const app = await Canvas.initialize({
+		topic: "example.xyz",
+		contract: `
+export const models = {
+	posts: {
+		pk: "string",
+		address: "string",
+		content: "string",
+		$rules: {
+			create: "address === this.did",
+			update: "address === this.did",
+			delete: false,
+		},
+		$primary: "pk"
+	}
+}`,
+		signers: [new SIWESigner({ signer: wallet })],
+	})
+	// t.teardown(() => app.stop())
 
 	await app.create("posts", { pk: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Hello world" })
 	await t.throwsAsync(async () => {

--- a/packages/core/test/modelContract.test.ts
+++ b/packages/core/test/modelContract.test.ts
@@ -1,0 +1,50 @@
+import test from "ava"
+
+import { ethers } from "ethers"
+
+import { SIWESigner } from "@canvas-js/signer-ethereum"
+import { Canvas } from "@canvas-js/core"
+
+test("create, update, and delete in a contract permissioned by model $rules", async (t) => {
+	const wallet = ethers.Wallet.createRandom()
+
+	const app = await Canvas.initialize({
+		topic: "example.xyz",
+		contract: {
+			models: {
+				posts: {
+					id: "primary",
+					address: "string",
+					content: "string",
+					$rules: {
+						create: "address === this.did",
+						update: "address === this.did",
+						delete: false,
+					},
+				},
+			},
+		},
+		signers: [new SIWESigner({ signer: wallet })],
+	})
+	t.teardown(() => app.stop())
+
+	await app.actions.createPosts({ id: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Hello world" })
+	await t.throwsAsync(async () => {
+		await app.actions.createPosts({ id: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
+	})
+
+	const value = await app.db.get("posts", "foo")
+	t.is(value?.address, `did:pkh:eip155:1:${wallet.address}`)
+	t.is(value?.content, "Hello world")
+
+	await t.throwsAsync(async () => {
+		await app.actions.updatePosts({ id: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
+	})
+	await app.actions.updatePosts({ id: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Bonk!" })
+	const value2 = await app.db.get("posts", "foo")
+	t.is(value2?.content, "Bonk!")
+
+	await t.throwsAsync(async () => {
+		await app.actions.deletePosts("foo")
+	})
+})

--- a/packages/core/test/modelContract.test.ts
+++ b/packages/core/test/modelContract.test.ts
@@ -29,9 +29,9 @@ test("create, update, and delete in a contract permissioned by model $rules", as
 	})
 	t.teardown(() => app.stop())
 
-	await app.actions.createPosts({ pk: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Hello world" })
+	await app.create("posts", { pk: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Hello world" })
 	await t.throwsAsync(async () => {
-		await app.actions.createPosts({ pk: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
+		await app.create("posts", { pk: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
 	})
 
 	const value = await app.db.get("posts", "foo")
@@ -39,13 +39,13 @@ test("create, update, and delete in a contract permissioned by model $rules", as
 	t.is(value?.content, "Hello world")
 
 	await t.throwsAsync(async () => {
-		await app.actions.updatePosts({ pk: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
+		await app.update("posts", { pk: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
 	})
-	await app.actions.updatePosts({ pk: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Bonk!" })
+	await app.update("posts", { pk: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Bonk!" })
 	const value2 = await app.db.get("posts", "foo")
 	t.is(value2?.content, "Bonk!")
 
 	await t.throwsAsync(async () => {
-		await app.actions.deletePosts("foo")
+		await app.delete("posts", "foo")
 	})
 })

--- a/packages/core/test/modelContract.test.ts
+++ b/packages/core/test/modelContract.test.ts
@@ -13,7 +13,7 @@ test("create, update, and delete in a contract permissioned by model $rules", as
 		contract: {
 			models: {
 				posts: {
-					id: "primary",
+					pk: "string",
 					address: "string",
 					content: "string",
 					$rules: {
@@ -21,6 +21,7 @@ test("create, update, and delete in a contract permissioned by model $rules", as
 						update: "address === this.did",
 						delete: false,
 					},
+					$primary: "pk"
 				},
 			},
 		},
@@ -28,9 +29,9 @@ test("create, update, and delete in a contract permissioned by model $rules", as
 	})
 	t.teardown(() => app.stop())
 
-	await app.actions.createPosts({ id: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Hello world" })
+	await app.actions.createPosts({ pk: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Hello world" })
 	await t.throwsAsync(async () => {
-		await app.actions.createPosts({ id: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
+		await app.actions.createPosts({ pk: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
 	})
 
 	const value = await app.db.get("posts", "foo")
@@ -38,9 +39,9 @@ test("create, update, and delete in a contract permissioned by model $rules", as
 	t.is(value?.content, "Hello world")
 
 	await t.throwsAsync(async () => {
-		await app.actions.updatePosts({ id: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
+		await app.actions.updatePosts({ pk: "foo", address: `did:pkh:eip155:1:${ethers.Wallet.createRandom().address}` })
 	})
-	await app.actions.updatePosts({ id: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Bonk!" })
+	await app.actions.updatePosts({ pk: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Bonk!" })
 	const value2 = await app.db.get("posts", "foo")
 	t.is(value2?.content, "Bonk!")
 

--- a/packages/core/test/modelContract.test.ts
+++ b/packages/core/test/modelContract.test.ts
@@ -71,7 +71,7 @@ export const models = {
 }`,
 		signers: [new SIWESigner({ signer: wallet })],
 	})
-	// t.teardown(() => app.stop())
+	t.teardown(() => app.stop())
 
 	await app.create("posts", { pk: "foo", address: `did:pkh:eip155:1:${wallet.address}`, content: "Hello world" })
 	await t.throwsAsync(async () => {

--- a/packages/hooks/src/useLiveQuery.ts
+++ b/packages/hooks/src/useLiveQuery.ts
@@ -1,8 +1,8 @@
-import type { Canvas } from "@canvas-js/core"
-import type { QueryParams, ModelSchema } from "@canvas-js/modeldb"
+import type { Canvas, ModelSchema } from "@canvas-js/core"
+import type { QueryParams } from "@canvas-js/modeldb"
 import { useLiveQuery as _useLiveQuery } from "@canvas-js/modeldb-idb"
 
-export function useLiveQuery<ModelsT extends ModelSchema, K extends (keyof ModelsT & string)>(
+export function useLiveQuery<ModelsT extends ModelSchema, K extends keyof ModelsT & string>(
 	app: Canvas<ModelsT> | null | undefined,
 	modelName: K,
 	query: QueryParams = {},

--- a/packages/modeldb/src/types.ts
+++ b/packages/modeldb/src/types.ts
@@ -19,11 +19,12 @@ export type PropertyType =
 
 /** property name, or property names joined by slashes */
 export type IndexInit = string
+
 /** This should be an intersection type or conditional mapped type, but TS 5.6 doesn't let us mix them.
  * If you need a proper conditional type here, consider overriding ModelInit with your own type.
  */
-export type ModelInit = { $indexes?: IndexInit[]; $primary?: string } | Record<string, PropertyType>
-export type ModelSchema = Record<string, ModelInit>
+export type ModelInit<Ext = {}> = ({ $indexes?: IndexInit[]; $primary?: string } & Ext) | Record<string, PropertyType>
+export type ModelSchema<Ext = {}> = Record<string, ModelInit<Ext>>
 
 // These are more structured representations of the schema defined by ModelSchema that are easier
 // to work with at runtime
@@ -93,30 +94,30 @@ export type QueryParams = {
 export type DerivePropertyType<T extends PropertyType> = T extends "primary"
 	? string
 	: T extends "integer" | "float" | "number"
-	? number
-	: T extends "integer?" | "float?" | "number?"
-	? number | null
-	: T extends "string"
-	? string
-	: T extends "string?"
-	? string | null
-	: T extends "bytes"
-	? Uint8Array
-	: T extends "bytes?"
-	? Uint8Array | null
-	: T extends "boolean"
-	? boolean
-	: T extends "boolean?"
-	? boolean | null
-	: T extends "json"
-	? JSONValue
-	: T extends `@${string}[]`
-	? RelationValue
-	: T extends `@${string}?`
-	? ReferenceValue | null
-	: T extends `@${string}`
-	? ReferenceValue
-	: never
+		? number
+		: T extends "integer?" | "float?" | "number?"
+			? number | null
+			: T extends "string"
+				? string
+				: T extends "string?"
+					? string | null
+					: T extends "bytes"
+						? Uint8Array
+						: T extends "bytes?"
+							? Uint8Array | null
+							: T extends "boolean"
+								? boolean
+								: T extends "boolean?"
+									? boolean | null
+									: T extends "json"
+										? JSONValue
+										: T extends `@${string}[]`
+											? RelationValue
+											: T extends `@${string}?`
+												? ReferenceValue | null
+												: T extends `@${string}`
+													? ReferenceValue
+													: never
 
 export type DeriveModelTypes<T extends ModelSchema> = {
 	[K in keyof T as Exclude<K, "$indexes" | "$primary">]: {


### PR DESCRIPTION
Implements #476 with some slight changes.

Refactors `ModelSchema` and `ModelInit` to be generic when exported from ModelDB. The core now accepts and strips `$rules: RulesInit` from the models configuration, and synthesizes actions based on the rules for each model inside AbstractRuntime.

Creates a new API only to be used with model contracts:
- `app.create("posts", { id: "foo" })`
- `app.update("posts", { id: "foo" })`
- `app.delete("posts", "foo")`

Creates a rule system for the new API:
- `create` rules check data *written to* the db, as it goes into the db
- `update` rules check data *already in* the db, according to the writer's local view
- `delete` rules check data *already in* the db, according to the writer's local view

As a result:
- A create operation will only call the `create` check.
- An update operation will call the `update` check, then the `create` check with its new data.
- A delete operation will call the `delete` check only.

These names may change to clarify that the rule system corresponds to data in/out of the system.

Todos:
- [x] Optimize action generation, it's inefficient right now. We can leave out disabled actions and generate more efficient functions that run less code at execution time
- [x] Not implemented for ContractRuntime yet
- [x] Need to add a test for ContractRuntime, add some tests to cover other contract syntaxes (which were tested manually)

## How has this been tested?

- [x] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
