### PR TITLE
`packages/network-explorer` - row-level editing cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38199,6 +38199,7 @@
 				"react-router-dom": "^6.20.1",
 				"siwe": "^3.0.0",
 				"swr": "^2.3.0",
+				"uuid": "^11.1.0",
 				"vite": "^6.3.2",
 				"vite-plugin-wasm": "^3.3.0"
 			},
@@ -38284,6 +38285,18 @@
 			},
 			"peerDependencies": {
 				"ethers": "^5.6.8 || ^6.0.8"
+			}
+		},
+		"packages/network-explorer/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"packages/relay-server": {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -156,7 +156,7 @@ export async function handler(args: Args) {
 		if (args.admin) {
 			const adminAddress = args.admin
 			instance.api.post("/api/migrate", async (req, res) => {
-				const { newContract, changesets, address, signature, siweMessage, changedRows, newRows, includeSnapshot } =
+				const { newContract, changesets, address, signature, siweMessage, changedRows, includeSnapshot } =
 					req.body ?? {}
 
 				if (address !== adminAddress && adminAddress !== "any") {
@@ -217,7 +217,7 @@ export async function handler(args: Args) {
 					)
 
 					instance.app
-						.createSnapshot({ changedRows, newRows })
+						.createSnapshot({ changedRows })
 						.then(async (snapshot: Snapshot) => {
 							console.log("[canvas] Stopping existing instance...")
 							await instance.stop()

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -96,7 +96,6 @@ export async function createSnapshot<T extends Contract<any>>(
 ): Promise<Snapshot> {
 	const changesets = changes?.changesets ?? []
 	const changedRows = changes?.changedRows ?? {}
-	const newRows = changes?.newRows ?? {}
 
 	const createdTables = changesets.filter((ch) => ch.change === "create_table").map((ch) => ch.table)
 	const droppedTables = changesets.filter((ch) => ch.change === "drop_table").map((ch) => ch.table)
@@ -168,8 +167,10 @@ export async function createSnapshot<T extends Contract<any>>(
 		}
 
 		// add created rows
-		for (const newRow of Object.values(newRows[modelName] ?? [])) {
-			models[modelName].push(cbor.encode(newRow))
+		for (const [_rowKey, rowChange] of Object.entries(modelChangedRows)) {
+			if (rowChange.type === "create") {
+				models[modelName].push(cbor.encode(rowChange.value))
+			}
 		}
 	}
 

--- a/packages/network-explorer/package.json
+++ b/packages/network-explorer/package.json
@@ -38,6 +38,7 @@
 		"react-router-dom": "^6.20.1",
 		"siwe": "^3.0.0",
 		"swr": "^2.3.0",
+		"uuid": "^11.1.0",
 		"vite": "^6.3.2",
 		"vite-plugin-wasm": "^3.3.0"
 	},

--- a/packages/network-explorer/src/components/StagedMigrationsBottomSheet.tsx
+++ b/packages/network-explorer/src/components/StagedMigrationsBottomSheet.tsx
@@ -84,6 +84,7 @@ export const StagedMigrationsBottomSheet = ({ showSidebar }: { showSidebar: bool
 		migrationIncludesSnapshot,
 		setMigrationIncludesSnapshot,
 		newContract,
+		errors,
 	} = useStagedMigrations()
 
 	const rowChangesets = flattenRowChanges(changedRows)
@@ -163,6 +164,13 @@ export const StagedMigrationsBottomSheet = ({ showSidebar }: { showSidebar: bool
 				<Box>
 					<Box pb="2">
 						<Box px="4" pt="1" pb="4">
+							{errors.length > 0 && (
+								<Box pb="2">
+									<Text size="2" color="red">
+										{errors.join("\n")}
+									</Text>
+								</Box>
+							)}
 							<Flex align="center">
 								<Box mr="5" display="inline-block">
 									<Button
@@ -210,7 +218,6 @@ export const StagedMigrationsBottomSheet = ({ showSidebar }: { showSidebar: bool
 									</Text>
 								</Box>
 							</Flex>
-
 							<Box mt="4" style={{ lineHeight: 1.2 }}>
 								<Text size="2">
 									{!migrationIncludesSnapshot
@@ -218,7 +225,6 @@ export const StagedMigrationsBottomSheet = ({ showSidebar }: { showSidebar: bool
 										: "This will restart your application, with existing data compacted into a snapshot."}
 								</Text>
 							</Box>
-
 							<Box mt="2" style={{ lineHeight: 1.2 }}>
 								<Text size="2">
 									{contractData.inMemory

--- a/packages/network-explorer/src/components/table/EditableRow.tsx
+++ b/packages/network-explorer/src/components/table/EditableRow.tsx
@@ -89,23 +89,26 @@ export const EditableRow = ({
 			}}
 		>
 			<ThCheckbox checked={checked} onCheckedChange={onCheckedChange} />
-			{row.getVisibleCells().map((cell) => (
-				<Td
-					key={cell.id}
-					width={cell.column.getSize()}
-					isEdited={stagedValues && cell.column.id in stagedValues && stagedValues[cell.column.id] !== cell.getValue()}
-				>
-					{cell.column.columnDef.meta?.editCell
-						? flexRender(cell.column.columnDef.meta?.editCell, {
-								value: stagedValues && stagedValues[cell.column.id] ? stagedValues[cell.column.id] : cell.getValue(),
-								setValue: (value: string) => {
-									setStagedValues({ ...stagedValues, [cell.column.id]: value })
-								},
-						  })
-						: // add something to say that the cell cannot be edited
-						  flexRender(cell.column.columnDef.cell, cell.getContext())}
-				</Td>
-			))}
+			{row.getVisibleCells().map((cell) => {
+				const originalValue = cell.getValue()
+				const value = stagedValues && cell.column.id in stagedValues ? stagedValues[cell.column.id] : originalValue
+
+				const isEdited = value !== originalValue
+
+				return (
+					<Td key={cell.id} width={cell.column.getSize()} isEdited={isEdited}>
+						{cell.column.columnDef.meta?.editCell
+							? flexRender(cell.column.columnDef.meta?.editCell, {
+									value,
+									setValue: (value: string) => {
+										setStagedValues({ ...stagedValues, [cell.column.id]: value })
+									},
+							  })
+							: // add something to say that the cell cannot be edited
+							  flexRender(cell.column.columnDef.cell, cell.getContext())}
+					</Td>
+				)
+			})}
 		</tr>
 	)
 }

--- a/packages/network-explorer/src/components/table/Table.tsx
+++ b/packages/network-explorer/src/components/table/Table.tsx
@@ -323,7 +323,7 @@ export const Table = <T,>({
 							))}
 						</Thead>
 						<Tbody>
-							{tanStackTable.getRowCount() === 0 && <NoneFound />}
+							{tanStackTable.getRowCount() === 0 && tableNewRows.length === 0 && <NoneFound />}
 							{tanStackTable.getRowModel().rows.map((row) => {
 								if (allowEditing) {
 									const rowKey = getRowKey(row)

--- a/packages/network-explorer/src/components/table/Table.tsx
+++ b/packages/network-explorer/src/components/table/Table.tsx
@@ -1,10 +1,11 @@
 import useSWR from "swr"
 import { ModelValue, WhereCondition } from "@canvas-js/modeldb"
-import { Map as ImmutableMap, Set as ImmutableSet, List as ImmutableList } from "immutable"
+import { Map as ImmutableMap, Set as ImmutableSet } from "immutable"
 import { Box, Button, Flex, Text } from "@radix-ui/themes"
 import { useCallback, useEffect, useState } from "react"
 import { LuDownload, LuExpand, LuRefreshCw } from "react-icons/lu"
 import { ColumnDef, flexRender, getCoreRowModel, Row, SortingState, useReactTable } from "@tanstack/react-table"
+import { v4 as uuidv4 } from "uuid"
 import useCursorStack from "../../hooks/useCursorStack.js"
 import { useApplicationData } from "../../hooks/useApplicationData.js"
 import { useSearchFilters } from "../../hooks/useSearchFilters.js"
@@ -71,7 +72,7 @@ export const Table = <T,>({
 }) => {
 	usePageTitle(`${tableName} | Application Explorer`)
 	const applicationData = useApplicationData()
-	const { stageRowChange, changedRows, newRows, setNewRows } = useStagedMigrations()
+	const { stageRowChange, changedRows } = useStagedMigrations()
 	const [columnFilters, setColumnFilters] = useSearchFilters(
 		defaultColumns.filter((col) => col.enableColumnFilter).map((col) => col.header as string),
 	)
@@ -186,11 +187,20 @@ export const Table = <T,>({
 
 	const tableChangedRows = changedRows.get(tableName) || ImmutableMap()
 
-	const tableNewRows = newRows.get(tableName) || ImmutableList.of()
+	const tableNewRows = tableChangedRows
+		.filter((row) => row.type === "create")
+		.toArray()
+		.map(
+			([key, row]) =>
+				({
+					...row.value,
+					$newRowKey: key,
+				} as ModelValue),
+		)
 
 	const newRowsTable = useReactTable<ModelValue>({
 		columns: defaultColumns as ColumnDef<ModelValue>[],
-		data: tableNewRows.toArray(),
+		data: tableNewRows,
 		getCoreRowModel: getCoreRowModel(),
 		manualPagination: true,
 		manualSorting: true,
@@ -203,7 +213,19 @@ export const Table = <T,>({
 
 	return (
 		<Flex direction="column" maxWidth={showSidebar ? "calc(100vw - 200px)" : "100%"} flexGrow="1">
-			<Flex position="fixed" style={{ zIndex: 5, background: "var(--gray-1)", width: showSidebar ? "calc(100vw - 200px)" : "100%", borderBottom: "1px solid var(--gray-3)" }} align="center" gap="2" p="2" py="3">
+			<Flex
+				position="fixed"
+				style={{
+					zIndex: 5,
+					background: "var(--gray-1)",
+					width: showSidebar ? "calc(100vw - 200px)" : "100%",
+					borderBottom: "1px solid var(--gray-3)",
+				}}
+				align="center"
+				gap="2"
+				p="2"
+				py="3"
+			>
 				{tableHasFilters && (
 					<FiltersDropdown
 						tanStackTable={tanStackTable}
@@ -225,8 +247,17 @@ export const Table = <T,>({
 					disabled={!allowEditing}
 					onClick={() => {
 						// add a new row
-						const tableRows = newRows.get(tableName) || ImmutableList.of()
-						setNewRows(newRows.set(tableName, tableRows.push({})))
+						const id = uuidv4()
+						// value should have all the fields with empty values
+						const value: ModelValue = {}
+						for (const col of defaultColumns) {
+							value[col.header as string] = ""
+						}
+
+						stageRowChange(tableName, `newRow-${id}`, {
+							type: "create",
+							value,
+						})
 					}}
 					color="gray"
 					variant="outline"
@@ -264,7 +295,12 @@ export const Table = <T,>({
 					<LuExpand />
 				</Button>
 			</Flex>
-			<Box pt="56px" overflowX="scroll" flexGrow="1" pb={(tableChangedRows.size > 0 || tableNewRows.size > 0) ? "80vh" : "0"}>
+			<Box
+				pt="56px"
+				overflowX="scroll"
+				flexGrow="1"
+				pb={tableChangedRows.size > 0 || tableNewRows.length > 0 ? "80vh" : "0"}
+			>
 				<Text size="2">
 					<TableElement>
 						<Thead>
@@ -320,17 +356,22 @@ export const Table = <T,>({
 									return <NonEditableRow key={row.id} row={row} />
 								}
 							})}
-							{newRowsTable.getRowModel().rows.map((row, index) => {
+							{newRowsTable.getRowModel().rows.map((row) => {
 								return (
 									<EditableRow
 										key={row.id}
 										row={row}
 										stagedValues={row.original as ModelValue}
 										setStagedValues={(newValues) => {
+											console.log("set staged values", newValues)
 											// update new row with index
-											const tableRows = newRows.get(tableName) || ImmutableList.of()
-											const newTableRows = tableRows.set(index, newValues)
-											setNewRows(newRows.set(tableName, newTableRows))
+											const { $newRowKey, ...rest } = newValues
+											console.log("newRowKey:", $newRowKey)
+											console.log("rest:", rest)
+											stageRowChange(tableName, JSON.parse($newRowKey as any), {
+												type: "create",
+												value: rest,
+											})
 										}}
 										isStagedDelete={false}
 										isNewRow={true}

--- a/packages/network-explorer/src/components/table/Table.tsx
+++ b/packages/network-explorer/src/components/table/Table.tsx
@@ -331,8 +331,10 @@ export const Table = <T,>({
 									const rowChange = tableChangedRows.get(encodedRowKey)
 
 									let stagedValues: ModelValue | undefined = undefined
-									if (rowChange && rowChange.type === "update") {
+									if (rowChange && (rowChange.type === "update" || rowChange.type === "create")) {
 										stagedValues = rowChange.value
+									} else {
+										stagedValues = row.original as ModelValue
 									}
 									return (
 										<EditableRow

--- a/packages/network-explorer/src/hooks/useChangedRows.tsx
+++ b/packages/network-explorer/src/hooks/useChangedRows.tsx
@@ -18,21 +18,30 @@ export const useChangedRows = () => {
 		ImmutableMap(),
 	)
 
-	const stageRowChange = useCallback((tableName: string, rowKey: RowKey, rowChange: RowChange) => {
-		const tableRows = changedRows.get(tableName) || ImmutableMap()
-		const newTableRows = tableRows.set(encodeRowKey(rowKey), rowChange)
-		setChangedRows(changedRows.set(tableName, newTableRows))
-	}, [changedRows])
+	const stageRowChange = useCallback(
+		(tableName: string, rowKey: RowKey, rowChange: RowChange) => {
+			setChangedRows((oldChangedRows) => {
+				const tableRows = oldChangedRows.get(tableName) || ImmutableMap()
+				const newTableRows = tableRows.set(encodeRowKey(rowKey), rowChange)
+				return oldChangedRows.set(tableName, newTableRows)
+			})
+		},
+		[changedRows],
+	)
 
-	const restoreRowChange = useCallback((tableName: string, rowKey: string[]) => {
-		const tableRows = changedRows.get(tableName) || ImmutableMap()
-		const newTableRows = tableRows.delete(encodeRowKey(rowKey))
-		if (newTableRows.size === 0) {
-			setChangedRows(changedRows.delete(tableName))
-		} else {
-			setChangedRows(changedRows.set(tableName, newTableRows))
-		}
-	}, [changedRows])
+	const restoreRowChange = useCallback(
+		(tableName: string, rowKey: string[]) =>
+			setChangedRows((oldChangedRows) => {
+				const tableRows = changedRows.get(tableName) || ImmutableMap()
+				const newTableRows = tableRows.delete(encodeRowKey(rowKey))
+				if (newTableRows.size === 0) {
+					return oldChangedRows.delete(tableName)
+				} else {
+					return oldChangedRows.set(tableName, newTableRows)
+				}
+			}),
+		[changedRows],
+	)
 
 	const clearRowChanges = useCallback(() => {
 		setChangedRows(ImmutableMap())

--- a/packages/network-explorer/src/hooks/useChangedRows.tsx
+++ b/packages/network-explorer/src/hooks/useChangedRows.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react"
 import { Map as ImmutableMap } from "immutable"
 import { RowChange } from "@canvas-js/core"
 
-export type RowKey = string[]
+export type RowKey = string[] | string
 export type ImmutableRowKey = string
 
 export function encodeRowKey(rowKey: RowKey): ImmutableRowKey {
@@ -30,7 +30,7 @@ export const useChangedRows = () => {
 	)
 
 	const restoreRowChange = useCallback(
-		(tableName: string, rowKey: string[]) =>
+		(tableName: string, rowKey: RowKey) =>
 			setChangedRows((oldChangedRows) => {
 				const tableRows = changedRows.get(tableName) || ImmutableMap()
 				const newTableRows = tableRows.delete(encodeRowKey(rowKey))

--- a/packages/network-explorer/src/hooks/useStagedMigrations.tsx
+++ b/packages/network-explorer/src/hooks/useStagedMigrations.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useState } from "react"
-import { Canvas, TableChange, generateChangesets, RowChange, ModelValue } from "@canvas-js/core"
+import { Canvas, TableChange, generateChangesets, RowChange } from "@canvas-js/core"
 import { Map as ImmutableMap } from "immutable"
 import { bytesToHex, randomBytes } from "@noble/hashes/utils"
 import { useContractData } from "../hooks/useContractData.js"
@@ -191,16 +191,6 @@ export const StagedMigrationsProvider = ({ children }: { children: React.ReactNo
 
 		// Send to API with SIWE data
 
-		const newRows: Record<string, ModelValue[]> = {}
-		for (const [tableName, tableRows] of changedRows.entries()) {
-			for (const [_rowKey, rowChange] of tableRows.entries()) {
-				if (rowChange.type === "create") {
-					newRows[tableName] = newRows[tableName] || []
-					newRows[tableName].push(rowChange.value)
-				}
-			}
-		}
-
 		const response = await fetch(`${BASE_URL}/api/migrate`, {
 			method: "POST",
 			headers: {
@@ -213,7 +203,6 @@ export const StagedMigrationsProvider = ({ children }: { children: React.ReactNo
 				address,
 				signature,
 				changedRows: changedRows?.toJSON() || {},
-				newRows,
 				includeSnapshot: migrationIncludesSnapshot,
 			}),
 		})


### PR DESCRIPTION
This PR fixes the bugs in https://github.com/canvasxyz/canvas/issues/486

- Fix bug where multiple rows cannot be deleted with one click
- Fix bug where we cannot undo create row
- Validate new/updated rows against the model schema before signing & committing, display the error in the UI

We also remove the `newRows` data structure which holds created rows, instead we generate a random placeholder id and store them in the `changedRows` object. This simplifies quite a bit of code.

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
