### PR TITLE
`packages/network-explorer` - Add page titles, fix back navigation bug

### DIFF
--- a/packages/network-explorer/src/ActionsTable.tsx
+++ b/packages/network-explorer/src/ActionsTable.tsx
@@ -1,7 +1,7 @@
 import { ColumnDef } from "@tanstack/react-table"
 import { Table } from "./components/Table.js"
 import { useApplicationData } from "./hooks/useApplicationData.js"
-
+import { usePageTitle } from "./hooks/usePageTitle.js"
 // special case of Table where the name field options are based on data from the API
 export const ActionsTable = ({
 	showSidebar,
@@ -10,6 +10,8 @@ export const ActionsTable = ({
 	showSidebar: boolean
 	setShowSidebar: (showSidebar: boolean) => void
 }) => {
+	usePageTitle("$actions | Application Explorer")
+
 	const applicationData = useApplicationData()
 
 	const tableName = "$actions"

--- a/packages/network-explorer/src/ContractView.tsx
+++ b/packages/network-explorer/src/ContractView.tsx
@@ -10,6 +10,7 @@ import { Editor } from "./components/Editor.js"
 import { SiweMessage } from "siwe"
 import { getAddress } from "ethers"
 import { BASE_URL } from "./utils.js"
+import { usePageTitle } from "./hooks/usePageTitle.js"
 
 // Define a localStorage key for unsaved changes
 const UNSAVED_CHANGES_KEY = "contract-editor-unsaved-changes"
@@ -46,6 +47,8 @@ const ChangesetMigrationRow = ({ change: c }: { change: Changeset }) => {
 }
 
 export const ContractView = () => {
+	usePageTitle("Contract | Application Explorer")
+
 	const contractData = useContractData()
 	const applicationData = useApplicationData()
 

--- a/packages/network-explorer/src/LandingPage.tsx
+++ b/packages/network-explorer/src/LandingPage.tsx
@@ -5,6 +5,7 @@ import { ApplicationData } from "./components/ApplicationData.js"
 import { fetchAndIpldParseJson } from "./utils.js"
 import { ReactNode } from "react"
 import { useTheme } from "./hooks/useTheme.js"
+import { usePageTitle } from "./hooks/usePageTitle.js"
 
 const Th = ({ children }: { children: ReactNode }) => (
 	<th style={{ padding: "8px 6px 8px 14px", textAlign: "left" }}>
@@ -18,6 +19,8 @@ const Td = ({ children, first }: { children: ReactNode; first: boolean }) => (
 )
 
 export const LandingPage = () => {
+	usePageTitle("Dashboard | Application Explorer")
+
 	const { theme } = useTheme()
 	const { data: actionData } = useSWR(
 		`/api/models/$actions?${stringifyRequestParams({

--- a/packages/network-explorer/src/components/Table.tsx
+++ b/packages/network-explorer/src/components/Table.tsx
@@ -136,7 +136,6 @@ export const Table = <T,>({
 		// invalidate the settings
 		setColumnVisibility({})
 		setSorting([])
-		setColumnFilters([])
 		clearCursors()
 	}, [tableName])
 

--- a/packages/network-explorer/src/components/Table.tsx
+++ b/packages/network-explorer/src/components/Table.tsx
@@ -9,6 +9,7 @@ import useCursorStack from "../hooks/useCursorStack.js"
 import { WhereCondition } from "@canvas-js/modeldb"
 import { useApplicationData } from "../hooks/useApplicationData.js"
 import { useSearchFilters } from "../hooks/useSearchFilters.js"
+import { usePageTitle } from "../hooks/usePageTitle.js"
 
 export type Column = {
 	name: string
@@ -56,6 +57,7 @@ export const Table = <T,>({
 	defaultSortColumn: string
 	defaultSortDirection: "desc" | "asc"
 }) => {
+	usePageTitle(`${tableName} | Application Explorer`)
 	const applicationData = useApplicationData()
 
 	const [columnFilters, setColumnFilters] = useSearchFilters(

--- a/packages/network-explorer/src/hooks/usePageTitle.tsx
+++ b/packages/network-explorer/src/hooks/usePageTitle.tsx
@@ -1,0 +1,7 @@
+import { useEffect } from "react"
+
+export const usePageTitle = (title: string) => {
+	useEffect(() => {
+		document.title = title
+	}, [title])
+}


### PR DESCRIPTION
This PR adds page titles of the format:  `<page> | Application Explorer` to all of the pages in the network explorer. This is a nice feature to have when navigating or debugging routing issues.

This PR also fixes the bug https://github.com/canvasxyz/canvas/issues/475 where if you navigate to a table view and then try to go back, you have to click the back button multiple times - the cause was that when the tableName prop changes we were setting `columnFilters` to `[]`, which actually sets the path because we are using the query params to store the filtering information, which then pushes another page onto the history stack.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
