### PR TITLE
packages/gossiplog: Track remote clocks in gossiplog, expose in hooks

### DIFF
--- a/examples/forum/src/Layout.tsx
+++ b/examples/forum/src/Layout.tsx
@@ -1,18 +1,16 @@
 import React, { useState, useContext } from "react"
-import { LuUnplug } from "react-icons/lu"
 import { MdOutlineSync, MdOutlineSyncProblem, MdOutlineSyncDisabled } from "react-icons/md"
 import { AuthKitProvider } from "@farcaster/auth-kit"
 import { JsonRpcProvider } from "ethers"
 
 import { renderSyncStatus } from "@canvas-js/core"
 import { AppInfo } from "@canvas-js/hooks"
-import { useCanvas, useSIWE, useSIWF, useLogout, useSyncStatus, useClock, AuthContext } from "@canvas-js/hooks"
+import { useCanvas, useSIWE, useSIWF, useLogout, useSyncStatus, useClock, useRemoteClock, AuthContext } from "@canvas-js/hooks"
 import { SIWESigner, SIWFSigner } from "@canvas-js/signer-ethereum"
 
 import { App } from "./App.js"
 import { AppContext } from "./AppContext.js"
 import Forum from "./contract.js"
-import { AppT } from "./index.js"
 
 const config = {
 	// For a production app, replace this with an Optimism Mainnet
@@ -47,6 +45,7 @@ const Layout: React.FC = () => {
 	const { Logout } = useLogout(app)
 	const syncStatus = useSyncStatus(app)
 	const clock = useClock(app)
+	const remoteClock = useRemoteClock(app)
 
 	return (
 		<AppContext.Provider value={{ app: app ?? null }}>
@@ -73,7 +72,7 @@ const Layout: React.FC = () => {
 								<a href="#" onClick={() => setInfoOpen(!infoOpen)}>
 									Info
 								</a>{" "}
-								&middot; Sync {renderSyncStatus(syncStatus)} ({clock}) &middot;{" "}
+								&middot; Sync {renderSyncStatus(syncStatus)} ({clock} / {remoteClock}) &middot;{" "}
 								<a
 									href="#"
 									onClick={async () => {

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -3,6 +3,7 @@ export { useCanvas } from "./useCanvas.js"
 export { useLiveQuery } from "./useLiveQuery.js"
 export { useSyncStatus } from "./useSyncStatus.js"
 export { useClock } from "./useClock.js"
+export { useRemoteClock } from "./useRemoteClock.js"
 
 export { AppInfo } from "./AppInfo.js"
 

--- a/packages/hooks/src/provider/hooks.tsx
+++ b/packages/hooks/src/provider/hooks.tsx
@@ -6,6 +6,7 @@ import { QueryParams } from "@canvas-js/modeldb"
 import { CanvasContext } from "./provider.js"
 import { useLiveQuery as _useLiveQuery } from "../useLiveQuery.js"
 import { useClock as _useClock } from "../useClock.js"
+import { useRemoteClock as _useRemoteClock } from "../useRemoteClock.js"
 import { useSyncStatus as _useSyncStatus } from "../useSyncStatus.js"
 import { useSIWE as _useSIWE } from "../auth/useSIWE.js"
 import { useSIWF as _useSIWF } from "../auth/useSIWF.js"
@@ -24,6 +25,11 @@ export function useLiveQuery<ModelsT extends ModelSchema, K extends keyof Models
 export function useClock() {
   const app = useApp()
   return _useClock(app)
+}
+
+export function useRemoteClock() {
+  const app = useApp()
+  return _useRemoteClock(app)
 }
 
 export function useSyncStatus() {

--- a/packages/hooks/src/useRemoteClock.ts
+++ b/packages/hooks/src/useRemoteClock.ts
@@ -1,22 +1,24 @@
 import { useState, useEffect } from "react"
 import { Canvas } from "@canvas-js/core"
 
-export const useClock = (app: Canvas | null | undefined) => {
+export const useRemoteClock = (app: Canvas | null | undefined) => {
 	const [clock, setClock] = useState<number>(0)
 	useEffect(() => {
 		if (!app) return
+
 		const updateClock = () => {
-			app.messageLog.getClock().then(([nextClock, heads]: [number, string[]]) => {
-				if (nextClock - 1 > clock) setClock(nextClock - 1)
-			})
+            const newClock = app.messageLog.getLatestRemoteClock()
+            if (newClock !== undefined) setClock(newClock)
 		}
 		updateClock()
 		app.messageLog.addEventListener("message", updateClock)
-		app.messageLog.addEventListener("sync", updateClock)
+        app.messageLog.addEventListener("connect", updateClock)
+        app.messageLog.addEventListener("disconnect", updateClock)
 		app.messageLog.addEventListener("sync:status", updateClock)
 		return () => {
 			app.messageLog.removeEventListener("message", updateClock)
-			app.messageLog.removeEventListener("sync", updateClock)
+			app.messageLog.removeEventListener("connect", updateClock)
+			app.messageLog.removeEventListener("disconnect", updateClock)
 			app.messageLog.removeEventListener("sync:status", updateClock)
 		}
 	}, [app])


### PR DESCRIPTION
track the latest remote clock of each peer in gossipLog's libp2p service and NetworkClient

## How has this been tested?

- [ ] CI tests pass
- [ ] Tested with example-chat (including login, all signers, and exchanging messages)
- [ ] Tested with `@canvas-js/test-network`: (optional)

## Does this contain any breaking changes to external interfaces?

- [ ] Contract interfaces
- [ ] Core interface
- [ ] CLI
- [ ] Data storage formats, including IndexedDB, SQLite, or filesystem storage (will this break existing apps?)
